### PR TITLE
key-chord で sticky-shift するようにした

### DIFF
--- a/hugo/content/keybinds/key-chord.md
+++ b/hugo/content/keybinds/key-chord.md
@@ -74,10 +74,15 @@ magit のコマンドとして成立しない。
 そこでセミコロンを2回叩くことで shift が押されてるという状態を実現する。
 
 ```emacs-lisp
+(key-chord-define-global ";;"
+                         'event-apply-shift-modifier)
+
 (key-chord-define key-translation-map
                   ";;"
                   'event-apply-shift-modifier)
 ```
+
+`global-key-map` と `key-translation-map` の両方に定義しないと動かないがその原因はよく分かってない。一旦動くから良しとしている。
 
 ここで使っている `event-apply-shift-modifier` はデフォルトでは `C-x @ S` にバインドされているやつ。お仲間に `event-apply-control-modifier` などの各 modifier キーがいるので
 sticky 的なことをやる上で便利な子達。

--- a/hugo/content/keybinds/key-chord.md
+++ b/hugo/content/keybinds/key-chord.md
@@ -26,7 +26,7 @@ draft = false
 同時押し時の許容時間、その前後で別のキーが押されていたら発動しない判断をする、みたいな設定を入れている。
 
 ```emacs-lisp
-(setq key-chord-two-keys-delay           0.15
+(setq key-chord-two-keys-delay           0.25
       key-chord-safety-interval-backward 0.1
       key-chord-safety-interval-forward  0.15)
 ```

--- a/hugo/content/keybinds/key-chord.md
+++ b/hugo/content/keybinds/key-chord.md
@@ -49,6 +49,55 @@ draft = false
 といいつつ現状では Hydra 起動のやつしか使ってないので、グローバルキーバインド設定でしか書いてない。
 
 
