### PR TITLE
org-mode 用の設定を更新

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -154,9 +154,6 @@
      "Babel"
      (("e" org-babel-confirm-evaluate "Eval"))
 
-     "Search"
-     (("H" org-search-view "Heading"))
-
      "Trello"
      (("K" org-trello-mode "On/Off" :toggle org-trello-mode)
       ("k" (if org-trello-mode
@@ -181,6 +178,7 @@
       ("t" my/org-tags-view-only-todo "Tagged Todo")
       ("F" org-gcal-fetch "Fetch Calendar")
       ("C" my/open-user-calendar "Calendar"))
+
      "Clock"
      (("i" org-clock-in  "In")
       ("o" org-clock-out "Out")
@@ -188,6 +186,10 @@
       ("x" org-clock-cancel "Cancel")
       ("j" org-clock-goto "Goto")
       ("r" org-clock-report "Report"))
+
+     "Search"
+     (("H" org-search-view "Heading"))
+
      "Pomodoro"
      (("p" org-pomodoro "Pomodoro")))))
 

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -154,6 +154,9 @@
      "Babel"
      (("e" org-babel-confirm-evaluate "Eval"))
 
+     "Search"
+     (("H" org-search-view "Heading"))
+
      "Trello"
      (("K" org-trello-mode "On/Off" :toggle org-trello-mode)
       ("k" (if org-trello-mode

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -141,15 +141,16 @@
       ("D" my/org-clock-toggle-display  "Toggle Display"))
 
      "Task"
-     (("s" org-schedule "Schedule")
-      ("d" org-deadline "Deadline")
-      ("t" my/org-todo  "Change state")
-      ("c" org-toggle-checkbox "Toggle checkbox"))
+     (("s" org-schedule         "Schedule")
+      ("d" org-deadline         "Deadline")
+      ("t" my/org-todo          "Change state")
+      ("c" org-toggle-checkbox  "Toggle checkbox"))
 
      "Clock"
-     (("i" org-clock-in  "In")
-      ("o" org-clock-out "Out")
-      ("p" org-pomodoro  "Pomodoro"))
+     (("i" org-clock-in      "In")
+      ("o" org-clock-out     "Out")
+      ("R" org-clock-report  "Report")
+      ("p" org-pomodoro      "Pomodoro"))
 
      "Babel"
      (("e" org-babel-confirm-evaluate "Eval"))
@@ -175,17 +176,18 @@
      (("a" org-agenda "Agenda")
       ("c" counsel-org-capture "Capture")
       ("l" org-store-link "Store link")
-      ("t" my/org-tags-view-only-todo "Tagged Todo")
-      ("F" org-gcal-fetch "Fetch Calendar")
+      ("t" my/org-tags-view-only-todo "Tagged Todo"))
+
+     "Calendar"
+     (("F" org-gcal-fetch "Fetch Calendar")
       ("C" my/open-user-calendar "Calendar"))
 
      "Clock"
-     (("i" org-clock-in  "In")
-      ("o" org-clock-out "Out")
-      ("r" org-clock-in-last "Restart")
-      ("x" org-clock-cancel "Cancel")
-      ("j" org-clock-goto "Goto")
-      ("r" org-clock-report "Report"))
+     (("i" org-clock-in       "In")
+      ("o" org-clock-out      "Out")
+      ("r" org-clock-in-last  "Restart")
+      ("x" org-clock-cancel   "Cancel")
+      ("j" org-clock-goto     "Goto"))
 
      "Search"
      (("H" org-search-view "Heading"))

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -56,6 +56,7 @@
 (setq my/org-tasks-directory (concat org-directory "tasks/"))
 (setq my/org-capture-interrupted-file (concat my/org-tasks-directory "interrupted.org"))
 (setq my/org-capture-gtd-file (concat my/org-tasks-directory "gtd.org"))
+(setq my/org-capture-pointers-file (concat my/org-tasks-directory "pointers.org"))
 (setq my/org-capture-impediments-file (concat org-directory "work/scrum/impediments.org"))
 (setq my/org-capture-memo-file (concat org-directory "memo.org"))
 
@@ -73,7 +74,10 @@
          "** TODO %?\n\t")
         ("m" "Memoにエントリー" entry
          (file+headline ,my/org-capture-memo-file "未分類")
-         "***  %?\n\t")
+         "*** %?\n\t")
+        ("p" "Pointersにエントリー" entry
+         (file+headline ,my/org-capture-pointers-file "Pointers")
+         "** %?\n\t")
         ("i" "割り込みタスクにエントリー" entry ;; 参考: http://grugrut.hatenablog.jp/entry/2016/03/13/085417
          (file+headline ,my/org-capture-interrupted-file "Interrupted")
          "** %?\n\t" :clock-in t :clock-resume t)

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -202,6 +202,12 @@
 
 (setq my/notify-slack-enable-p t)
 
+(defun my/notify-slack-toggle ()
+  (interactive)
+  (if my/notify-slack-enable-p
+      (setq my/notify-slack-enable-p nil)
+    (setq my/notify-slack-enable-p t)))
+
 (defun my/notify-slack (channel text)
   (start-process "my/org-clock-slack-notifier" "*my/org-clock-slack-notifier*" "my-slack-notifier" channel text))
 


### PR DESCRIPTION
## GTD の Pointers に即時登録できるようにした

Inbox に突っ込んでも
どうせ翌日に Pointers に移動することがわかるものは
最初から Pointers でいいなと思ったので

## clock-in/clock-out の Slack 通知を ON/OFF できるようにした

家にいる時のやつは通知したくないとか、まあ、通知したくない時はちょこちょこあるので。
あと機能は以前に用意してたけど、手軽にコマンドで切り替えたかった
Hydra で Toggle できるしね。

## org-search-view を hydra から起動できるようにした

検索したいよね〜ということで。

## hydra 周りを整理

ごちゃっとしてたので