### PR TITLE
起動時に server を立ち上げるようにした

### DIFF
--- a/inits/99-server.el
+++ b/inits/99-server.el
@@ -1,0 +1,5 @@
+;; サーバとして起動
+;; Firefox から org-capture を動かすのに必要
+(require 'server)
+(unless (server-running-p)
+  (server-start))


### PR DESCRIPTION
Firefox から org-capture するのに server が必要だけど
いつも手で起動していた。

いい加減それがだるくなってきたので自動起動するようにした