### PR TITLE
ruby-end を削除した

### DIFF
--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -1,7 +1,6 @@
 (el-get-bundle rbenv)
 (global-rbenv-mode)
 (el-get-bundle enh-ruby-mode)
-(el-get-bundle ruby-end) ;; end の自動挿入とハイライト
 
 (with-eval-after-load 'enh-ruby-mode
   (setq enh-ruby-add-encoding-comment-on-save nil)


### PR DESCRIPTION
smartparens と競合するので
smartparens に任せることにした