### PR TITLE
all-the-icons と neotree を最新化した

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((color-theme-molokai :checksum "04a44f21184b6a26caae4f2c92db9019d883309c")
+      '((emacs-neotree-dev :checksum "98fe21334affaffe2334bf7c987edaf1980d2d0b")
+        (color-theme-molokai :checksum "04a44f21184b6a26caae4f2c92db9019d883309c")
         (helm-posframe :checksum "b107e64eedef6292c49d590f30d320c29b64190b")
         (gnuplot-mode :checksum "f0001c30010b2899e36d7d89046322467e923088")
         (ivy-posframe :checksum "51d753544ea35c035c45420c3075933a2fe83ffd")
@@ -38,7 +39,6 @@
         (el-get-lock :checksum "df8cfe55441695865a64b97946750b6413a40425")
         (eldoc-eval :checksum "a67fe3637378dcb6c5f9e140acc8131f0d2346b3")
         (emacs-async :checksum "35ab78afb9ec4929552f43c6bab09bbd7da3842a")
-        (emacs-neotree :checksum "5e1271655170f4cdc6849258e383c548a4e6e3d0")
         (emacsql :checksum "d5c37d905d133a3887bc582e4a0126671816beaa")
         (emojify :checksum "a16199dcf9b4688839eba00f1e356d9beac46cfe")
         (enh-ruby-mode :checksum "f334c42986e93c60fba144d732becfcbdb13bb7d")

--- a/el-get.lock
+++ b/el-get.lock
@@ -22,7 +22,7 @@
         (request :checksum "912525c772984c6af0fd84acd6699ee43d91037a")
         (helm :checksum "68a4a19b75913a4402bcdc97539dac687e3f8c9a")
         (avy :checksum "cf95ba9582121a1c2249e3c5efdc51acd566d190")
-        (all-the-icons :checksum "f996fafa5b2ea072d0ad1df9cd98acc75820f530")
+        (all-the-icons :checksum "ed8e44de4fa601309d2bba902c3b37cb73e4daa0")
         (alert :checksum "b5ef49bbb871867ac03d2943a720576336cd7025")
         (calfw :checksum "03abce97620a4a7f7ec5f911e669da9031ab9088")
         (circe :checksum "e4af7143bd32907d0bf922bee53a96399f0376fa")

--- a/el-get.lock
+++ b/el-get.lock
@@ -38,7 +38,7 @@
         (el-get-lock :checksum "df8cfe55441695865a64b97946750b6413a40425")
         (eldoc-eval :checksum "a67fe3637378dcb6c5f9e140acc8131f0d2346b3")
         (emacs-async :checksum "35ab78afb9ec4929552f43c6bab09bbd7da3842a")
-        (emacs-neotree :checksum "c2420a4b344a9337760981c451783f0ff9df8bbf")
+        (emacs-neotree :checksum "5e1271655170f4cdc6849258e383c548a4e6e3d0")
         (emacsql :checksum "d5c37d905d133a3887bc582e4a0126671816beaa")
         (emojify :checksum "a16199dcf9b4688839eba00f1e356d9beac46cfe")
         (enh-ruby-mode :checksum "f334c42986e93c60fba144d732becfcbdb13bb7d")

--- a/inits/40-neotree.el
+++ b/inits/40-neotree.el
@@ -1,3 +1,3 @@
-(el-get-bundle emacs-neotree)
+(el-get-bundle emacs-neotree-dev)
 (setq projectile-switch-project-action 'neotree-projectile-action)
 (setq neo-theme (if (display-graphic-p) 'icons 'arrow))

--- a/recipes/emacs-neotree-dev.rcp
+++ b/recipes/emacs-neotree-dev.rcp
@@ -1,0 +1,6 @@
+(:name emacs-neotree-dev
+       :website "https://github.com/jaypei/emacs-neotree"
+       :description "An Emacs tree plugin like NerdTree for Vim."
+       :type github
+       :branch "dev"
+       :pkgname "jaypei/emacs-neotree")


### PR DESCRIPTION
## all-the-icons

https://github.com/domtronn/all-the-icons.el/compare/f996fafa5b2ea072d0ad1df9cd98acc75820f530...ed8e44de4fa601309d2bba902c3b37cb73e4daa0

差分的にはアイコン対応ファイルが増えたのと
ディレクトリ用の関数が変更になってる。

all-the-icons-for-dir で chevron を使ってる場合には影響がありそう

## neotree

https://github.com/jaypei/emacs-neotree/compare/c2420a4b344a9337760981c451783f0ff9df8bbf...98fe21334affaffe2334bf7c987edaf1980d2d0b

差分はディレクトリ用の関数変更に対応したもの