### PR TITLE
org-mode の設定をいくつか修正した

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -103,7 +103,7 @@
     (org-clock-display)))
 
 (with-eval-after-load 'major-mode-hydra
-  (major-mode-hydra-define org-mode (:quit-key "q" :title (concat (all-the-icons-fileicon "org") " Org commands"))
+  (major-mode-hydra-define org-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-fileicon "org") " Org commands"))
     ("Insert"
      (("l" org-insert-link "Link")
       ("t" org-insert-todo-heading "Todo")

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -71,26 +71,11 @@
       `(("g" "GTDにエントリー" entry
          (file+headline ,my/org-capture-gtd-file "Inbox")
          "** TODO %?\n\t")
-        ("c" "同期カレンダーにエントリー" entry
-         (file+headline ,org-capture-ical-file "Schedule")
-         "** TODO %?\n\t")
-        ("e" "環境問題にエントリー" entry
-         (file+headline ,my/org-capture-env-file "Environment")
-         "** TODO %?\n\t")
-        ("r" "レビューにエントリー" entry
-         (file+headline ,my/org-capture-review-file "Review")
-         "** TODO %?\n\t")
-        ("R" "調査にエントリー" entry
-         (file+headline ,my/org-capture-research-file "Research")
-         "** TODO %?\n\t")
-        ("d" "開発タスクにエントリー" entry
-         (file+headline ,my/org-capture-develop-file "Develop")
-         "** TODO %?\n\t")
         ("i" "割り込みタスクにエントリー" entry ;; 参考: http://grugrut.hatenablog.jp/entry/2016/03/13/085417
          (file+headline ,my/org-capture-interrupted-file "Interrupted")
          "** %?\n\t" :clock-in t :clock-resume t)
-        ("m" "管理系タスクにエントリー" entry
-         (file+headline ,my/org-capture-management-file "Management")
+        ("c" "同期カレンダーにエントリー" entry
+         (file+headline ,org-capture-ical-file "Schedule")
          "** TODO %?\n\t")))
 
 (setq org-clock-clocktable-default-properties

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -79,7 +79,7 @@
          "** TODO %?\n\t")))
 
 (setq org-clock-clocktable-default-properties
-      '(:maxlevel 4
+      '(:maxlevel 10
                  :lang "ja"
                  :scope agenda
                  :block today


### PR DESCRIPTION
- org-capture 用のファイルで使わなくなったのがあったので capture で入れる対象から削除した
- clocktable のインデントが深くても大丈夫なように max-level を深くした
- major-mode-hydra の separator がデフォのやつになる時があったので明示することにした
  - デフォのやつ、全角文字なので表示崩れるのよな