### PR TITLE
org-capture の起動キーバインドを短かくした

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -142,7 +142,8 @@
     ("Main"
      (("a" org-agenda "Agenda")
       ("c" org-capture "Capture")
-      ("l" org-store-link "Store link"))
+      ("l" org-store-link "Store link")
+      ("C" my/open-user-calendar "Calendar"))
      "Clock"
      (("i" org-clock-in  "In")
       ("o" org-clock-out "Out")

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -27,7 +27,7 @@
     ("i" counsel-imenu "imenu"))
 
    "Tool"
-   (("c" my/open-user-calendar "Calendar")
+   (("c" org-capture "Capture")
     ("o" global-org-hydra/body "Org")
     ("/" google-this-pretty-hydra/body "Google")
     ("SPC" major-mode-hydra "Hydra(Major)")


### PR DESCRIPTION
org-capture はよく使うので起動を手早くしたかったのでキーバインドを変更した

calfw は org-capture ほど使用頻度は高くないので
そこで使ってるキーバインドを渡して、
calfw には別のキーバインドを渡した