### PR TITLE
org-gcal フォルダの無視リスト指定が雑だったので修正した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ url
 emojis
 secret
 skk-jisyo
-org-gcal
+/org-gcal
 .cache
 transient
 .trello

--- a/hugo/content/org-mode/org-gcal.md
+++ b/hugo/content/org-mode/org-gcal.md
@@ -18,7 +18,7 @@ el-get のレシピもそっちを見ている。
 org-gcal が依存しているので [parsist](https://elpa.gnu.org/packages/persist.html) を入れている。
 
 ```emacs-lisp
-(el-get-bundle persist) ;; org-gcal に必要
+(el-get-bundle persist)
 ```
 
 あとは当然 org-gcal 本体を入れないと動かない

--- a/init.org
+++ b/init.org
@@ -5324,7 +5324,7 @@
     org-gcal が依存しているので [[https://elpa.gnu.org/packages/persist.html][parsist]] を入れている。
 
     #+begin_src emacs-lisp :tangle inits/61-org-gcal.el
-    (el-get-bundle persist) ;; org-gcal に必要
+    (el-get-bundle persist)
     #+end_src
 
     あとは当然 org-gcal 本体を入れないと動かない


### PR DESCRIPTION
多分 org-gcal を無視リストに入れているせいで
自動生成・コミットがうまくいってなかったのだと思う。

というわけで自動生成もされるように
org-gcal のファイルに変更を加えている。
コメントを省いただけだけど。