### PR TITLE
ob-async, async を melpa 版から github 版に乗り換えた

### DIFF
--- a/custom.el
+++ b/custom.el
@@ -37,7 +37,7 @@
    (expand-file-name "~/.emacs.d/el-get/plantuml-mode/plantuml.jar"))
  '(package-selected-packages
    (quote
-    (async gnu-elpa-keyring-update ivy dumb-jump gnuplot calfw-org hide-mode-line oauth2 zoom highlight-indent-guides rainbow-mode molokai-theme xml-rpc vue-html-mode ssass-mode edit-indirect ember-mode)))
+    (gnu-elpa-keyring-update ivy dumb-jump gnuplot calfw-org hide-mode-line oauth2 zoom highlight-indent-guides rainbow-mode molokai-theme xml-rpc vue-html-mode ssass-mode edit-indirect ember-mode)))
  '(projectile-mode-line-prefix "")
  '(pug-tab-width 2)
  '(recentf-auto-cleanup (quote never))

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -98,7 +98,6 @@
 (require 'org-gcal)
 (load "my-org-gcal-config")
 
-(el-get-bundle async)
 (el-get-bundle ob-async)
 (require 'ob-async)
 (add-hook 'ob-async-pre-execute-src-block-hook

--- a/recipes/ob-async.rcp
+++ b/recipes/ob-async.rcp
@@ -1,0 +1,7 @@
+(:name ob-async
+:description "Asynchronous org-babel src block execution"
+:type github
+:pkgname "astahlman/ob-async"
+:depends (emacs-async org-mode dash)
+:minimum-emacs-version (24 4)
+)


### PR DESCRIPTION
ob-async のレシピとして
el-get-elpa-build-local-recipes で生成したものを使っていたが
そいつが依存してる org-mode がまた melpa のものだったため
自前で GitHub から入れてる org-mode と二重にインストールされてる状態になっていた

それを ob-async のレシピを自前の物にすることで解決した。

async も依存関係で入ってただけで emacs-async という GitHub を見てるレシピがあったので
そっちを使うことにした