### PR TITLE
ivy を使った自作コマンドのテストを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,9 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          # XXX Emacs 26.1's make install doesn't install emacs-module.h
-          # - 26.1
           - 26.3
           - 27.1
+          - 27.2
 
     steps:
     - uses: purcell/setup-emacs@master

--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((flycheck-pos-tip :checksum "dc57beac0e59669926ad720c7af38b27c3a30467")
+      '((with-simulated-input :checksum "0f43fe46d4ab098c18a90b9df18cb96bab8e4a35")
+        (flycheck-pos-tip :checksum "dc57beac0e59669926ad720c7af38b27c3a30467")
         (pos-tip :checksum "179cc126b363f72ca12fab1e0dc462ce0ee79742")
         (emacs-neotree :checksum "5e1271655170f4cdc6849258e383c548a4e6e3d0")
         (company-lsp :checksum "f921ffa0cdc542c21dc3dd85f2c93df4288e83bd")

--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((with-simulated-input :checksum "0f43fe46d4ab098c18a90b9df18cb96bab8e4a35")
+      '((mocker\.el :checksum "5b01b3cc51388faf1ba823683c3600790099c84c")
+        (with-simulated-input :checksum "0f43fe46d4ab098c18a90b9df18cb96bab8e4a35")
         (flycheck-pos-tip :checksum "dc57beac0e59669926ad720c7af38b27c3a30467")
         (pos-tip :checksum "179cc126b363f72ca12fab1e0dc462ce0ee79742")
         (emacs-neotree :checksum "5e1271655170f4cdc6849258e383c548a4e6e3d0")

--- a/init-el-get.el
+++ b/init-el-get.el
@@ -1,0 +1,14 @@
+(add-to-list 'load-path "~/.emacs.d/el-get/el-get")
+
+(unless (require 'el-get nil 'noerror)
+  (with-current-buffer
+      (url-retrieve-synchronously
+       "https://raw.githubusercontent.com/dimitri/el-get/master/el-get-install.el")
+    (goto-char (point-max))
+    (eval-print-last-sexp)))
+
+(add-to-list 'el-get-recipe-path "~/.emacs.d/recipes")
+
+;; el-get のバージョンロック機構の導入
+(el-get-bundle tarao/el-get-lock)
+(el-get-lock)

--- a/init.el
+++ b/init.el
@@ -2,20 +2,7 @@
 			 ("melpa" . "https://melpa.org/packages/")))
 ;; (package-initialize)
 
-(add-to-list 'load-path "~/.emacs.d/el-get/el-get")
-
-(unless (require 'el-get nil 'noerror)
-  (with-current-buffer
-      (url-retrieve-synchronously
-       "https://raw.githubusercontent.com/dimitri/el-get/master/el-get-install.el")
-    (goto-char (point-max))
-    (eval-print-last-sexp)))
-
-(add-to-list 'el-get-recipe-path "~/.emacs.d/recipes")
-
-;; el-get のバージョンロック機構の導入
-(el-get-bundle tarao/el-get-lock)
-(el-get-lock)
+(load "~/.emacs.d/init-el-get.el")
 
 (el-get-bundle init-loader)
 (init-loader-load)

--- a/inits/99-mocker.el
+++ b/inits/99-mocker.el
@@ -1,0 +1,1 @@
+(el-get-bundle sigma/mocker.el)

--- a/inits/99-with-simulated-input.el
+++ b/inits/99-with-simulated-input.el
@@ -1,0 +1,1 @@
+(el-get-bundle DarwinAwardWinner/with-simulated-input)

--- a/inits/test/68-my-org-commands-test.el
+++ b/inits/test/68-my-org-commands-test.el
@@ -1,5 +1,6 @@
 (require 'ert)
 
+(load (expand-file-name (concat user-emacs-directory "/init-el-get.el")))
 (load (expand-file-name (concat user-emacs-directory "/inits/68-my-org-commands.el")))
 
 (ert-deftest test:my/org-todo-keyword-strings ()

--- a/inits/test/68-my-org-commands-test.el
+++ b/inits/test/68-my-org-commands-test.el
@@ -1,6 +1,12 @@
 (require 'ert)
 
+;; 外部ライブラリの設定
 (load (expand-file-name (concat user-emacs-directory "/init-el-get.el")))
+(load (expand-file-name (concat user-emacs-directory "/inits/99-with-simulated-input")))
+
+(el-get-bundle abo-abo/swiper)
+
+;; テスト対象の読み込み
 (load (expand-file-name (concat user-emacs-directory "/inits/68-my-org-commands.el")))
 
 (ert-deftest test:my/org-todo-keyword-strings ()
@@ -9,3 +15,13 @@
     (should (equal '("TODO" "DOING" "WAIT" "DONE" "SOMEDAY")
                    (my/org-todo-keyword-strings)))))
 
+(ert-deftest test:my/org-todo ()
+  "Test of `my/org-todo'."
+  (let ((org-todo-keywords '((sequence "TODO" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)")))
+        (result))
+    ;; org-mode を読まずに済むように org-todo を差し替えてテストしている
+    (cl-letf (((symbol-function 'org-todo)
+               (lambda (keyword)
+                 (setq result keyword))))
+      (with-simulated-input "DOI RET" (my/org-todo))
+      (should (equal "DOING" result)))))

--- a/inits/test/68-my-org-commands-test.el
+++ b/inits/test/68-my-org-commands-test.el
@@ -5,7 +5,7 @@
 
 (ert-deftest test:my/org-todo-keyword-strings ()
   "Test of `my/org-todo-keyword-strings'."
-  (setq org-todo-keywords
-        '((sequence "TODO" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)")))
-  (should (equal '("TODO" "DOING" "WAIT" "DONE" "SOMEDAY")
-                 (my/org-todo-keyword-strings))))
+  (let ((org-todo-keywords '((sequence "TODO" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)"))))
+    (should (equal '("TODO" "DOING" "WAIT" "DONE" "SOMEDAY")
+                   (my/org-todo-keyword-strings)))))
+


### PR DESCRIPTION
my/org-todo という、
ivy を使って org-mode の TODO キーワードを設定する関数のテストを追加した

org-mode 関係までテストするのはだるいので
内部で利用している org-todo は cl-letf を使って stub している