### PR TITLE
Mac では起動時にフルスクリーンにするのをやめた

### DIFF
--- a/inits/90-fullscreen.el
+++ b/inits/90-fullscreen.el
@@ -1,8 +1,11 @@
-(if (or (eq window-system 'ns) (eq window-system 'mac))
-    (add-hook 'window-setup-hook
-              (lambda ()
-                (set-frame-parameter nil 'fullscreen 'fullboth))))
+;; Mac の場合にフルスクリーンにする
+;; 2020-01-08 yabai WM を導入したのでフルスクリーンじゃない方がよくなったのでコメントアウト
+;; (if (or (eq window-system 'ns) (eq window-system 'mac))
+;;     (add-hook 'window-setup-hook
+;;               (lambda ()
+;;                 (set-frame-parameter nil 'fullscreen 'fullboth))))
 
+;; X Window system の場合にフルスクリーンにする
 (if (eq window-system 'x)
     (add-hook 'window-setup-hook
               (lambda ()


### PR DESCRIPTION
タイル型 WM の yabai を入れたら
フルスクリーンされるのはかえって邪魔になった