### PR TITLE
slack と circe は使ってないので削除

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -35,7 +35,6 @@
         (all-the-icons :checksum "ed8e44de4fa601309d2bba902c3b37cb73e4daa0")
         (alert :checksum "7046393272686c7a1a9b3e7f7b1d825d2e5250a6")
         (calfw :checksum "03abce97620a4a7f7ec5f911e669da9031ab9088")
-        (circe :checksum "7386df382d6cc819c9f6290c185f3f962339afd1")
         (closql :checksum "c864c1fadfea4a05fff29cb60891b7a32ac88c78")
         (company-mode :checksum "97cfbc3967c195fb4ccb171735b9b1dea97e681a")
         (counsel-projectile :checksum "06b03c1080d3ccc3fa9b9c41b1ccbcf13f058e4b")

--- a/inits/80-slack.el
+++ b/inits/80-slack.el
@@ -1,4 +1,0 @@
-(el-get-bundle slack)
-(setq slack-buffer-emojify t)
-(setq slack-prefer-current-team t)
-(my/load-config "my-slack-config")


### PR DESCRIPTION
slack.el とそれが依存している circe は削除した
差分更新時に面倒なのと、今使ってないので。