### PR TITLE
my/org-todo を修正

### DIFF
--- a/inits/68-my-org-commands.el
+++ b/inits/68-my-org-commands.el
@@ -16,7 +16,9 @@ org-todo-keywords-for-agenda ではなく
 "
   (interactive)
   (ivy-read "Org todo: "
-            org-todo-keywords-for-agenda
+            (mapcar (lambda (element)
+                      (replace-regexp-in-string "\(.+\)" "" element))
+                    (--remove (string= "|" it) (cdar org-todo-keywords)))
             :require-match t
             :sort nil
             :action (lambda (keyword)


### PR DESCRIPTION
org-todo-keywords-for-agenda を利用していたが
それが nil なことがよくあったので
org-todo-keywords からデータを加工して取得するように修正した