### PR TITLE
対象のカレンダーを選んで org-gcal を開く関数で ivy を使うようにした

### DIFF
--- a/inits/68-my-org-commands.el
+++ b/inits/68-my-org-commands.el
@@ -25,3 +25,14 @@ org-todo-keywords-for-agenda ではなく
 (defun my/org-tags-view-only-todo ()
   (interactive)
   (org-tags-view t))
+
+(defun my/open-calendar ()
+  (interactive)
+  (ivy-read "Calendar: "
+            my/calendar-targets
+            :require-match t
+            :sort nil
+            :action (lambda (target)
+                      (progn
+                        (setq cfw:org-icalendars `(,(concat org-directory target ".org")))
+                        (cfw:open-org-calendar)))))

--- a/inits/69-org-mode-hydra.el
+++ b/inits/69-org-mode-hydra.el
@@ -60,7 +60,7 @@
 
      "Calendar"
      (("F" org-gcal-fetch "Fetch Calendar")
-      ("C" my/open-user-calendar "Calendar"))
+      ("C" my/open-calendar "Calendar"))
 
      "Clock"
      (("i" org-clock-in       "In")


### PR DESCRIPTION
元々は helm で書いていたのを移植した。
また、Git で管理していなかった関数を管理できるようにした

変数だけは秘匿情報として分離している