### PR TITLE
昔はお世話になった open-junk-file とお別れした

### DIFF
--- a/init.org
+++ b/init.org
@@ -2332,14 +2332,6 @@
    (my/load-config "my-todoist-config")
    #+end_src
 
-** 60-open-junk-file.el                                              :unused:
-
-   #+begin_src emacs-lisp :tangle inits/60-open-junk-file.el
-   (el-get-bundle open-junk-file)
-   (setq open-junk-file-format "~/junk/%Y-%m-%d-%H%M%S.")
-   (global-set-key (kbd "C-o") 'open-junk-file)
-   #+end_src
-
 ** 60-org.el
 
    #+begin_src emacs-lisp :tangle inits/60-org.el

--- a/inits/60-open-junk-file.el
+++ b/inits/60-open-junk-file.el
@@ -1,3 +1,0 @@
-(el-get-bundle open-junk-file)
-(setq open-junk-file-format "~/junk/%Y-%m-%d-%H%M%S.")
-(global-set-key (kbd "C-o") 'open-junk-file)


### PR DESCRIPTION
open-junk-file の代わりに今では org-capture を使っているため
open-junk-file は用済みになった