### PR TITLE
helm-posframe を最新版で lock した

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((gnuplot-mode :checksum "f0001c30010b2899e36d7d89046322467e923088")
+      '((helm-posframe :checksum "b107e64eedef6292c49d590f30d320c29b64190b")
+        (gnuplot-mode :checksum "f0001c30010b2899e36d7d89046322467e923088")
         (ivy-posframe :checksum "51d753544ea35c035c45420c3075933a2fe83ffd")
         (dumb-jump :checksum "260054500d4731c36574b6cbc519de29fdd22f43")
         (ember-mode :checksum "a587c423041b2fcb065fd5b6a03b2899b764e462")


### PR DESCRIPTION
使ってるかと思ったら使ってなかった。

使ってなかったのは、インストールしていたバージョンはバグがあって
helm 終了時に Emacs を一瞬最小化する挙動をしていたからかと思われる。

この機会に最新化したらそのバグも直ってたので
ひとまず有効化しておく