### PR TITLE
paredit と flex-autopair を smartparens に置き換えた

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((mocker\.el :checksum "5b01b3cc51388faf1ba823683c3600790099c84c")
+      '((smartparens :checksum "911cc896a0f2eb8b5fbdd6fc8331523ad9889a3a")
+        (mocker\.el :checksum "5b01b3cc51388faf1ba823683c3600790099c84c")
         (with-simulated-input :checksum "0f43fe46d4ab098c18a90b9df18cb96bab8e4a35")
         (flycheck-pos-tip :checksum "dc57beac0e59669926ad720c7af38b27c3a30467")
         (pos-tip :checksum "179cc126b363f72ca12fab1e0dc462ce0ee79742")

--- a/inits/20-smartparens.el
+++ b/inits/20-smartparens.el
@@ -1,1 +1,2 @@
 (el-get-bundle smartparens)
+(require 'smartparens-config)

--- a/inits/20-smartparens.el
+++ b/inits/20-smartparens.el
@@ -1,0 +1,1 @@
+(el-get-bundle smartparens)

--- a/inits/40-emacs-lisp.el
+++ b/inits/40-emacs-lisp.el
@@ -1,8 +1,6 @@
-(el-get-bundle paredit)
 (defun my/emacs-lisp-mode-hook ()
   (display-line-numbers-mode 1)
-  (company-mode 1)
-  (paredit-mode 1))
+  (company-mode 1))
 (add-hook 'emacs-lisp-mode-hook 'my/emacs-lisp-mode-hook)
 
 (defun my/insert-all-the-icons-code (family)

--- a/inits/40-emacs-lisp.el
+++ b/inits/40-emacs-lisp.el
@@ -2,7 +2,7 @@
   (display-line-numbers-mode 1)
   (company-mode 1)
   (smartparens-mode 1)
-  (turn-on-smartparens-strict-mode)))
+  (turn-on-smartparens-strict-mode))
 (add-hook 'emacs-lisp-mode-hook 'my/emacs-lisp-mode-hook)
 
 (defun my/insert-all-the-icons-code (family)

--- a/inits/40-emacs-lisp.el
+++ b/inits/40-emacs-lisp.el
@@ -1,6 +1,8 @@
 (defun my/emacs-lisp-mode-hook ()
   (display-line-numbers-mode 1)
-  (company-mode 1))
+  (company-mode 1)
+  (smartparens-mode 1)
+  (turn-on-smartparens-strict-mode)))
 (add-hook 'emacs-lisp-mode-hook 'my/emacs-lisp-mode-hook)
 
 (defun my/insert-all-the-icons-code (family)

--- a/inits/40-es6.el
+++ b/inits/40-es6.el
@@ -4,6 +4,7 @@
   (setq flycheck-disabled-checkers '(javascript-standard javascript-jshint))
 
   (company-mode 1)
+  (turn-on-smartparens-strict-mode)
 
   (setq js2-basic-offset 2))
 (add-to-list 'auto-mode-alist '("\\.es6$" . js2-mode))

--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -13,6 +13,7 @@
   (company-mode 1)
   (lsp)
   (lsp-ui-mode 1)
+  (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode 1))
 
 (add-hook 'enh-ruby-mode-hook 'my/enh-ruby-mode-hook)

--- a/inits/70-flex-autopair.el
+++ b/inits/70-flex-autopair.el
@@ -1,2 +1,0 @@
-(el-get-bundle flex-autopair)
-(flex-autopair-mode 1)

--- a/inits/90-mode-line.el
+++ b/inits/90-mode-line.el
@@ -36,7 +36,6 @@
 ;; minor-mode
 ;; (my/diminish "helm" 'helm-mode ":helmet-with-cross:")
 ;; (my/diminish "git-gutter" 'git-gutter-mode (all-the-icons-octicon "git-compare"))
-;; (my/diminish "paredit" 'paredit-mode "()")
 ;; (my/diminish "yasnippet" 'yas-minor-mode " Ys")
 ;; (my/diminish "whitespace" 'whitespace-mode "◽")
 ;; (my/diminish "whitespace" 'global-whitespace-mode "◽")


### PR DESCRIPTION
paredit と ddskk の skk-sticky が競合していて
Emacs Lisp を書いている時に日本語入力で sticky が効かなくてつらいことになっていた

そこで smartparens に置き換えることでその問題を解消した。

その際に flex-autopair と smartparens が同時に動いていると
カッコを入力した際に二重にコッカが挿入されるので
依存モードを減らすという意味で flex-autopair を削除した

あとついでに Ruby と JS でも strict にしてみた。
使って見て気に食わなければ off にするが、多分大丈夫だろう