### PR TITLE
git-gutter と git-gutter-frindge をアップデート

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -54,7 +54,7 @@
         (fringe-helper :checksum "ef4a9c023bae18ec1ddd7265f1f2d6d2e775efdd")
         (ghub :checksum "3f53691bf8475e92b3cb8f779dc745ade0e247ed")
         (git-gutter :checksum "00c05264af046b5ce248e5b0bc42f117d9c27a09")
-        (git-gutter-fringe :checksum "16226caab44174301f1659f7bf8cc67a76153445")
+        (git-gutter-fringe :checksum "da19a474137876b29b5658ee7e9ae366f2b65c1d")
         (google-this :checksum "8a2e3ca5da6a8c89bfe99a21486c6c7db125dc84")
         (graphql :checksum "e2b309689f4faf9225f290080f836e988c5a576d")
         (haml-mode :checksum "bf5b6c11b1206759d2b28af48765e04882dd1fc4")

--- a/el-get.lock
+++ b/el-get.lock
@@ -53,7 +53,7 @@
         (forge :checksum "237d71da64b90b3d4da5fe35588546567a5c1c81")
         (fringe-helper :checksum "ef4a9c023bae18ec1ddd7265f1f2d6d2e775efdd")
         (ghub :checksum "3f53691bf8475e92b3cb8f779dc745ade0e247ed")
-        (git-gutter :checksum "00c05264af046b5ce248e5b0bc42f117d9c27a09")
+        (git-gutter :checksum "2c3242116a42dbbe30fc0844d1ec3c41074cdaba")
         (git-gutter-fringe :checksum "da19a474137876b29b5658ee7e9ae366f2b65c1d")
         (google-this :checksum "8a2e3ca5da6a8c89bfe99a21486c6c7db125dc84")
         (graphql :checksum "e2b309689f4faf9225f290080f836e988c5a576d")


### PR DESCRIPTION
## git-gutter-frindge

https://github.com/emacsorphanage/git-gutter-fringe/compare/16226caab44174301f1659f7bf8cc67a76153445...da19a474137876b29b5658ee7e9ae366f2b65c1d

コメントの更新やテスト周りの更新。

ところでこいつ使ってないことに気付いた……。

## git-gutter

https://github.com/emacsorphanage/git-gutter/compare/00c05264af046b5ce248e5b0bc42f117d9c27a09...2c3242116a42dbbe30fc0844d1ec3c41074cdaba

色々更新されてる。
コマンド活用してないなあという感想