### PR TITLE
counsel-project-switch-project で neotree を開くようにした

### DIFF
--- a/custom.el
+++ b/custom.el
@@ -8,6 +8,33 @@
  '(aw-background t)
  '(column-number-mode t)
  '(counsel-locate-cmd (quote counsel-locate-cmd-mdfind))
+ '(counsel-projectile-switch-project-action
+   (quote
+    (1
+     ("o" counsel-projectile-switch-project-action "jump to a project buffer or file")
+     ("f" counsel-projectile-switch-project-action-find-file "jump to a project file")
+     ("d" counsel-projectile-switch-project-action-find-dir "jump to a project directory")
+     ("D" counsel-projectile-switch-project-action-dired "open project in dired")
+     ("b" counsel-projectile-switch-project-action-switch-to-buffer "jump to a project buffer")
+     ("m" counsel-projectile-switch-project-action-find-file-manually "find file manually from project root")
+     ("S" counsel-projectile-switch-project-action-save-all-buffers "save all project buffers")
+     ("k" counsel-projectile-switch-project-action-kill-buffers "kill all project buffers")
+     ("K" counsel-projectile-switch-project-action-remove-known-project "remove project from known projects")
+     ("c" counsel-projectile-switch-project-action-compile "run project compilation command")
+     ("C" counsel-projectile-switch-project-action-configure "run project configure command")
+     ("E" counsel-projectile-switch-project-action-edit-dir-locals "edit project dir-locals")
+     ("v" counsel-projectile-switch-project-action-vc "open project in vc-dir / magit / monky")
+     ("sg" counsel-projectile-switch-project-action-grep "search project with grep")
+     ("si" counsel-projectile-switch-project-action-git-grep "search project with git grep")
+     ("ss" counsel-projectile-switch-project-action-ag "search project with ag")
+     ("sr" counsel-projectile-switch-project-action-rg "search project with rg")
+     ("xs" counsel-projectile-switch-project-action-run-shell "invoke shell from project root")
+     ("xe" counsel-projectile-switch-project-action-run-eshell "invoke eshell from project root")
+     ("xt" counsel-projectile-switch-project-action-run-term "invoke term from project root")
+     ("xv" counsel-projectile-switch-project-action-run-vterm "invoke vterm from project root")
+     ("Oc" counsel-projectile-switch-project-action-org-capture "capture into project")
+     ("Oa" counsel-projectile-switch-project-action-org-agenda "open project agenda")
+     ("N" neotree-dir "Switch Neotree"))))
  '(css-indent-offset 2)
  '(custom-safe-themes
    (quote

--- a/inits/40-neotree.el
+++ b/inits/40-neotree.el
@@ -1,3 +1,4 @@
 (el-get-bundle emacs-neotree-dev)
-(setq projectile-switch-project-action 'neotree-projectile-action)
+;; counsel-projectile を使ってると意味がないのでコメントアウト
+;; (setq projectile-switch-project-action 'neotree-projectile-action)
 (setq neo-theme (if (display-graphic-p) 'icons 'arrow))

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -24,7 +24,7 @@
 
 (pretty-hydra-define pretty-hydra-usefull-commands (:separator "-" :color teal :foreign-key warn :title (concat (all-the-icons-material "build") " Usefull commands") :quit-key "q")
   ("File"
-   (("p" counsel-projectile-switch-project "Switch Project")
+   (("p" (counsel-projectile-switch-project 'neotree-dir) "Switch Project")
     ("r" projectile-recentf "Recentf")
     ("d" counsel-projectile-find-dir "Find Dir")
     ("f" counsel-projectile-find-file "Find File")


### PR DESCRIPTION
## 課題
counsel-projectile-switch-project を hydra で呼び出しているが
find-file になるのが挙動として気に入ってなかった

なぜなら、自社のプロジェクトはファイル数が多いので find-file で絞るよりも
projectile-rails の機能で絞り込むのが常であり
なのでまずそれの選択からする方が良いと思っていた。

あと projectile-find-file の補完だとなんか微妙。
ドットファイルとかも検索対象になるから邪魔でしょうがない

## 解決方法

neotree を使ってるので、とりあえず最初にそれを開くことで
次のアクションを自分でできるようにした