### PR TITLE
hydra-posframe の導入

### DIFF
--- a/inits/20-posframe.el
+++ b/inits/20-posframe.el
@@ -1,0 +1,1 @@
+(el-get-bundle posframe)

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -20,7 +20,7 @@
    (("j" dumb-jump-go "Dumb Jump"))))
 
 (pretty-hydra-define dumb-jump-pretty-hydra
-  (:foreign-keys warn :title "Dumb jump" :quit-key "q" :color blue)
+  (:foreign-keys warn :title "Dumb jump" :quit-key "q" :color blue :separator "-")
   ("Go"
    (("j" dumb-jump-go "Jump")
     ("o" dumb-jump-go-other-window "Other window"))
@@ -35,7 +35,7 @@
    "Other"
    (("b" dumb-jump-back "Back"))))
 
-(pretty-hydra-define pretty-hydra-usefull-commands (:color teal :foreign-key warn :title "Usefull commands" :quit-key "q")
+(pretty-hydra-define pretty-hydra-usefull-commands (:separator "-" :color teal :foreign-key warn :title "Usefull commands" :quit-key "q")
   ("File"
    (("p" helm-projectile-switch-project "Switch Project")
     ("r" helm-projectile-recentf "Recentf")
@@ -60,7 +60,7 @@
     ("P" my/open-review-requested-pr "Open Requested PR")
     ("D" delete-other-windows "Delete Other Windows"))))
 
-(pretty-hydra-define pretty-hydra-projectile-rails-find (:color blue :foreign-keys warn :title "Projectile Rails" :quit-key "q")
+(pretty-hydra-define pretty-hydra-projectile-rails-find (:separator "-" :color blue :foreign-keys warn :title "Projectile Rails" :quit-key "q")
   ("Current"
    (("M" projectile-rails-find-current-model      "current model")
     ("V" projectile-rails-find-current-view       "current view")

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -1,4 +1,11 @@
 (el-get-bundle hydra)
+
+;; hydra-posframe
+;; https://github.com/Ladicle/hydra-posframe
+;; 画面真ん中に表示されて便利
+(el-get-bundle hydra-posframe)
+(add-hook 'after-init-hook 'hydra-postframe-enable)
+
 (el-get-bundle pretty-hydra)
 (el-get-bundle major-mode-hydra)
 

--- a/recipes/hydra-posframe.rcp
+++ b/recipes/hydra-posframe.rcp
@@ -1,0 +1,4 @@
+(:name hydra-posframe
+       :description "a hydra extension which shows hydra hints on posframe."
+       :type github
+       :pkgname "Ladicle/hydra-posframe")


### PR DESCRIPTION
画面の真ん中に表示される方が便利なので導入した

hydra 本体にも posframe 対応が入っていたが
バッファの真ん中に表示しようとするので
frame の真ん中に出てほしいなと思いこちらを導入