### PR TITLE
update yascroll

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -108,7 +108,7 @@
         (websocket :checksum "5be01c6d1a8e87d001916fc40a77d779826fcacf")
         (with-editor :checksum "7c512887c6d69864fb600d32fb92857c51babcff")
         (yaml-mode :checksum "34648f2502f52f4744d62758fa381fa35db1da49")
-        (yascroll :checksum "fe4494e5f4faf2832e665c7de0fed99cdbb39478")
+        (yascroll :checksum "9e828920d1931da66a473a66019922b9c3b729f5")
         (yasnippet :checksum "d3d6d70b1cd4818d271752468e0fdb0788db750d")
         (zoom-window :checksum "ab14a365f3e496b07f5efc20992f9094ec166f06")
         (ace-window :checksum "c7cb315c14e36fded5ac4096e158497ae974bec9")


### PR DESCRIPTION
https://github.com/emacsorphanage//yascroll/compare/fe4494e5f4faf2832e665c7de0fed99cdbb39478...9e828920d1931da66a473a66019922b9c3b729f5

更新前は動かなくなってたのが更新したら動くようになったのでよし!