### PR TITLE
表示調整用に pretty-hydra の関数上書きについて記述

### DIFF
--- a/hugo/content/ui/hydra.md
+++ b/hugo/content/ui/hydra.md
@@ -60,6 +60,30 @@ js2-mode 用の Hydra などを定義できて便利。
 ```
 
 
+### pretty-hydra の関数上書き {#pretty-hydra-の関数上書き}
+
+Hydra の表示には hydra-posframe を使っているが
+hydra-posframe は最初に空行があると最後の行を表示しないようなので一時的に pretty-hydra--maybe-add-title を上書きして使ってみている。
+
+```emacs-lisp
+(with-eval-after-load 'pretty-hydra
+  (defun pretty-hydra--maybe-add-title (title docstring)
+  "Add TITLE to the DOCSTRING if it's not nil, other return DOCSTRING unchanged."
+  (if (null title)
+      docstring
+    (format "%s\n%s"
+            (cond
+             ((char-or-string-p title) title)
+             ((symbolp title)          (format "%%s`%s" title))
+             ((listp title)            (format "%%s%s" (prin1-to-string title)))
+             (t                        ""))
+            docstring))))
+```
+
+今のところ快適に使えているが
+posframe か hydra-posframe か pretty-hydra のどれかの修正で実はもう不要になっている可能性もある。
+
+
 ## キーバインド {#キーバインド}
 
 Hydra でいくつかのキーバインドを設定していて他の機能に属さないものはここでまとめてキーバインドを定義している。

--- a/init.org
+++ b/init.org
@@ -1652,6 +1652,30 @@
      (el-get-bundle jerrypnz/major-mode-hydra.el)
      #+end_src
 
+**** pretty-hydra の関数上書き
+     Hydra の表示には hydra-posframe を使っているが
+     hydra-posframe は最初に空行があると最後の行を表示しないようなので
+     一時的に pretty-hydra--maybe-add-title を上書きして使ってみている。
+
+     #+begin_src emacs-lisp :tangle inits/01-override.el
+     (with-eval-after-load 'pretty-hydra
+       (defun pretty-hydra--maybe-add-title (title docstring)
+       "Add TITLE to the DOCSTRING if it's not nil, other return DOCSTRING unchanged."
+       (if (null title)
+           docstring
+         (format "%s\n%s"
+                 (cond
+                  ((char-or-string-p title) title)
+                  ((symbolp title)          (format "%%s`%s" title))
+                  ((listp title)            (format "%%s%s" (prin1-to-string title)))
+                  (t                        ""))
+                 docstring))))
+     #+end_src
+
+     今のところ快適に使えているが
+     posframe か hydra-posframe か pretty-hydra のどれかの修正で実はもう不要になっている可能性もある。
+
+
 *** キーバインド
     Hydra でいくつかのキーバインドを設定していて
     他の機能に属さないものはここでまとめてキーバインドを定義している。
@@ -5253,25 +5277,6 @@
 
   ここにはとりあえず inits 以下に出力できるようにしただけの記述を連ねていきます。
   あとで移動する。
-
-** override
-
-   #+begin_src emacs-lisp :tangle inits/01-override.el
-   ;; posframe が最初に空行があると最後の行を表示しないため
-   ;; 一時的にこちらを直してみている
-   (with-eval-after-load 'pretty-hydra
-     (defun pretty-hydra--maybe-add-title (title docstring)
-     "Add TITLE to the DOCSTRING if it's not nil, other return DOCSTRING unchanged."
-     (if (null title)
-         docstring
-       (format "%s\n%s"
-               (cond
-                ((char-or-string-p title) title)
-                ((symbolp title)          (format "%%s`%s" title))
-                ((listp title)            (format "%%s%s" (prin1-to-string title)))
-                (t                        ""))
-               docstring))))
-   #+end_src
 
 ** migemo
 


### PR DESCRIPTION
とりあえず手元で pretty-hydra を快適に使いたかったので上書きしている
pretty-hydra 本体に PR は出してない。

もしかしたら pretty-hydra か posframe か hydra-posframe の更新で解決されてるかもしれない。

とりあえず自分のところの問題解決を優先していたので、最小の再現環境も特に調べてない