### PR TITLE
update org-tree-slide

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -82,7 +82,7 @@
         (multiple-cursors :checksum "b880554d04b8f61165afba7d4de19ac9e39bb7ab")
         (ob-async :checksum "80a30b96a007d419ece12c976a81804ede340311")
         (org-gcal :checksum "bdc704842da000a1cffb8f155ef3887c5e1d0446")
-        (org-tree-slide :checksum "7bf09a02bd2d8f1ccfcb5209bfb18fbe02d1f44e")
+        (org-tree-slide :checksum "7126a4365072a32898f169ead8fb59265dabc605")
         (paredit :checksum "8330a41e8188fe18d3fa805bb9aa529f015318e8")
         (pkg-info :checksum "76ba7415480687d05a4353b27fea2ae02b8d9d61")
         (plantuml-mode :checksum "e9c8e76ff25013e05ab83de9462bbcdd74e27237")


### PR DESCRIPTION
https://github.com/takaxp/org-tree-slide/compare/7bf09a02bd2d8f1ccfcb5209bfb18fbe02d1f44e...7126a4365072a32898f169ead8fb59265dabc605

まだ活用してないのでとりあえず最新にしとく。
Changelog 見る感じ大丈夫そうな気がするし