### PR TITLE
emacs lisp 用 hydra の separator が全角なために崩れてたのを修正

### DIFF
--- a/inits/40-emacs-lisp.el
+++ b/inits/40-emacs-lisp.el
@@ -12,7 +12,7 @@
     (insert "(all-the-icons-" (symbol-name family) " \"" selection "\")")))
 
 (with-eval-after-load 'major-mode-hydra
-  (major-mode-hydra-define emacs-lisp-mode (:quit-key "q" :title (concat (all-the-icons-fileicon "elisp") " Emacs Lisp"))
+  (major-mode-hydra-define emacs-lisp-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-fileicon "elisp") " Emacs Lisp"))
     ("Describe"
      (("F" counsel-describe-function "Function")
       ("V" counsel-describe-variable "Variable"))


### PR DESCRIPTION
| Before | After |
|----|----|
| <img width="510" alt="image" src="https://user-images.githubusercontent.com/106833/83317757-00179500-a26a-11ea-94ee-64d79019de11.png"> | <img width="259" alt="image" src="https://user-images.githubusercontent.com/106833/83317714-90a1a580-a269-11ea-8f65-3f8ea760d398.png"> |

そもそも
major-mode-hydra-separator を custom してやれば良さそうだけど、ま、いいや……
