### PR TITLE
major-mode-hydra を enh-ruby で使えるようにした

### DIFF
--- a/inits/80-global-keybinds.el
+++ b/inits/80-global-keybinds.el
@@ -50,5 +50,8 @@
 (global-set-key (kbd (concat my/org-mode-prefix-key "c")) 'org-capture)
 (global-set-key (kbd (concat my/org-mode-prefix-key "l")) 'org-store-link)
 
+;; major-mode-hydra
+(global-set-key (kbd "C-c SPC") #'major-mode-hydra)
+
 ;; with keychord
 (key-chord-define-global "jk" 'pretty-hydra-usefull-commands/body)

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -1,5 +1,6 @@
 (el-get-bundle hydra)
 (el-get-bundle pretty-hydra)
+(el-get-bundle major-mode-hydra)
 
 (pretty-hydra-define dumb-jump-pretty-hydra
   (:foreign-keys warn :title "Dumb jump" :quit-key "q" :color blue)

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -2,6 +2,23 @@
 (el-get-bundle pretty-hydra)
 (el-get-bundle major-mode-hydra)
 
+(major-mode-hydra-define enh-ruby-mode (:quit-key "q")
+  ("Enh Ruby"
+   (("{" enh-ruby-toggle-block "Toggle block")
+    ("e" enh-ruby-insert-end "Insert end"))
+
+   "RSpec"
+   (("s" rspec-verify "Run associated spec")
+    ("m" rspec-verify-method "Run method spec")
+    ("r" rspec-rerun "Rerun")
+    ("l" rspec-run-last-failed "Run last failed"))
+
+   "REPL"
+   (("i" inf-ruby "inf-ruby"))
+
+   "Other"
+   (("j" dumb-jump-go "Dumb Jump"))))
+
 (pretty-hydra-define dumb-jump-pretty-hydra
   (:foreign-keys warn :title "Dumb jump" :quit-key "q" :color blue)
   ("Go"


### PR DESCRIPTION
major-mode ごとに良い感じに hydra のコマンドが割り当てられると便利そうなので
major-mode-hydra を導入し、
ひとまず enh-ruby-mode で使えるようにしてみた