### PR TITLE
update inf-ruby

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -66,7 +66,7 @@
         (ht :checksum "5650a8cd190badb49d28d21e72a2f55c9380de7b")
         (hydra :checksum "8a9124f80b6919ad5288172b3e9f46c5332763ca")
         (hydra-posframe :checksum "d02452f10e071f28d1e1e35e8b2ea6a41451da2e")
-        (inf-ruby :checksum "fd8d392fefd1d99eb58fc597d537d0d7df29c334")
+        (inf-ruby :checksum "f3c927c1b917a20ce6b2228d480db43171aadd9b")
         (init-loader :checksum "5d3cea1004c11ff96b33020e337b03b925c67c42")
         (japanese-holidays :checksum "45e70a6eaf4a555fadc58ab731d522a037a81997")
         (js2-mode :checksum "90e1434146988e855ade79c5acefc156f6420d7a")


### PR DESCRIPTION
https://github.com/nonsequitur/inf-ruby/compare/fd8d392fefd1d99eb58fc597d537d0d7df29c334...f3c927c1b917a20ce6b2228d480db43171aadd9b

Ruby 2.7 の対応が入ってるみたい。
とりあえず手元の環境で問題がないので入れとく