### PR TITLE
magit 関係をまとめてアップデートしました

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -106,7 +106,7 @@
         (twittering-mode :checksum "114891e8fdb4f06b1326a6cf795e49c205cf9e29")
         (wakatime-mode :checksum "2531cb58287770883ba534d20b3288955c4d6ef3")
         (websocket :checksum "5be01c6d1a8e87d001916fc40a77d779826fcacf")
-        (with-editor :checksum "ff23166feb857e3cfee96cb1c9ef416a224a7e20")
+        (with-editor :checksum "7c512887c6d69864fb600d32fb92857c51babcff")
         (yaml-mode :checksum "34648f2502f52f4744d62758fa381fa35db1da49")
         (yascroll :checksum "fe4494e5f4faf2832e665c7de0fed99cdbb39478")
         (yasnippet :checksum "e45e3de357fbd4289fcfa3dd26aaa7be357fb0b8")

--- a/el-get.lock
+++ b/el-get.lock
@@ -102,7 +102,7 @@
         (spinner :checksum "4b335260edcdd8dcee0811d7048bb08274e941f1")
         (swiper :checksum "d951004c7f3ebf98d55fc5a80a3471ec95b6db05")
         (transient :checksum "629c963e1f17715b56848a5bbd9017896fa49bdf")
-        (treepy :checksum "b40e6b09eb9be45da67b8c9e4990a5a0d7a2a09d")
+        (treepy :checksum "306f7031d26e4ebfc9ff36614acdc6993f3e23c3")
         (twittering-mode :checksum "114891e8fdb4f06b1326a6cf795e49c205cf9e29")
         (wakatime-mode :checksum "2531cb58287770883ba534d20b3288955c4d6ef3")
         (websocket :checksum "5be01c6d1a8e87d001916fc40a77d779826fcacf")

--- a/el-get.lock
+++ b/el-get.lock
@@ -52,7 +52,7 @@
         (flycheck :checksum "bd8a93240aee78e90c83a54ab3799ff4d02f9f15")
         (forge :checksum "bf521e07693f6274ec99c72ceb16f66b78b788dc")
         (fringe-helper :checksum "ef4a9c023bae18ec1ddd7265f1f2d6d2e775efdd")
-        (ghub :checksum "2b196577d463b5685decca1d4fa20e2858725a25")
+        (ghub :checksum "3f53691bf8475e92b3cb8f779dc745ade0e247ed")
         (git-gutter :checksum "00c05264af046b5ce248e5b0bc42f117d9c27a09")
         (git-gutter-fringe :checksum "16226caab44174301f1659f7bf8cc67a76153445")
         (google-this :checksum "8a2e3ca5da6a8c89bfe99a21486c6c7db125dc84")

--- a/el-get.lock
+++ b/el-get.lock
@@ -39,7 +39,7 @@
         (doom-modeline :checksum "6ecda37e4550e85cfa5e4957d0a05bd393e6a4b3")
         (el-get-lock :checksum "df8cfe55441695865a64b97946750b6413a40425")
         (eldoc-eval :checksum "a67fe3637378dcb6c5f9e140acc8131f0d2346b3")
-        (emacs-async :checksum "35ab78afb9ec4929552f43c6bab09bbd7da3842a")
+        (emacs-async :checksum "86aef2c38e7d35e8509b7feeee3e989d825eba91")
         (emacsql :checksum "a118b6c95af1306f0288a383d274b5dd93efbbda")
         (emojify :checksum "a16199dcf9b4688839eba00f1e356d9beac46cfe")
         (enh-ruby-mode :checksum "f334c42986e93c60fba144d732becfcbdb13bb7d")

--- a/el-get.lock
+++ b/el-get.lock
@@ -101,7 +101,7 @@
         (smart-mode-line :checksum "999be065b195f2eddb4e1b629f99038d832d44b7")
         (spinner :checksum "4b335260edcdd8dcee0811d7048bb08274e941f1")
         (swiper :checksum "d951004c7f3ebf98d55fc5a80a3471ec95b6db05")
-        (transient :checksum "629c963e1f17715b56848a5bbd9017896fa49bdf")
+        (transient :checksum "73694be44a802cac89bfe0798e2a4aeb79e39ead")
         (treepy :checksum "306f7031d26e4ebfc9ff36614acdc6993f3e23c3")
         (twittering-mode :checksum "114891e8fdb4f06b1326a6cf795e49c205cf9e29")
         (wakatime-mode :checksum "2531cb58287770883ba534d20b3288955c4d6ef3")

--- a/el-get.lock
+++ b/el-get.lock
@@ -75,7 +75,7 @@
         (lsp-mode :checksum "7ce0d789a313b84ef7c1b00b63a3db4cc0959fbe")
         (lsp-ui :checksum "7d5326430eb88a58e111cb22ffa42c7d131e5052")
         (major-mode-hydra\.el :checksum "20362323f66883c1336ffe70be24f91509addf54")
-        (magit :checksum "7118a9af4f002d6cdc8762b16c45e1ba307dcc8a")
+        (magit :checksum "485ee181564655d21c0770a4e021f7b805f4d643")
         (markdown-mode :checksum "399df42755ccf31cecb61c9f5d8ad72bc30d7e4b")
         (memoize :checksum "9a561268ffb550b257a08710489a95cd087998b6")
         (migemo :checksum "f42832c8ac462ecbec9a16eb781194f876fba64a")

