### PR TITLE
`@` で日付入力ができるように SKK-JISYO.lisp を導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ elpa
 url
 emojis
 secret
+skk-jisyo
 org-gcal
 
 # auto generated files

--- a/inits/30-skk.el
+++ b/inits/30-skk.el
@@ -19,6 +19,8 @@
                            ("?" nil nil)
                            ("!" nil nil))))))
 
+(setq skk-extra-jisyo-file-list (list '("~/.emacs.d/skk-jisyo/SKK-JISYO.lisp" . japanese-iso-8bit-unix)))
+
 ;; AquaSKKのL辞書をつかうようにする
 (setq skk-large-jisyo (expand-file-name "~/Library/Application Support/AquaSKK/SKK-JISYO.L"))
 


### PR DESCRIPTION
AquaSKK の L辞書を ddskk でも読むようにしているが
そのせいで @ で今日の日付が入らない問題を修正

辞書そのものはリポジトリには含めないことにした