### PR TITLE
Projectile の補完で ivy を利用するようにした

### DIFF
--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -20,3 +20,4 @@
 (add-to-list 'projectile-globally-ignored-files "manifest.json")
 
 (setq projectile-completion-system 'ivy)
+(el-get-bundle counsel-projectile)

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -18,3 +18,5 @@
 (add-to-list 'projectile-globally-ignored-files "gems.tags")
 (add-to-list 'projectile-globally-ignored-files "project.tags")
 (add-to-list 'projectile-globally-ignored-files "manifest.json")
+
+(setq projectile-completion-system 'ivy)

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -45,7 +45,7 @@
 (pretty-hydra-define pretty-hydra-usefull-commands (:separator "-" :color teal :foreign-key warn :title "Usefull commands" :quit-key "q")
   ("File"
    (("p" counsel-projectile-switch-project "Switch Project")
-    ("r" helm-projectile-recentf "Recentf")
+    ("r" projectile-recentf "Recentf")
     ("d" counsel-projectile-find-dir "Find dir")
     ("f" counsel-projectile-find-file "Find file"))
 

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -44,10 +44,10 @@
 
 (pretty-hydra-define pretty-hydra-usefull-commands (:separator "-" :color teal :foreign-key warn :title "Usefull commands" :quit-key "q")
   ("File"
-   (("p" helm-projectile-switch-project "Switch Project")
+   (("p" counsel-projectile-switch-project "Switch Project")
     ("r" helm-projectile-recentf "Recentf")
-    ("d" helm-projectile-find-dir "Find dir")
-    ("f" helm-projectile-find-file "Find file"))
+    ("d" counsel-projectile-find-dir "Find dir")
+    ("f" counsel-projectile-find-file "Find file"))
 
    "Edit"
    (("v" my/replace-var "Replace var")
@@ -59,7 +59,7 @@
     ("0" text-scale-adjust   "Adjust"))
 
    "Search"
-   (("g" helm-projectile-ag "grep")
+   (("g" counsel-projectile-ag "grep")
     ("j" dumb-jump-pretty-hydra/body "Dumb jump"))
 
    "Other"


### PR DESCRIPTION
- 補完インターフェースの指定を ivy にした
- counsel-projectile を導入
- major-mode-hydra で helm 系を指定していたものをできるだけ counsel 系にした
- projectile-recentf は本体の ivy インターフェースで十分なのでそっちにした