### PR TITLE
org-trello を導入した

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((undo-fu :checksum "0ce9ac36144e80316fff50bfe1bc5dd7e5e7ded6")
+      '((org-trello :checksum "9f77459541eaea14069baf116dc51ba82eea80b4")
+        (undo-fu :checksum "0ce9ac36144e80316fff50bfe1bc5dd7e5e7ded6")
         (emacs-todoist :checksum "b1fba9f3600e6cfe129efae304b96a7f6dc66e1a")
         (org-mode :checksum "66810d2121aa1d936238fc53cc155e6eda425313")))
 (setq el-get-lock-locked-packages 'nil)

--- a/inits/61-org-trello.el
+++ b/inits/61-org-trello.el
@@ -1,0 +1,1 @@
+(el-get-bundle org-trello)


### PR DESCRIPTION
とりあえず試しに閲覧専用に使ってみるためだと以下の感じ

1. `M-x org-trello-install-key-and-token` でトークンなどを設定する
  - ~/.emacs.d/.trello/mugijiru とかに保存される
2. Trello の board に対応させたい空の org ファイルを予め作成しておく
  - `touch kanban.org` などしたらいいかもね
3. 2で作ったファイルを Emacs で開く
4. `M-x org-trello-mode` で org-trello-mode にする
5. `M-x org-trello-install-board-metadata` で metadata を突っ込む
6. `C-u C-c o s` で Trello のデータを手元に引っ張り寄せる
  - `C-u` が必要なので直コマンド叩きができない 😇 

----

## 気になる点

- 自動的に org-trello-mode にしたい
- コマンド覚えてられないので hydra に投げたい
  - それをやる場合は major-mode-hydra が多分使える……!
- board は全部自動で close してきてほしい……