### PR TITLE
org-mode 用の設定を更新した

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -78,7 +78,7 @@
 (setq org-clock-clocktable-default-properties
       '(:maxlevel 10
                  :lang "ja"
-                 :scope agenda
+                 :scope agenda-with-archives
                  :block today
                  :level 4))
 

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -134,8 +134,9 @@
       ("c" org-toggle-checkbox "Toggle checkbox"))
 
      "Clock"
-     (("i" org-clock-in   "In")
-      ("o" org-clock-out  "Out"))
+     (("i" org-clock-in  "In")
+      ("o" org-clock-out "Out")
+      ("p" org-pomodoro  "Pomodoro"))
 
      "Babel"
      (("e" org-babel-confirm-evaluate "Eval"))

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -120,6 +120,7 @@
 
      "Edit"
      (("a" org-archive-subtree  "Archive")
+      ("r" org-refile           "Refile")
       ("Q" org-set-tags-command "Tag"))
 
      "View"


### PR DESCRIPTION
- アーカイブしてるやつも org-clock-reports で計測対象にしてほしいので scope を agenda-with-archives に変更
- org-refile を使うために major-mode-hydra に設定
- org-pomodoro も便利に使えるようにするため設定
  - これも major-mode-hydra の方がいいかもって思ってるけど、今度にしよう。