### PR TITLE
imenu を使えるようにした

### DIFF
--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -25,6 +25,10 @@
      (("{" enh-ruby-toggle-block "Toggle block")
       ("e" enh-ruby-insert-end "Insert end"))
 
+     "LSP"
+     (("i" lsp-ui-imenu "Imenu")
+      ("f" lsp-ui-flycheck-list "Flycheck list"))
+
      "RSpec"
      (("s" rspec-verify "Run associated spec")
       ("m" rspec-verify-method "Run method spec")
@@ -32,7 +36,7 @@
       ("l" rspec-run-last-failed "Run last failed"))
 
      "REPL"
-     (("i" inf-ruby "inf-ruby"))
+     (("I" inf-ruby "inf-ruby"))
 
      "Other"
      (("j" dumb-jump-go "Dumb Jump")))))

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -23,7 +23,8 @@
 
    "Code"
    (("g" counsel-projectile-ag "Grep")
-    ("j" dumb-jump-pretty-hydra/body "Dumb jump"))
+    ("j" dumb-jump-pretty-hydra/body "Dumb jump")
+    ("i" counsel-imenu "imenu"))
 
    "Tool"
    (("c" my/open-user-calendar "Calendar")


### PR DESCRIPTION
- ruby-mode 用の hydra で lsp-ui-imenu が使えるようにした
- Global な hydra で counsel-imenu を呼べるようにした

今のところ counsel-imenu の方が便利な感じ
ruby-mode 用は広い画面で右側に常に表示とかだと便利なのかも