### PR TITLE
ivy で名前の長さ順にソートされるのをやめた

### DIFF
--- a/inits/83-prescient.el
+++ b/inits/83-prescient.el
@@ -1,2 +1,3 @@
 (el-get-bundle raxod502/prescient.el)
 (ivy-prescient-mode 1)
+(setq prescient-sort-length-enable nil)


### PR DESCRIPTION
`prescient-sort-length-enable` はデフォルトで有効になっているが、
名前の長さ順でソートされてるのが肌に合わないので無効にした