### PR TITLE
savehist を有効にして kill-ring を再起動しても使えるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ kkcrc
 projectile-bookmarks.eld
 projectile.cache
 places
+history

--- a/inits/00-savehist.el
+++ b/inits/00-savehist.el
@@ -1,0 +1,2 @@
+(savehist-mode 1)
+(setq savehist-additional-variables '(kill-ring))


### PR DESCRIPTION
いつも再起動すると kill-ring が消えて悲しかったので