### PR TITLE
Hydra 系のバインディングを変更した

### DIFF
--- a/inits/01-override.el
+++ b/inits/01-override.el
@@ -1,4 +1,4 @@
-;; posframe が最初に空行があると最後お行を表示しないため
+;; posframe が最初に空行があると最後の行を表示しないため
 ;; 一時的にこちらを直してみている
 (with-eval-after-load 'pretty-hydra
   (defun pretty-hydra--maybe-add-title (title docstring)

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -21,3 +21,14 @@
 
 (setq projectile-completion-system 'ivy)
 (el-get-bundle counsel-projectile)
+
+(with-eval-after-load 'pretty-hydra
+  (pretty-hydra-define
+    projectile-hydra (:separator "-" :title "Projectile" :foreaign-key warn :quit-key "q" :exit t)
+    ("File"
+     (("f" counsel-projectile-find-file "Find File")
+      ("d" counsel-projectile-find-dir "Find Dir")
+      ("r" projectile-recentf "Recentf"))
+
+     "Other"
+     (("p" (counsel-projectile-switch-project 'neotree-dir) "Switch Project")))))

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -68,6 +68,12 @@
    "Other"
    (("@"   all-the-icons-hydra/body "List icons"))))
 
+(pretty-hydra-define text-scale-hydra (:separator "-" :title (concat (all-the-icons-material "text_fields") " Text Scale") :exit nil :quit-key "q")
+  ("Scale"
+   (("+" text-scale-increase "Increase")
+    ("-" text-scale-decrease "Decrease")
+    ("0" text-scale-adjust   "Adjust"))))
+
 (pretty-hydra-define pretty-hydra-usefull-commands (:separator "-" :color teal :foreign-key warn :title (concat (all-the-icons-material "build") " Usefull commands") :quit-key "q")
   ("File"
    (("p" (counsel-projectile-switch-project 'neotree-dir) "Switch Project")

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -76,45 +76,33 @@
 
 (pretty-hydra-define pretty-hydra-usefull-commands (:separator "-" :color teal :foreign-key warn :title (concat (all-the-icons-material "build") " Usefull commands") :quit-key "q")
   ("File"
-   (("p" (counsel-projectile-switch-project 'neotree-dir) "Switch Project")
-    ("r" projectile-recentf "Recentf")
-    ("d" counsel-projectile-find-dir "Find Dir")
-    ("f" counsel-projectile-find-file "Find File")
-    ("l" counsel-locate "Locate"))
+   (("p" projectile-hydra/body "Projectile")
+    ("f" counsel-find-file     "Find File")
+    ("d" counsel-find-dir      "Find Dir")
+    ("r" counsel-recentf       "Recentf")
+    ("l" counsel-locate        "Locate")
+    ("A" counsel-osx-app       "macOS App"))
 
    "Edit"
-   (("a" align-regexp "Align Regexp"))
+   (("a" align-regexp "Align Regexp")
+    (";" comment-dwim "Comment"))
 
    "Code"
-   (("g" counsel-projectile-ag "Grep")
+   (("g" counsel-projectile-ag       "Grep")
     ("j" dumb-jump-pretty-hydra/body "Dumb jump")
-    ("i" counsel-imenu "imenu"))
+    ("i" counsel-imenu               "imenu")
+    ("m" magit-status                "Magit"))
 
    "View"
-   (("D" delete-other-windows "Only This Win")
-    ("W" window-control-hydra/body "Window Control"))
-
-   "Scale"
-   (("+" text-scale-increase "Increase")
-    ("-" text-scale-decrease "Decrease")
-    ("0" text-scale-adjust   "Adjust"))
-
-   "Describe"
-   (("B" counsel-descbinds "Keybind")
-    ("F" counsel-describe-function "Function")
-    ("V" counsel-describe-variable "Variable")
-    ("M" describe-minor-mode "Minor mode"))
+   (("D" delete-other-windows      "Only This Win")
+    ("W" window-control-hydra/body "Window Control")
+    ("+" text-scale-hydra/body     "Text Scale"))
 
    "Tool"
-   (("SPC" major-mode-hydra "Hydra(Major)")
-    ("s"   toggle-hydra/body "Toggle switches")
-    ("c"   counsel-org-capture "Capture")
-    ("o"   global-org-hydra/body "Org")
-    ("m"   magit-status "Magit")
-    ("A"   counsel-osx-app "macOS App")
-    ("@"   all-the-icons-hydra/body "All the icons")
-    ("e"   el-get-hydra/body "el-get")
+   (("SPC" major-mode-hydra              "Hydra(Major)")
+    ("s"   toggle-hydra/body             "Toggle switches")
+    ("c"   counsel-org-capture           "Capture")
+    ("o"   global-org-hydra/body         "Org")
+    ("e"   el-get-hydra/body             "el-get")
     ("/"   google-this-pretty-hydra/body "Google")
-    ("t"   google-translate-at-point "EN => JP")
-    ("T"   google-translate-at-point-reverse "JP => EN")
-    ("P"   my/open-review-requested-pr "Open Requested PR"))))
+    ("t"   subtools-hydra/body           "Sub Tools"))))

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -46,6 +46,28 @@
     ("v" my/toggle-view-mode       "Readonly"       :toggle view-mode)
     ("E" toggle-debug-on-error     "Debug on error" :toggle debug-on-error))))
 
+(pretty-hydra-define
+  subtools-hydra
+  (:separator "-"
+              :color teal
+              :foreign-key warn
+              :title (concat (all-the-icons-material "build") " Sub tools")
+              :quit-key "q"
+              :exit t)
+  ("Translation"
+   (("t" google-translate-at-point "EN => JP")
+    ("T" google-translate-at-point-reverse "JP => EN"))
+
+   "Describe"
+   (("b" counsel-descbinds "Keybind")
+    ("f" counsel-describe-function "Function")
+    ("v" counsel-describe-variable "Variable")
+    ("m" describe-minor-mode "Minor mode"))
+
+   ;; ("P"   my/open-review-requested-pr "Open Requested PR")
+   "Other"
+   (("@"   all-the-icons-hydra/body "List icons"))))
+
 (pretty-hydra-define pretty-hydra-usefull-commands (:separator "-" :color teal :foreign-key warn :title (concat (all-the-icons-material "build") " Usefull commands") :quit-key "q")
   ("File"
    (("p" (counsel-projectile-switch-project 'neotree-dir) "Switch Project")


### PR DESCRIPTION
## Main で使ってるやつの変更

- テキストスケールは表示系に
- magit-status はコード系に
- 翻訳関係はサブツールに
- Application 検索はファイル系に
- ファイル系を projectile 系ではなく全体検索に
- projectile 系は別の pretty-hydra に移動

## その他

- projectile 系を分離
- テキストスケール系も分離
- 思ったより使わないコマンドもサブツールとして分離