### PR TITLE
Ubuntu でも migemo が使えるように設定を修正

### DIFF
--- a/inits/01-load-libraries.el
+++ b/inits/01-load-libraries.el
@@ -1,0 +1,2 @@
+(el-get-bundle s)
+(require 's)

--- a/inits/10-migemo.el
+++ b/inits/10-migemo.el
@@ -1,7 +1,21 @@
 (el-get-bundle migemo)
 (load "migemo")
-(setq migemo-dictionary "/usr/local/share/migemo/utf-8/migemo-dict")
-(setq migemo-command "/usr/local/bin/cmigemo")
+
+;; Mac
+(let ((path "/usr/local/share/migemo/utf-8/migemo-dict"))
+  (if (file-exists-p path)
+      (setq migemo-dictionary path)))
+
+;; Ubuntu
+(let ((path "/usr/share/cmigemo/utf-8/migemo-dict"))
+  (if (file-exists-p path)
+      (setq migemo-dictionary path)))
+
+(let ((path (s-chomp (shell-command-to-string "which cmigemo"))))
+  (if (s-ends-with? "not found" path)
+      (message "cmigemo not found")
+    (setq migemo-command path)))
+
 (setq migemo-options '("-q" "--emacs"))
 (setq migemo-coding-system 'utf-8-unix)
 (migemo-init)


### PR DESCRIPTION
Mac と Ubuntu で migemo の辞書の位置が変わったりするので
どっちでもいい感じに使えるように分岐を入れた

正直 Mac での動作確認はしてないが、ま、壊れてたら後から直せばいいので良しとする