### PR TITLE
yaml-mode と highlight-indent-guides を更新した

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -107,7 +107,7 @@
         (wakatime-mode :checksum "2531cb58287770883ba534d20b3288955c4d6ef3")
         (websocket :checksum "5be01c6d1a8e87d001916fc40a77d779826fcacf")
         (with-editor :checksum "ff23166feb857e3cfee96cb1c9ef416a224a7e20")
-        (yaml-mode :checksum "40067a10ac1360f0b9533f0bbbb2eea128e2574d")
+        (yaml-mode :checksum "34648f2502f52f4744d62758fa381fa35db1da49")
         (yascroll :checksum "fe4494e5f4faf2832e665c7de0fed99cdbb39478")
         (yasnippet :checksum "e45e3de357fbd4289fcfa3dd26aaa7be357fb0b8")
         (zoom-window :checksum "ab14a365f3e496b07f5efc20992f9094ec166f06")

--- a/el-get.lock
+++ b/el-get.lock
@@ -9,7 +9,7 @@
         (ember-mode :checksum "a587c423041b2fcb065fd5b6a03b2899b764e462")
         (font-lock+ :checksum "829cf337e9ec10116f6ec47e759fc72b7a8dda48")
         (emacs-hide-mode-line :checksum "88888825b5b27b300683e662fa3be88d954b1cea")
-        (highlight-indent-guides :checksum "3a080a7469d06a1cde8a0abaebfa66b553b1c965")
+        (highlight-indent-guides :checksum "11bd2d30d56f273223f64f8f3eb5fc8565245959")
         (org-export-blocks-format-plantuml :checksum "9d8b93ae4f30e61ef6dbbf6d24118aa577c501ec")
         (ruby-end :checksum "a136f75abb6d5577ce40d61dfeb778c2e9bb09c0")
         (scratch-log :checksum "1168f7f16d36ca0f4ddf2bb98881f8db62cc5dc0")


### PR DESCRIPTION
## yaml-mode

https://github.com/yoshiki/yaml-mode/compare/40067a10ac1360f0b9533f0bbbb2eea128e2574d...34648f2502f52f4744d62758fa381fa35db1da49#files_bucket

高速化や不具合修正をやってるみたい

## highlight-indent-guides

https://github.com/DarthFennec/highlight-indent-guides/compare/3a080a7469d06a1cde8a0abaebfa66b553b1c965...11bd2d30d56f273223f64f8f3eb5fc8565245959

テストコードの更新のみ