### PR TITLE
user-emacs-directory 指定時に slash も付与した

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
 
     - name: Run tests
       run: |
-        emacs -Q --batch --eval "(setq user-emacs-directory \"$(pwd)\")" -l inits/test/*-test.el -l inits/test/run-tests.el
+        emacs -Q --batch --eval "(setq user-emacs-directory \"$(pwd)/\")" -l inits/test/*-test.el -l inits/test/run-tests.el


### PR DESCRIPTION
デフォの定義みたいに slash も入ってる方が扱いやすそうなので