### PR TITLE
TAG 限定で TODO を絞れるようにした

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -143,6 +143,7 @@
      (("a" org-agenda "Agenda")
       ("c" org-capture "Capture")
       ("l" org-store-link "Store link")
+      ("t" my/org-tags-view-only-todo "Tagged Todo")
       ("C" my/open-user-calendar "Calendar"))
      "Clock"
      (("i" org-clock-in  "In")
@@ -152,6 +153,10 @@
       ("j" org-clock-goto "Goto")
       ("d" org-clock-display "Display")
       ("r" org-clock-report "Report")))))
+
+(defun my/org-tags-view-only-todo ()
+  (interactive)
+  (org-tags-view t))
 
 (load "my-notify-slack-config")
 (defun my/notify-slack (channel text)


### PR DESCRIPTION
`M-x org-agenda M` と同様のことを
`jk o t` で起動できるようにした。

なぜならそれで絞り込みたいことが現状多そうだから。

(category を活用するようになったりしたらまたやりたいことが変わるかもしれない)