### PR TITLE
ivy が melpa から呼ばれないように対応

### DIFF
--- a/inits/82-ivy.el
+++ b/inits/82-ivy.el
@@ -23,11 +23,11 @@
 (counsel-mode 1)
 
 ;; posframe を使って中央表示
-(el-get-bundle tumashu/ivy-posframe)
+(el-get-bundle ivy-posframe)
 (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display-at-frame-center)))
 (ivy-posframe-mode 1)
 
-(el-get-bundle Yevgnen/ivy-rich)
+(el-get-bundle ivy-rich)
 
 ;; https://ladicle.com/post/config/#ivy
 ;; に書かれている関数を丸コピしてきた

--- a/inits/83-counsel-osx-app.el
+++ b/inits/83-counsel-osx-app.el
@@ -1,1 +1,1 @@
-(el-get-bundle d12frosted/counsel-osx-app)
+(el-get-bundle counsel-osx-app)

--- a/recipes/counsel-osx-app.rcp
+++ b/recipes/counsel-osx-app.rcp
@@ -1,0 +1,6 @@
+(:name counsel-osx-app
+:type github
+:description "Select an app to launch using ivy completion."
+:pkgname "d12frosted/counsel-osx-app"
+:minimum-emacs-version (24 3)
+)

--- a/recipes/ivy-posframe.rcp
+++ b/recipes/ivy-posframe.rcp
@@ -1,0 +1,6 @@
+(:name ivy-posframe
+:type github
+:description "ivy-posframe is a ivy extension, which let ivy use posframe to show its candidate menu."
+:pkgname "tumashu/ivy-posframe"
+:minimum-emacs-version (26)
+)

--- a/recipes/ivy-rich.rcp
+++ b/recipes/ivy-rich.rcp
@@ -1,0 +1,6 @@
+(:name ivy-rich
+:type github
+:description "More friendly interface for ivy"
+:pkgname "Yevgnen/ivy-rich"
+:minimum-emacs-version (25 1)
+)


### PR DESCRIPTION
Package required 周りで自動的に呼ばれるらしいので
Recipe を追加することで回避。

いずれ逆に (M)ELPA 側に依存する方向で対応することを検討したい