### PR TITLE
AquaSKK の辞書を使うのはそれが存在する時だけにした

### DIFF
--- a/inits/30-skk.el
+++ b/inits/30-skk.el
@@ -22,7 +22,9 @@
 (setq skk-extra-jisyo-file-list (list '("~/.emacs.d/skk-jisyo/SKK-JISYO.lisp" . japanese-iso-8bit-unix)))
 
 ;; AquaSKKのL辞書をつかうようにする
-(setq skk-large-jisyo (expand-file-name "~/Library/Application Support/AquaSKK/SKK-JISYO.L"))
+(let ((l-dict (expand-file-name "~/Library/Application Support/AquaSKK/SKK-JISYO.L")))
+  (if (file-exists-p l-dict)
+      (setq skk-large-jisyo l-dict)))
 
 (el-get-bundle conao3/ddskk-posframe.el)
 (ddskk-posframe-mode 1)


### PR DESCRIPTION
Mac で同じ辞書を2つ入れるのが嫌だからと設定していたが
Ubuntu で動かす時に邪魔な設定になってたのでとりあえず読まないようにした。

今 Ubuntu で何の辞書が使われてるかは把握できてないが、
とりあえず変換はできるから良し