### PR TITLE
view-mode の設定について記述した

### DIFF
--- a/hugo/content/editing/_index.md
+++ b/hugo/content/editing/_index.md
@@ -26,6 +26,9 @@ disableToc = true
 [undo-fu]({{< relref "undo-fu" >}})
 : シンプルな undo/redo の機能を提供してくれるやつ
 
+[view-mode]({{< relref "view-mode" >}})
+: Emacs に組込まれてる閲覧専用のモード。コードリーディングの時に有効にすると便利
+
 [whitespace]({{< relref "whitespace" >}})
 : 空白文字を可視化したり自動的に消したりする便利なやつ
 

--- a/hugo/content/editing/view-mode.md
+++ b/hugo/content/editing/view-mode.md
@@ -1,0 +1,84 @@
++++
+title = "view-mode"
+draft = false
++++
+
+## 概要 {#概要}
+
+[view-mode](https://www.emacswiki.org/emacs/ViewMode) は Emacs に標準で組込まれているモードで、バッファを閲覧専用にする機能を提供してくれるやつ。コードを眺めたい時などに使っている。
+
+
+## キーバインド {#キーバインド}
+
+view-mode の時は文字入力をする必要がないので通常のモードの時とは違うキーバインドが使えるようにしている。
+
+```emacs-lisp
+(defun my/setup-view-mode-keymap ()
+    (let ((keymap view-mode-map))
+      (define-key keymap (kbd "h") 'backward-char)
+      (define-key keymap (kbd "j") 'next-line)
+      (define-key keymap (kbd "k") 'previous-line)
+      (define-key keymap (kbd "l") 'forward-char)
+
+      (define-key keymap (kbd "e") 'forward-word)
+
+      (define-key keymap (kbd "b")   'scroll-down)
+      (define-key keymap (kbd "SPC") 'scroll-up)
+
+      (define-key keymap (kbd "g") 'beginning-of-buffer)
+      (define-key keymap (kbd "G") 'end-of-buffer)
+      (define-key keymap (kbd "<") 'beginning-of-buffer)
+      (define-key keymap (kbd ">") 'end-of-buffer)))
+```
+
+| Key  | 効果       |
+|------|----------|
+| h    | 1文字戻る  |
+| j    | 1行下がる  |
+| k    | 1行上がる  |
+| l    | 1文字進む  |
+| e    | 単語の直後に移動 |
+| b    | 1スクロール戻る |
+| SPC  | 1スクロール進む |
+| g, < | バッファの先頭に移動 |
+| G, > | バッファの末尾に移動 |
+
+適当だけど Vim の通常モードの時みたいな操作ができるようにしている。
+
+これで不要に左手小指を痛める可能性が下がるであろう。
+
+
+## hook {#hook}
+
+上でキーバインドを設定できる関数を用意してあるので
+view-mode が有効になる時にそれを hook して設定されるようにしている。
+
+が、 hook する必要あるのか疑問ではあるな。ま、動いているからとりあえずいいけど。
+
+```emacs-lisp
+(defun my/view-mode-hook ()
+  (my/setup-view-mode-keymap))
+
+(add-hook 'view-mode-hook 'my/view-mode-hook)
+```
+
+
+## Toggle するコマンド {#toggle-するコマンド}
+
+view-mode にしたり戻したりするコマンドを用意している。
+
+view-mode を有効にする時には hl-line-mode も有効にしているのでその時眺めている行がハイライトされるようになっている。普段はそれがあるかどうかでどっちもモードかざっくり判断している。
+
+他にも mode-line の色を変更するなどの技があるようだがひとまず今の設定でそう困ってないのでいいかな。
+
+```emacs-lisp
+(defun my/toggle-view-mode ()
+  "view-mode と通常モードの切り替えコマンド"
+  (interactive)
+  (cond (view-mode
+         (hl-line-mode -1)
+         (view-mode -1))
+        (t
+         (hl-line-mode 1)
+         (view-mode 1))))
+```

--- a/init.org
+++ b/init.org
@@ -1409,66 +1409,6 @@
     各言語の hook で ~smartparens-strict-mode~ を有効にしている。
     なんか常に有効だと困りそうな気がしたので。
 
-** yasnippet
-   :PROPERTIES:
-   :EXPORT_FILE_NAME: yasnippet
-   :END:
-
-*** 概要
-    [[https://github.com/joaotavora/yasnippet][yasnippet]] はテンプレートを挿入する機能を持ったパッケージ。
-    Emacs でそこそこ何かを書いている人なら大体知ってるような有名なやつだと思う。
-
-*** インストール
-    いつも通り el-get でインストール
-
-    #+begin_src emacs-lisp :tangle inits/20-yasnippet.el
-    (el-get-bundle yasnippet)
-    #+end_src
-*** 有効化
-    どこでも使いたいぐらい便利なやつなので global に有効化している
-
-    #+begin_src emacs-lisp :tangle inits/20-yasnippet.el
-    (yas-global-mode 1)
-    #+end_src
-
-*** キーバインド
-    基本的に覚えられないので Hydra を使って定義している
-
-    #+begin_src emacs-lisp :tangle inits/20-yasnippet.el
-    (with-eval-after-load 'pretty-hydra
-      (pretty-hydra-define
-        yasnippet-hydra (:separator "-" :title "Yasnippet" :foreign-key warn :quit-key "q" :exit t)
-        ("Edit"
-         (("n" yas-new-snippet        "New")
-          ("v" yas-visit-snippet-file "Visit"))
-
-         "Other"
-         (("i" yas-insert-snippet  "Insert")
-          ("l" yas-describe-tables "List")
-          ("r" yas-reload-all      "Reload all")))))
-    #+end_src
-
-    | Key | 効果                                                |
-    | n   | 現在のメジャーモード用に新しい snippet を作る       |
-    | v   | 現在のメジャーモードの登録済 snippet ファイルを開く |
-    | i   | snippet の挿入。選択は ivy で行われる。             |
-    | l   | 現在のメジャーモードの登録済 snippet の一覧表示     |
-    | r   | snippet を全部 load し直す                          |
-
-*** その他
-    実は、どういう snippet があれば便利なのかよくわかってなくて
-    snippet をほとんど登録してない。
-
-    [[https://github.com/AndreaCrotti/yasnippet-snippets][yasnippet-snippets]] などのよくある snippet 集は、
-    そんなの省略形をまず覚えられないだろと思っている。
-    ivy で選択可能なので省略形は長くていいので中身がわかりやすい方が良い。
-
-    また導入はしてないが [[https://github.com/mkcms/ivy-yasnippet][ivy-yasnippet]] を入れるとさらにそのあたりがやりやすくなるんじゃないかと思う。
-
-    それから company-yasnippet で補完できるようにしているとより良いかもれない。
-
-    とはいえ snippet を充実させてない今だとどうにもイマイチそのあたりを充実させる気力がない
-
 ** undo-fu
    :PROPERTIES:
    :EXPORT_FILE_NAME: undo-fu
@@ -1597,6 +1537,65 @@
     (global-whitespace-mode 1)
     #+end_src
 
+** yasnippet
+   :PROPERTIES:
+   :EXPORT_FILE_NAME: yasnippet
+   :END:
+
+*** 概要
+    [[https://github.com/joaotavora/yasnippet][yasnippet]] はテンプレートを挿入する機能を持ったパッケージ。
+    Emacs でそこそこ何かを書いている人なら大体知ってるような有名なやつだと思う。
+
+*** インストール
+    いつも通り el-get でインストール
+
+    #+begin_src emacs-lisp :tangle inits/20-yasnippet.el
+    (el-get-bundle yasnippet)
+    #+end_src
+*** 有効化
+    どこでも使いたいぐらい便利なやつなので global に有効化している
+
+    #+begin_src emacs-lisp :tangle inits/20-yasnippet.el
+    (yas-global-mode 1)
+    #+end_src
+
+*** キーバインド
+    基本的に覚えられないので Hydra を使って定義している
+
+    #+begin_src emacs-lisp :tangle inits/20-yasnippet.el
+    (with-eval-after-load 'pretty-hydra
+      (pretty-hydra-define
+        yasnippet-hydra (:separator "-" :title "Yasnippet" :foreign-key warn :quit-key "q" :exit t)
+        ("Edit"
+         (("n" yas-new-snippet        "New")
+          ("v" yas-visit-snippet-file "Visit"))
+
+         "Other"
+         (("i" yas-insert-snippet  "Insert")
+          ("l" yas-describe-tables "List")
+          ("r" yas-reload-all      "Reload all")))))
+    #+end_src
+
+    | Key | 効果                                                |
+    | n   | 現在のメジャーモード用に新しい snippet を作る       |
+    | v   | 現在のメジャーモードの登録済 snippet ファイルを開く |
+    | i   | snippet の挿入。選択は ivy で行われる。             |
+    | l   | 現在のメジャーモードの登録済 snippet の一覧表示     |
+    | r   | snippet を全部 load し直す                          |
+
+*** その他
+    実は、どういう snippet があれば便利なのかよくわかってなくて
+    snippet をほとんど登録してない。
+
+    [[https://github.com/AndreaCrotti/yasnippet-snippets][yasnippet-snippets]] などのよくある snippet 集は、
+    そんなの省略形をまず覚えられないだろと思っている。
+    ivy で選択可能なので省略形は長くていいので中身がわかりやすい方が良い。
+
+    また導入はしてないが [[https://github.com/mkcms/ivy-yasnippet][ivy-yasnippet]] を入れるとさらにそのあたりがやりやすくなるんじゃないかと思う。
+
+    それから company-yasnippet で補完できるようにしているとより良いかもれない。
+
+    とはいえ snippet を充実させてない今だとどうにもイマイチそのあたりを充実させる気力がない
 * UI
   :PROPERTIES:
   :EXPORT_HUGO_SECTION: ui

--- a/init.org
+++ b/init.org
@@ -1232,6 +1232,7 @@
    - [[*multiple-cursors][multiple-cursors]] :: カーソルを増やして複数箇所を同時に編集できるようになるやつ
    - [[*smartparens][smartparens]] :: カッコや引用符などのペアになるやつの入力補助をしてくれるやつ
    - [[*undo-fu][undo-fu]] :: シンプルな undo/redo の機能を提供してくれるやつ
+   - [[*view-mode][view-mode]] :: Emacs に組込まれてる閲覧専用のモード。コードリーディングの時に有効にすると便利
    - [[*whitespace][whitespace]] :: 空白文字を可視化したり自動的に消したりする便利なやつ
    - [[*yasnippet][yasnippet]] :: テンプレート挿入機能を提供してくれるやつ
 

--- a/init.org
+++ b/init.org
@@ -1433,6 +1433,89 @@
     | C-/   | undo |
     | C-M-/ | redo |
 
+** view-mode
+   :PROPERTIES:
+   :EXPORT_FILE_NAME: view-mode
+   :END:
+*** 概要
+    [[https://www.emacswiki.org/emacs/ViewMode][view-mode]] は Emacs に標準で組込まれているモードで、バッファを閲覧専用にする機能を提供してくれるやつ。
+    コードを眺めたい時などに使っている。
+
+*** キーバインド
+    view-mode の時は文字入力をする必要がないので
+    通常のモードの時とは違うキーバインドが使えるようにしている。
+
+    #+begin_src emacs-lisp :tangle inits/40-view.el
+    (defun my/setup-view-mode-keymap ()
+        (let ((keymap view-mode-map))
+          (define-key keymap (kbd "h") 'backward-char)
+          (define-key keymap (kbd "j") 'next-line)
+          (define-key keymap (kbd "k") 'previous-line)
+          (define-key keymap (kbd "l") 'forward-char)
+
+          (define-key keymap (kbd "e") 'forward-word)
+
+          (define-key keymap (kbd "b")   'scroll-down)
+          (define-key keymap (kbd "SPC") 'scroll-up)
+
+          (define-key keymap (kbd "g") 'beginning-of-buffer)
+          (define-key keymap (kbd "G") 'end-of-buffer)
+          (define-key keymap (kbd "<") 'beginning-of-buffer)
+          (define-key keymap (kbd ">") 'end-of-buffer)))
+    #+end_src
+
+    |------+----------------------|
+    | Key  | 効果                 |
+    |------+----------------------|
+    | h    | 1文字戻る            |
+    | j    | 1行下がる            |
+    | k    | 1行上がる            |
+    | l    | 1文字進む            |
+    | e    | 単語の直後に移動     |
+    | b    | 1スクロール戻る      |
+    | SPC  | 1スクロール進む      |
+    | g, < | バッファの先頭に移動 |
+    | G, > | バッファの末尾に移動 |
+    |------+----------------------|
+
+    適当だけど Vim の通常モードの時みたいな操作ができるようにしている。
+
+    これで不要に左手小指を痛める可能性が下がるであろう。
+
+*** hook
+    上でキーバインドを設定できる関数を用意してあるので
+    view-mode が有効になる時にそれを hook して設定されるようにしている。
+
+    が、 hook する必要あるのか疑問ではあるな。ま、動いているからとりあえずいいけど。
+
+    #+begin_src emacs-lisp :tangle inits/40-view.el
+    (defun my/view-mode-hook ()
+      (my/setup-view-mode-keymap))
+
+    (add-hook 'view-mode-hook 'my/view-mode-hook)
+    #+end_src
+*** Toggle するコマンド
+    view-mode にしたり戻したりするコマンドを用意している。
+
+    view-mode を有効にする時には hl-line-mode も有効にしているので
+    その時眺めている行がハイライトされるようになっている。
+    普段はそれがあるかどうかでどっちもモードかざっくり判断している。
+
+    他にも mode-line の色を変更するなどの技があるようだが
+    ひとまず今の設定でそう困ってないのでいいかな。
+
+    #+begin_src emacs-lisp :tangle inits/40-view.el
+    (defun my/toggle-view-mode ()
+      "view-mode と通常モードの切り替えコマンド"
+      (interactive)
+      (cond (view-mode
+             (hl-line-mode -1)
+             (view-mode -1))
+            (t
+             (hl-line-mode 1)
+             (view-mode 1))))
+    #+end_src
+
 ** whitespace
    :PROPERTIES:
    :EXPORT_FILE_NAME: whitespace
@@ -6289,46 +6372,6 @@
    (el-get-bundle lsp-ui)
    (add-hook 'lsp-mode-hook 'lsp-ui-mode)
    (setq lsp-ui-doc-alignment 'window)
-   #+end_src
-
-** 40-view.el
-
-   #+begin_src emacs-lisp :tangle inits/40-view.el
-   ;; view-mode 用の設定
-
-   ;; (define-key projectile-rails-mode-map (kbd "C-c r") 'pretty-hydra-projectile-rails-find/body)
-
-   (defun my/setup-view-mode-keymap ()
-       (let ((keymap view-mode-map))
-         (define-key keymap (kbd "h") 'backward-char)
-         (define-key keymap (kbd "j") 'next-line)
-         (define-key keymap (kbd "k") 'previous-line)
-         (define-key keymap (kbd "l") 'forward-char)
-
-         (define-key keymap (kbd "e") 'forward-word)
-
-         (define-key keymap (kbd "b")   'scroll-down)
-         (define-key keymap (kbd "SPC") 'scroll-up)
-
-         (define-key keymap (kbd "g") 'beginning-of-buffer)
-         (define-key keymap (kbd "G") 'end-of-buffer)
-         (define-key keymap (kbd "<") 'beginning-of-buffer)
-         (define-key keymap (kbd ">") 'end-of-buffer)))
-
-   (defun my/view-mode-hook ()
-     (my/setup-view-mode-keymap))
-
-   (add-hook 'view-mode-hook 'my/view-mode-hook)
-
-   (defun my/toggle-view-mode ()
-     "view-mode と通常モードの切り替えコマンド"
-     (interactive)
-     (cond (view-mode
-            (hl-line-mode -1)
-            (view-mode -1))
-           (t
-            (hl-line-mode 1)
-            (view-mode 1))))
    #+end_src
 
 ** 70-my-commands.el


### PR DESCRIPTION
view-mode は Emacs に標準で組込まれているモードで
閲覧専用モードになるのでコードリーディングの時に便利。

さらに便利にするために
Vim っぽいキーバインドで使えるようにしていたりする。
これで小指の痛みから開放されるであろう……