### PR TITLE
hydra 経由で describe-* ができるようにした

### DIFF
--- a/inits/40-emacs-lisp.el
+++ b/inits/40-emacs-lisp.el
@@ -4,3 +4,9 @@
   (company-mode 1)
   (paredit-mode 1))
 (add-hook 'emacs-lisp-mode-hook 'my/emacs-lisp-mode-hook)
+
+(with-eval-after-load 'major-mode-hydra
+  (major-mode-hydra-define emacs-lisp-mode (:quit-key "q" :title (concat (all-the-icons-fileicon "elisp") " Emacs Lisp"))
+    ("Describe"
+     (("F" counsel-describe-function "Function")
+      ("V" counsel-describe-variable "Variable")))))

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -39,4 +39,5 @@
    (("c" my/open-user-calendar "Calendar")
     ("SPC" major-mode-hydra "Hydra(Major)")
     ("P" my/open-review-requested-pr "Open Requested PR")
+    ("B" counsel-descbinds "Describe Keybind")
     ("D" delete-other-windows "Delete Other Windows"))))


### PR DESCRIPTION
ファンクションキーがないキーボードだと F1 を押して作業するのはつらいので
hydra 経由で describe 系でよく使うやつを使えるようにした

- [x] どこでも counsel-descbind を hydra 経由で呼べるようにした
- [x] emacs-lisp-mode で describe-{variable|function} できるようにした
