### PR TITLE
yaml-mode でインデントがわからなくなるので highlight-indent-guide を使うようにした

### DIFF
--- a/inits/30-highlight-indent-guides.el
+++ b/inits/30-highlight-indent-guides.el
@@ -1,1 +1,2 @@
 (el-get-bundle highlight-indent-guides)
+(setq highlight-indent-guides-responsive "stack")

--- a/inits/40-yaml.el
+++ b/inits/40-yaml.el
@@ -1,1 +1,5 @@
 (el-get-bundle yaml-mode)
+(defun my/yaml-mode-hook ()
+  (highlight-indent-guides-mode 1))
+
+(add-hook 'yaml-mode-hook 'my/yaml-mode-hook)


### PR DESCRIPTION
元々パッケージ自体は入れてたけど
デフォで有効にするのを忘れてたようなので