+## sticky-shift {#sticky-shift}
+
+
+### セミコロン+アルファベット入力で大文字とする {#セミコロン-plus-アルファベット入力で大文字とする}
+
+セミコロンとアルファベットをほぼ同時に叩くことにより対応する大文字を出力できるようにしている。
+
+これで PascalCase を入力しないといけない時でもシフトキーを叩かずに済む。少し慣れは必要だけども。
+
+```emacs-lisp
+(mapc (lambda (key)
+        (key-chord-define-global (concat ";" (char-to-string key)) (char-to-string (- key 32))))
+      (number-sequence ?a ?z))
+```
+
+
+### セミコロン2つでシフトを押した状態にする {#セミコロン2つでシフトを押した状態にする}
+
+上に書いたやつだけだと設定が足りなくて何故かというと、
+magit を使う時なんかは結構 P とかで push したりするけども上記の設定だと `;p` を入力しても、あくまで文字の出力が変わるだけになってしまうため
+magit のコマンドとして成立しない。
+
+そこでセミコロンを2回叩くことで shift が押されてるという状態を実現する。
+
+```emacs-lisp
+(key-chord-define key-translation-map
+                  ";;"
+                  'event-apply-shift-modifier)
+```
+
+ここで使っている `event-apply-shift-modifier` はデフォルトでは `C-x @ S` にバインドされているやつ。お仲間に `event-apply-control-modifier` などの各 modifier キーがいるので
+sticky 的なことをやる上で便利な子達。
+[sticky-control]({{< relref "sticky-control" >}}) の中でも `event-apply-control-modifier` が使われているぞい。
+
+
+### やりたかったけど実現できてないこと {#やりたかったけど実現できてないこと}
+
+
+#### セミコロン+アルファベット入力で大文字を入力したことにする {#セミコロン-plus-アルファベット入力で大文字を入力したことにする}
+
+今だとセミコロン+アルファベット入力ではその文字を出力することしかできてないので
+magit を操作する時はセミコロンを2回叩く必要があってだるいなって。
+
+
+#### セミコロン+数字キー、セミコロン+記号キーの対応 {#セミコロン-plus-数字キー-セミコロン-plus-記号キーの対応}
+
+[sticky.el](https://www.emacswiki.org/emacs/sticky.el) では実現されてそうなことなので、同じことをできるようにしたいのと「セミコロン2回 + 数字または記号キー」みたいな組み合わせも対応していきたい
+
+
 ## その他 {#その他}
 
 [sticky-control]({{< relref "sticky-control" >}}) も control 限定で似たようなことをしているので

--- a/init.org
+++ b/init.org
@@ -572,6 +572,49 @@
     といいつつ現状では Hydra 起動のやつしか使ってないので、
     グローバルキーバインド設定でしか書いてない。
 
+*** sticky-shift
+**** セミコロン+アルファベット入力で大文字とする
+     セミコロンとアルファベットをほぼ同時に叩くことにより
+     対応する大文字を出力できるようにしている。
+
+     これで PascalCase を入力しないといけない時でもシフトキーを叩かずに済む。
+     少し慣れは必要だけども。
+
+     #+begin_src emacs-lisp :tangle inits/70-key-chord.el
+     (mapc (lambda (key)
+             (key-chord-define-global (concat ";" (char-to-string key)) (char-to-string (- key 32))))
+           (number-sequence ?a ?z))
+     #+end_src
+
+**** セミコロン2つでシフトを押した状態にする
+     上に書いたやつだけだと設定が足りなくて
+     何故かというと、
+     magit を使う時なんかは結構 P とかで push したりするけども
+     上記の設定だと ~;p~ を入力しても、あくまで文字の出力が変わるだけになってしまうため
+     magit のコマンドとして成立しない。
+
+     そこでセミコロンを2回叩くことで shift が押されてるという状態を実現する。
+
+     #+begin_src emacs-lisp :tangle inits/70-key-chord.el
+     (key-chord-define key-translation-map
+                       ";;"
+                       'event-apply-shift-modifier)
+     #+end_src
+
+     ここで使っている ~event-apply-shift-modifier~ はデフォルトでは ~C-x @ S~ にバインドされているやつ。
+     お仲間に ~event-apply-control-modifier~ などの各 modifier キーがいるので
+     sticky 的なことをやる上で便利な子達。
+     [[*sticky-control][sticky-control]] の中でも ~event-apply-control-modifier~ が使われているぞい。
+
+**** やりたかったけど実現できてないこと
+***** セミコロン+アルファベット入力で大文字を入力したことにする
+      今だとセミコロン+アルファベット入力ではその文字を出力することしかできてないので
+      magit を操作する時はセミコロンを2回叩く必要があってだるいなって。
+***** セミコロン+数字キー、セミコロン+記号キーの対応
+      [[https://www.emacswiki.org/emacs/sticky.el][sticky.el]] では実現されてそうなことなので、
+      同じことをできるようにしたいのと
+      「セミコロン2回 + 数字または記号キー」みたいな組み合わせも対応していきたい
+
 *** その他
 
     [[*sticky-control][sticky-control]] も control 限定で似たようなことをしているので
@@ -4947,11 +4990,6 @@
 
    ;; with keychord
    (key-chord-define-global "jk" 'pretty-hydra-usefull-commands/body)
-
-   ;; `;` とアルファベット小文字をほぼ同時に入力すると大文字入力扱いにする
-   (mapc (lambda (key)
-           (key-chord-define-global (concat ";" (char-to-string key)) (char-to-string (- key 32))))
-         (number-sequence ?a ?z))
 
    ;; Don't ask yes or no.
    (defalias 'yes-or-no-p 'y-or-n-p)

--- a/init.org
+++ b/init.org
@@ -545,7 +545,7 @@
     同時押し時の許容時間、その前後で別のキーが押されていたら発動しない判断をする、みたいな設定を入れている。
 
     #+begin_src emacs-lisp :tangle inits/70-key-chord.el
-    (setq key-chord-two-keys-delay           0.15
+    (setq key-chord-two-keys-delay           0.25
           key-chord-safety-interval-backward 0.1
           key-chord-safety-interval-forward  0.15)
     #+end_src

--- a/init.org
+++ b/init.org
@@ -4948,6 +4948,11 @@
    ;; with keychord
    (key-chord-define-global "jk" 'pretty-hydra-usefull-commands/body)
 
+   ;; `;` とアルファベット小文字をほぼ同時に入力すると大文字入力扱いにする
+   (mapc (lambda (key)
+           (key-chord-define-global (concat ";" (char-to-string key)) (char-to-string (- key 32))))
+         (number-sequence ?a ?z))
+
    ;; Don't ask yes or no.
    (defalias 'yes-or-no-p 'y-or-n-p)
    #+end_src

--- a/init.org
+++ b/init.org
@@ -596,10 +596,16 @@
      そこでセミコロンを2回叩くことで shift が押されてるという状態を実現する。
 
      #+begin_src emacs-lisp :tangle inits/70-key-chord.el
+     (key-chord-define-global ";;"
+                              'event-apply-shift-modifier)
+
      (key-chord-define key-translation-map
                        ";;"
                        'event-apply-shift-modifier)
      #+end_src
+
+     ~global-key-map~ と ~key-translation-map~ の両方に定義しないと動かないが
+     その原因はよく分かってない。一旦動くから良しとしている。
 
      ここで使っている ~event-apply-shift-modifier~ はデフォルトでは ~C-x @ S~ にバインドされているやつ。
      お仲間に ~event-apply-control-modifier~ などの各 modifier キーがいるので

--- a/inits/70-key-chord.el
+++ b/inits/70-key-chord.el
@@ -5,3 +5,11 @@
       key-chord-safety-interval-forward  0.15)
 
 (key-chord-mode 1)
+
+(mapc (lambda (key)
+        (key-chord-define-global (concat ";" (char-to-string key)) (char-to-string (- key 32))))
+      (number-sequence ?a ?z))
+
+(key-chord-define key-translation-map
+                  ";;"
+                  'event-apply-shift-modifier)

--- a/inits/70-key-chord.el
+++ b/inits/70-key-chord.el
@@ -1,6 +1,6 @@
 (el-get-bundle zk-phi/key-chord)
 
-(setq key-chord-two-keys-delay           0.15
+(setq key-chord-two-keys-delay           0.25
       key-chord-safety-interval-backward 0.1
       key-chord-safety-interval-forward  0.15)
 

--- a/inits/70-key-chord.el
+++ b/inits/70-key-chord.el
@@ -10,6 +10,9 @@
         (key-chord-define-global (concat ";" (char-to-string key)) (char-to-string (- key 32))))
       (number-sequence ?a ?z))
 
+(key-chord-define-global ";;"
+                         'event-apply-shift-modifier)
+
 (key-chord-define key-translation-map
                   ";;"
                   'event-apply-shift-modifier)

--- a/inits/80-global-keybinds.el
+++ b/inits/80-global-keybinds.el
@@ -66,10 +66,5 @@
 ;; with keychord
 (key-chord-define-global "jk" 'pretty-hydra-usefull-commands/body)
 
-;; `;` とアルファベット小文字をほぼ同時に入力すると大文字入力扱いにする
-(mapc (lambda (key)
-        (key-chord-define-global (concat ";" (char-to-string key)) (char-to-string (- key 32))))
-      (number-sequence ?a ?z))
-
 ;; Don't ask yes or no.
 (defalias 'yes-or-no-p 'y-or-n-p)

--- a/inits/80-global-keybinds.el
+++ b/inits/80-global-keybinds.el
@@ -66,5 +66,10 @@
 ;; with keychord
 (key-chord-define-global "jk" 'pretty-hydra-usefull-commands/body)
 
+;; `;` とアルファベット小文字をほぼ同時に入力すると大文字入力扱いにする
+(mapc (lambda (key)
+        (key-chord-define-global (concat ";" (char-to-string key)) (char-to-string (- key 32))))
+      (number-sequence ?a ?z))
+
 ;; Don't ask yes or no.
 (defalias 'yes-or-no-p 'y-or-n-p)


### PR DESCRIPTION
`;` とアルファベットの小文字をほぼ同時に入力すると
その文字の大文字が表示されるように設定した。

また `;;` と入力するとシフトキーが押された状態になるようにもした。
これでシフトキーを押さなくても良くなるパターンが増えたので左手小指を今までよりも守れるかもしれない