### PR TITLE
pretty-hydra を posframe で使った時の問題を回避した

### DIFF
--- a/custom.el
+++ b/custom.el
@@ -25,6 +25,7 @@
  '(indent-tabs-mode nil)
  '(js-indent-level 2)
  '(line-number-mode nil)
+ '(major-mode-hydra-separator "=")
  '(org-modules
    (quote
     (ol-bbdb ol-bibtex ol-docview ol-eww ol-gnus ol-info ol-irc ol-mhe ol-rmail org-tempo ol-w3m)))

--- a/inits/01-override.el
+++ b/inits/01-override.el
@@ -1,0 +1,14 @@
+;; posframe が最初に空行があると最後お行を表示しないため
+;; 一時的にこちらを直してみている
+(with-eval-after-load 'pretty-hydra
+  (defun pretty-hydra--maybe-add-title (title docstring)
+  "Add TITLE to the DOCSTRING if it's not nil, other return DOCSTRING unchanged."
+  (if (null title)
+      docstring
+    (format "%s\n%s"
+            (cond
+             ((char-or-string-p title) title)
+             ((symbolp title)          (format "%%s`%s" title))
+             ((listp title)            (format "%%s%s" (prin1-to-string title)))
+             (t                        ""))
+            docstring))))

--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -17,7 +17,7 @@
 (add-to-list 'context-skk-programming-mode 'enh-ruby-mode)
 
 (with-eval-after-load 'major-mode-hydra
-  (major-mode-hydra-define enh-ruby-mode (:quit-key "q")
+  (major-mode-hydra-define enh-ruby-mode (:quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
     ("Enh Ruby"
      (("{" enh-ruby-toggle-block "Toggle block")
       ("e" enh-ruby-insert-end "Insert end"))

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -80,7 +80,7 @@
 (load "my-org-gcal-config")
 
 (with-eval-after-load 'major-mode-hydra
-  (major-mode-hydra-define org-mode (:quit-key "q")
+  (major-mode-hydra-define org-mode (:quit-key "q" :title (concat (all-the-icons-fileicon "org") " Org commands"))
     ("Insert"
      (("l" org-insert-link "Link")
       ("t" org-insert-todo-heading "Todo")

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -107,7 +107,13 @@
      (("," org-cycle-agenda-files "Cycle")))))
 
 (with-eval-after-load 'pretty-hydra
-  (pretty-hydra-define global-org-hydra (:separator "-" :color teal :foreign-key warn :title "Global org commands" :quit-key "q")
+  (pretty-hydra-define
+    global-org-hydra
+    (:separator "-"
+                :color teal
+                :foreign-key warn
+                :title (concat (all-the-icons-fileicon "org") " Global Org commands")
+                :quit-key "q")
     ("Main"
      (("a" org-agenda "Agenda")
       ("c" org-capture "Capture")

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -9,6 +9,22 @@
 (el-get-bundle pretty-hydra)
 (el-get-bundle major-mode-hydra)
 
+;; override
+;; posframe が最初に空行があると最後お行を表示しないため
+;; 一時的にこちらを直してみている
+(with-eval-after-load 'pretty-hydra
+  (defun pretty-hydra--maybe-add-title (title docstring)
+  "Add TITLE to the DOCSTRING if it's not nil, other return DOCSTRING unchanged."
+  (if (null title)
+      docstring
+    (format "%s\n%s"
+            (cond
+             ((char-or-string-p title) title)
+             ((symbolp title)          (format "%%s`%s" title))
+             ((listp title)            (format "%%s%s" (prin1-to-string title)))
+             (t                        ""))
+            docstring))))
+
 (pretty-hydra-define pretty-hydra-usefull-commands (:separator "-" :color teal :foreign-key warn :title "Usefull commands" :quit-key "q")
   ("File"
    (("p" counsel-projectile-switch-project "Switch Project")

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -9,22 +9,6 @@
 (el-get-bundle pretty-hydra)
 (el-get-bundle major-mode-hydra)
 
-;; override
-;; posframe が最初に空行があると最後お行を表示しないため
-;; 一時的にこちらを直してみている
-(with-eval-after-load 'pretty-hydra
-  (defun pretty-hydra--maybe-add-title (title docstring)
-  "Add TITLE to the DOCSTRING if it's not nil, other return DOCSTRING unchanged."
-  (if (null title)
-      docstring
-    (format "%s\n%s"
-            (cond
-             ((char-or-string-p title) title)
-             ((symbolp title)          (format "%%s`%s" title))
-             ((listp title)            (format "%%s%s" (prin1-to-string title)))
-             (t                        ""))
-            docstring))))
-
 (pretty-hydra-define pretty-hydra-usefull-commands (:separator "-" :color teal :foreign-key warn :title "Usefull commands" :quit-key "q")
   ("File"
    (("p" counsel-projectile-switch-project "Switch Project")


### PR DESCRIPTION
pretty-hydra を hydra-posframe 経由で posframe 表示した際に
最終行が表示されない問題があった。

原因は `posframe-show` が src を受け取る時に
最初の行が空行だと最後の行が無視されることだった。

恐らくその中で高さを計算しているロジックに不具合があると思われるが
そこまで調査して対応するのは面倒だったので
より小さい Emacs Lisp である pretty-hydra の実装を override し、
最初の行が空行にならないように変更することで問題を回避した

major-mode-hydra もまた同様の問題があったが
こちらは :title を指定することで問題を回避できたのでそのように対応している

# 対応内容

- [x] pretty-hydra + posframe で最終行が表示されなくなる問題の回避
- [x] major-mode-hydra + posframe で最終行が表示されなくなる問題の回避
- [x] その他ついでの修正
  - [x] タイトルにアイコンを表示できそうなやつは表示するようにした
  - [x] major-mode-hydra の区切り文字を半角の文字にした