### PR TITLE
key-chord 経由で起動している hydra の起動が遅かったので調整

### DIFF
--- a/inits/70-key-chord.el
+++ b/inits/70-key-chord.el
@@ -1,5 +1,5 @@
 (el-get-bundle zk-phi/key-chord)
 (setq key-chord-two-keys-delay           0.15
       key-chord-safety-interval-backward 0.1
-      key-chord-safety-interval-forward  0.25)
+      key-chord-safety-interval-forward  0.15)
 (key-chord-mode 1)


### PR DESCRIPTION
jk 同時押しで hydra を起動しているけど、
判定が遅いのかどうもワンテンポ待たされる感があるので
間隔を短かくしてみた 