### PR TITLE
dumb-jump-selector には ivy を使うことにした

### DIFF
--- a/inits/40-dumb-jump.el
+++ b/inits/40-dumb-jump.el
@@ -1,6 +1,6 @@
 (el-get-bundle dumb-jump)
 (setq dumb-jump-default-project "~/projects")
-(setq dumb-jump-selector 'helm)
+(setq dumb-jump-selector 'ivy)
 
 (with-eval-after-load 'pretty-hydra
   (pretty-hydra-define dumb-jump-pretty-hydra


### PR DESCRIPTION
helm から ivy に基本的には乗り換えていく方針なので。