### PR TITLE
X で fullscreen で左上に寄るようにした

### DIFF
--- a/inits/90-fullscreen.el
+++ b/inits/90-fullscreen.el
@@ -2,3 +2,9 @@
     (add-hook 'window-setup-hook
               (lambda ()
                 (set-frame-parameter nil 'fullscreen 'fullboth))))
+
+(if (eq window-system 'x)
+    (add-hook 'window-setup-hook
+              (lambda ()
+                (set-frame-parameter nil 'fullscreen 'fullboth)
+                (set-frame-position nil 0 0))))


### PR DESCRIPTION
X Window System を使ってる場合にも
Emacs が画面いっぱいに広がるようにした

ツールバーも隠れるようにしたい気もするが、
最初に frame を広げる作業が不要になったのでひとまず OK