### PR TITLE
日報生成に org-ql を使うようにした

### DIFF
--- a/inits/62-nippou.el
+++ b/inits/62-nippou.el
@@ -1,0 +1,19 @@
+(load "my-nippou-config")
+(defun my/org-nippou-targets ()
+      (-concat (my/org-nippou-files) my/org-nippou-additional-files))
+
+(defun my/org-nippou-files ()
+  (let* ((dir my/org-tasks-directory)
+         (cmd (format "find \"%s\" -name '*.org' -or -name '*.org_archive'" dir))
+         (result (shell-command-to-string cmd))
+         (file-names (split-string result "\n")))
+    (-remove (lambda (file-name) (string= "" file-name))
+             file-names)))
+
+(defun my/nippou-query ()
+  (interactive)
+  (org-ql-search
+    (my/org-nippou-targets)
+    "todo:TODO,DOING,WAIT,DONE ts:on=today"
+    :title "日報"
+    :super-groups '((:auto-group))))


### PR DESCRIPTION
自分用メモ。
とりあえず雑な作りの奴の使い方を残しておく。

# org-ql を用いた管理日報ツール

## これは何?

日報を書くのだるいので
org-mode で記録している情報をそれなりの形で出せるようにしたやつ。
あくまでそれなりだけど。

## 準備

### タスクファイルの用意

日報出力のための元データになる org ファイルを `my/org-tasks-directory` に用意する(複数 OK)

### タスクファイルの記法

```
* Next Actions
  :PROPERTIES:
  :agenda-group: 01_レビュー
  :END:
```

みたいに TODO の対象にしたい TODO を放り込む tree に agenda-group という property を用意する
agenda-group については org-ql や org-super-agenda-mode 辺りを調べてね。

タスク自体は、上で用意したツリーの下に

```
** TODO 日報生成のやつを PR にする
```

みたいに TODO を突っ込むイメージ。

まあ実は TODO とかであれば全部日報の対象にはなるんだけど
auto-group を使ってる関係上は agenda-group を設定しているツリー内に置いておく方がいい感じになる。

対象になる TODO keywords は

- TODO
- DOING
- WAIT
- DONE

### my/org-nippou-additional-files の設定

my/org-tasks-directory 以外にあるファイルは以下の方法で対象に追加できます

```
(setq my/org-nippou-additional-files 
  (list (expand-file-name "~/path/to/hoge.org")))
```

現状はこの変数がリストとして設定されてないとダメというクソな作りなのでそこはよしなに。

## 使い方

`M-x my/nippou-query`

を叩くと
org-ql-search でそれっぽいのが出力される。