### PR TITLE
el-get-lock を導入し org-mode を 9.3.6 でロックしてみた

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,0 +1,4 @@
+(setq el-get-lock-package-versions
+      '((org-mode :checksum "66810d2121aa1d936238fc53cc155e6eda425313")))
+(setq el-get-lock-locked-packages 'nil)
+(setq el-get-lock-unlocked-packages 'nil)

--- a/init.el
+++ b/init.el
@@ -13,5 +13,9 @@
 
 (add-to-list 'el-get-recipe-path "~/.emacs.d/recipes")
 
+;; el-get のバージョンロック機構の導入
+(el-get-bundle tarao/el-get-lock)
+(el-get-lock)
+
 (el-get-bundle init-loader)
 (init-loader-load)

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -1,4 +1,4 @@
-(el-get-bundle org-mode) ;; from Git. because melpa cannot resolve dependencies.
+(el-get-bundle org-mode :checkout "release_9.3.6") ;; from Git. because melpa cannot resolve dependencies.
 (el-get-bundle org-export-blocks-format-plantuml)
 (org-babel-do-load-languages 'org-babel-load-languages
                              '((plantuml . t)


### PR DESCRIPTION
el-get-lock をまだ活用できてないが、
ひとまず org-mode が管理対象になるようにした