### PR TITLE
org-mode のチェックボックスを hydra で切り替えられるようにする

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -130,7 +130,8 @@
      "Task"
      (("s" org-schedule "Schedule")
       ("d" org-deadline "Deadline")
-      ("t" my/org-todo  "Change state"))
+      ("t" my/org-todo  "Change state")
+      ("c" org-toggle-checkbox "Toggle checkbox"))
 
      "Clock"
      (("i" org-clock-in   "In")


### PR DESCRIPTION
org-mode のチェックボックスを弄るキーバインドを忘れたので
hydra 経由でやらせればいいかなと思いました