### PR TITLE
lsp-ui-doc の表示設定を変更

### DIFF
--- a/inits/20-lsp.el
+++ b/inits/20-lsp.el
@@ -1,3 +1,4 @@
 (el-get-bundle lsp-mode)
 (el-get-bundle lsp-ui)
 (add-hook 'lsp-mode-hook 'lsp-ui-mode)
+(setq lsp-ui-doc-alignment 'window)


### PR DESCRIPTION
frame の右上に出ていたのを
window の右上に出るように変更した

frame だと大画面でのフルスクリーン時につらいのよね