--- a/el-get.lock
+++ b/el-get.lock
@@ -32,7 +32,7 @@
         (company-lsp :checksum "f921ffa0cdc542c21dc3dd85f2c93df4288e83bd")
         (company-mode :checksum "ad6ff0eecca99dc5ac8b6a8a6174df7d2ad88ae7")
         (counsel-projectile :checksum "77392cbbc42e98fc137b43f1db1b111ba6e2dd75")
-        (dash :checksum "77f3bf40c9c85386a50f2dab3dc950513f6f88bd")
+        (dash :checksum "732d92eac56023a4fb4a5dc3d9d4e274ebf44bf9")
         (ddskk :checksum "ad61579af269291b4446f4bab0a58522cc454f1c")
         (ddskk-posframe\.el :checksum "8a37953b37d397ba406bc308eb908bd966d34af6")
         (deferred :checksum "2239671d94b38d92e9b28d4e12fd79814cfb9c16")

--- a/el-get.lock
+++ b/el-get.lock
@@ -28,7 +28,7 @@
         (alert :checksum "b5ef49bbb871867ac03d2943a720576336cd7025")
         (calfw :checksum "03abce97620a4a7f7ec5f911e669da9031ab9088")
         (circe :checksum "e4af7143bd32907d0bf922bee53a96399f0376fa")
-        (closql :checksum "7db24ab416925214b364ffe6bb36e367c43d5d35")
+        (closql :checksum "e074a6ddb17a2109c15ca6a2d84e4bc3071a1147")
         (company-lsp :checksum "f921ffa0cdc542c21dc3dd85f2c93df4288e83bd")
         (company-mode :checksum "ad6ff0eecca99dc5ac8b6a8a6174df7d2ad88ae7")
         (counsel-projectile :checksum "77392cbbc42e98fc137b43f1db1b111ba6e2dd75")

--- a/el-get.lock
+++ b/el-get.lock
@@ -50,7 +50,7 @@
         (f :checksum "8191672377816a1975414cc1f116fd3b94b30bd0")
         (flex-autopair :checksum "4bb757f2556a4a51828e2fed8fb81e31e83052cb")
         (flycheck :checksum "bd8a93240aee78e90c83a54ab3799ff4d02f9f15")
-        (forge :checksum "bf521e07693f6274ec99c72ceb16f66b78b788dc")
+        (forge :checksum "237d71da64b90b3d4da5fe35588546567a5c1c81")
         (fringe-helper :checksum "ef4a9c023bae18ec1ddd7265f1f2d6d2e775efdd")
         (ghub :checksum "3f53691bf8475e92b3cb8f779dc745ade0e247ed")
         (git-gutter :checksum "00c05264af046b5ce248e5b0bc42f117d9c27a09")


### PR DESCRIPTION
magit と関連パッケージとそれらが依存しているパッケージを更新しました

## magit

https://github.com/magit/magit/compare/7118a9af4f002d6cdc8762b16c45e1ba307dcc8a...485ee181564655d21c0770a4e021f7b805f4d643

Changelog を見た感じ、バグ修正や機能追加でより良くなってる感じ

## treepy

https://github.com/volrath/treepy.el/compare/b40e6b09eb9be45da67b8c9e4990a5a0d7a2a09d...306f7031d26e4ebfc9ff36614acdc6993f3e23c3

ドキュメントの typo 修正と
`(require 'cl-lib)` が追加されたぐらい

## transient

https://github.com/magit/transient/compare/629c963e1f17715b56848a5bbd9017896fa49bdf...73694be44a802cac89bfe0798e2a4aeb79e39ead

## ghub

https://github.com/magit/ghub/compare/2b196577d463b5685decca1d4fa20e2858725a25...3f53691bf8475e92b3cb8f779dc745ade0e247ed

よくわかってないが CHANGELOG を見る限りよくなってそう

## emacs-async

https://github.com/jwiegley/emacs-async/compare/35ab78afb9ec4929552f43c6bab09bbd7da3842a...86aef2c38e7d35e8509b7feeee3e989d825eba91

サポートする Emacs のバージョンが明示されたのと
ドキュメントやインデントの修正のみ

## with-editor

https://github.com/magit/with-editor/compare/ff23166feb857e3cfee96cb1c9ef416a224a7e20...7c512887c6d69864fb600d32fb92857c51babcff

イマイチどう使われていてどういう更新なのかわからないがひとまずよし

## closql

https://github.com/emacscollective/closql/compare/7db24ab416925214b364ffe6bb36e367c43d5d35...e074a6ddb17a2109c15ca6a2d84e4bc3071a1147

依存関係に入ってたので更新。
EIEIO がわからんからわからん……。

## dash.el

https://github.com/magnars/dash.el/compare/77f3bf40c9c85386a50f2dab3dc950513f6f88bd...732d92eac56023a4fb4a5dc3d9d4e274ebf44bf9

これも依存関係なので最新化

## forge

https://github.com/magit/forge/compare/bf521e07693f6274ec99c72ceb16f66b78b788dc...237d71da64b90b3d4da5fe35588546567a5c1c81

- forge-owned-accounts
- forge-list-requested-reviews
- forge-list-owned-pullreqs
- forge-list-owned-issues

とか気になる
色々便利そうな機能ありそう。

ただ大きいリポジトリに実行すると結構重いから使ってないんだよな……