### PR TITLE
Hydra 経由でフレームの移動ができるようにした

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,7 @@
 (setq el-get-lock-package-versions
-      '((dashboard :checksum "bf38867ae80902d58207974b4a2bba4249324599")
+      '((frame-cmds :checksum "1279ebaddcbf15bf2a2eae548d13ad33632a97b4")
+        (frame-fns :checksum "251f37fe805af7a8b3e0e5af9af76263f663a366")
+        (dashboard :checksum "bf38867ae80902d58207974b4a2bba4249324599")
         (page-break-lines :checksum "314b397910b3d16bb7cbcc25098696348e678080")
         (org-trello :checksum "9f77459541eaea14069baf116dc51ba82eea80b4")
         (undo-fu :checksum "0ce9ac36144e80316fff50bfe1bc5dd7e5e7ded6")

--- a/inits/80-frame-cmds.el
+++ b/inits/80-frame-cmds.el
@@ -1,0 +1,8 @@
+(el-get-bundle frame-cmds)
+
+(pretty-hydra-define window-control-hydra (:separator "-" :title "Window Control" :exit nil :quit-key "q")
+  ("Move"
+   (("h" move-frame-left  "Left")
+    ("j" move-frame-down  "Down")
+    ("k" move-frame-up    "Up")
+    ("l" move-frame-right "Right"))))

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -37,7 +37,8 @@
    "View"
    (("Z" toggle-frame-fullscreen "Fullscreen")
     ("D" delete-other-windows "Only This Win")
-    ("N" neotree-toggle "Neotree"))
+    ("N" neotree-toggle "Neotree")
+    ("W" window-control-hydra/body "Window Control"))
 
    "Scale"
    (("+" text-scale-increase "Increase")


### PR DESCRIPTION
タイトルバーがない状態のビルドにしているので
フルスクリーンじゃない時にどこかに移動しようにも移動ができず
困っていたのを
hydra + frame-cmds で移動できるようにした

![May-23-2020 12-28-51](https://user-images.githubusercontent.com/106833/82720725-36489800-9cf1-11ea-8359-22e5892828d5.gif)
