### PR TITLE
company の keymap が起動直後に設定されないので修正

### DIFF
--- a/inits/30-company.el
+++ b/inits/30-company.el
@@ -1,10 +1,10 @@
 (el-get-bundle company-mode)
+(with-eval-after-load 'company
+  ;; active
+  (define-key company-active-map (kbd "C-n") 'company-select-next)
+  (define-key company-active-map (kbd "C-p") 'company-select-previous)
+  (define-key company-active-map (kbd "C-s") 'company-search-candidates)
 
-;; active
-(define-key company-active-map (kbd "C-n") 'company-select-next)
-(define-key company-active-map (kbd "C-p") 'company-select-previous)
-(define-key company-active-map (kbd "C-s") 'company-search-candidates)
-
-;; search
-(define-key company-search-map (kbd "C-n") 'company-select-next)
-(define-key company-search-map (kbd "C-p") 'company-select-previous)
+  ;; search
+  (define-key company-search-map (kbd "C-n") 'company-select-next)
+  (define-key company-search-map (kbd "C-p") 'company-select-previous))


### PR DESCRIPTION
with-eval-after-load を噛ますことで対応した