### PR TITLE
org-refile の設定を追加した

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -173,7 +173,8 @@
      "Pomodoro"
      (("p" org-pomodoro "Pomodoro")))))
 
-(setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 2)))
+(setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 2)
+                           (,(concat org-directory "tasks/next-actions.org") :level . 1)))
 
 (defun my/org-tags-view-only-todo ()
   (interactive)

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -174,6 +174,7 @@
      (("p" org-pomodoro "Pomodoro")))))
 
 (setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 2)
+                           (,(concat org-directory "tasks/pointers.org") :level . 1)
                            (,(concat org-directory "tasks/next-actions.org") :level . 1)))
 
 (defun my/org-tags-view-only-todo ()

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -173,6 +173,8 @@
      "Pomodoro"
      (("p" org-pomodoro "Pomodoro")))))
 
+(setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 2)))
+
 (defun my/org-tags-view-only-todo ()
   (interactive)
   (org-tags-view t))


### PR DESCRIPTION
org-mode のツリーを移動できる org-refile という機能に気付いたので設定を入れた。
GTD をベースにしているので、
next-actions と projects 及び pointers にとりあえず移動できるようにしている。