### PR TITLE
org-capture も posframe で表示したかったので counsel のやつに切替

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -149,7 +149,7 @@
                 :quit-key "q")
     ("Main"
      (("a" org-agenda "Agenda")
-      ("c" org-capture "Capture")
+      ("c" counsel-org-capture "Capture")
       ("l" org-store-link "Store link")
       ("t" my/org-tags-view-only-todo "Tagged Todo")
       ("F" org-gcal-fetch "Fetch Calendar")

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -56,7 +56,7 @@
     ("F" counsel-describe-function "Function"))
 
    "Tool"
-   (("c" org-capture "Capture")
+   (("c" counsel-org-capture "Capture")
     ("o" global-org-hydra/body "Org")
     ("@" all-the-icons-hydra/body "All the icons")
     ("e" el-get-hydra/body "el-get")


### PR DESCRIPTION
org-capture はデフォルトだとバッファを表示したりするが
posframe で表示したかった。

ちょっと調べると counsel-org-capture というのが用意されていた。

ivy は posframe を使うようにしているので
それで解決できるので、そのように変更した