### PR TITLE
org-mode 周辺のものを更新

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -83,7 +83,7 @@
         (multiple-cursors :checksum "5ffb19af48bf8a76ddc9f81745be052f050bddef")
         (ob-async :checksum "80a30b96a007d419ece12c976a81804ede340311")
         (org-gcal :checksum "bdc704842da000a1cffb8f155ef3887c5e1d0446")
-        (org-tree-slide :checksum "7bf09a02bd2d8f1ccfcb5209bfb18fbe02d1f44e")
+        (org-tree-slide :checksum "7126a4365072a32898f169ead8fb59265dabc605")
         (paredit :checksum "acbe10fdd85d2e91831adf70b6a828bc7e900da0")
         (pkg-info :checksum "76ba7415480687d05a4353b27fea2ae02b8d9d61")
         (plantuml-mode :checksum "e9c8e76ff25013e05ab83de9462bbcdd74e27237")

--- a/el-get.lock
+++ b/el-get.lock
@@ -120,7 +120,7 @@
         (el-get :checksum "f3873bebdb6ee713d16e323ee14786549b5cf7f0")
         (dashboard :checksum "bf38867ae80902d58207974b4a2bba4249324599")
         (page-break-lines :checksum "314b397910b3d16bb7cbcc25098696348e678080")
-        (org-trello :checksum "9f77459541eaea14069baf116dc51ba82eea80b4")
+        (org-trello :checksum "56c519a00c6e3c8f6923cd0460342089d58c41c9")
         (undo-fu :checksum "0ce9ac36144e80316fff50bfe1bc5dd7e5e7ded6")
         (emacs-todoist :checksum "b3f003603111b7e31b94c354cf4c83c8208c01c3")
         (org-mode :checksum "66810d2121aa1d936238fc53cc155e6eda425313")))

--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((ivy-rich :checksum "10970130b41c6ef9570893cdab8dfbe720e2b1a9")
+      '((htmlize :checksum "86f22f211e9230857197c42a9823d3f05381deed")
+        (ivy-rich :checksum "10970130b41c6ef9570893cdab8dfbe720e2b1a9")
         (emacs-neotree-dev :checksum "98fe21334affaffe2334bf7c987edaf1980d2d0b")
         (color-theme-molokai :checksum "04a44f21184b6a26caae4f2c92db9019d883309c")
         (helm-posframe :checksum "b107e64eedef6292c49d590f30d320c29b64190b")


### PR DESCRIPTION
org 本体を更新してないから放置でいいかも。

## htmlize

org-re-reveal を更新しようと思ったらこいつも更新された
org-re-reveal については使ってないし
MELPA の org を読み出したので削除した。

## org-trello

https://github.com/org-trello/org-trello/compare/9f77459541eaea14069baf116dc51ba82eea80b4...56c519a00c6e3c8f6923cd0460342089d58c41c9

結構な差分がある...


## org-tree-slide