### PR TITLE
React のために JSX/TSX の調整をした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ request
 .mc-lists.el
 .org-generic-id-locations
 .org-id-locations
+.dap-breakpoints
 bookmarks
 forge-database.sqlite
 ido.last

--- a/custom.el
+++ b/custom.el
@@ -59,7 +59,7 @@
    (expand-file-name "~/.emacs.d/el-get/plantuml-mode/plantuml.jar"))
  '(package-selected-packages
    (quote
-    (gcmh peg persist gnu-elpa-keyring-update oauth2 rainbow-mode xml-rpc)))
+    (tree-mode gcmh peg persist gnu-elpa-keyring-update oauth2 rainbow-mode xml-rpc)))
  '(projectile-mode-line-prefix "")
  '(pug-tab-width 2)
  '(recentf-auto-cleanup (quote never))

--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,11 @@
 (setq el-get-lock-package-versions
-      '((smartparens :checksum "911cc896a0f2eb8b5fbdd6fc8331523ad9889a3a")
+      '((web-mode :checksum "8ef47935d638902ba35a557cae5edd6ab6ab1346")
+        (dap-mode :checksum "8ec7e98986ea46e3c36b7ecbdf9a6562c90c7632")
+        (lsp-treemacs :checksum "905cc74726438cf06d8ad7cabb2efae75aeb2359")
+        (treemacs :checksum "e90abcdf86f289c0f4079a4c2ebb0152001fa408")
+        (pfuture :checksum "d7926de3ba0105a36cfd00811fd6278aea903eef")
+        (bui :checksum "f3a137628e112a91910fd33c0cff0948fa58d470")
+        (smartparens :checksum "911cc896a0f2eb8b5fbdd6fc8331523ad9889a3a")
         (mocker\.el :checksum "5b01b3cc51388faf1ba823683c3600790099c84c")
         (with-simulated-input :checksum "0f43fe46d4ab098c18a90b9df18cb96bab8e4a35")
         (flycheck-pos-tip :checksum "dc57beac0e59669926ad720c7af38b27c3a30467")

--- a/hugo/content/programming/_index.md
+++ b/hugo/content/programming/_index.md
@@ -36,6 +36,9 @@ markdown-mode とか yaml-mode なんかはプログラム言語ではないけ�
 [rails]({{< relref "rails" >}})
 : Rails 開発をする上での設定
 
+[React.js]({{< relref "react-js" >}})
+: React.js アプリを開発するための設定
+
 [rspec-mode]({{< relref "rspec-mode" >}})
 : Ruby のテストフレームワーク RSpec を書いたりするのに便利なモード
 

--- a/hugo/content/programming/react-js.md
+++ b/hugo/content/programming/react-js.md
@@ -1,0 +1,65 @@
++++
+title = "React.js"
+draft = false
++++
+
+## 概要 {#概要}
+
+React.js を書くための設定をここにまとめている
+
+
+## dap-mode {#dap-mode}
+
+Debug Adapter Protocol をサポートするモード。入れておいた方がきっとデバッグしやすいんだろうということで入れている。
+
+lsp-mode の仲間なので、本当はそっち側で入れるようにした方が良さそうだけどひとまず React のために入れているので React 用の設定ファイルに書いている。
+
+```emacs-lisp
+(el-get-bundle dap-mode)
+```
+
+同時に treemacs や lsp-treemacs も入ってくる罠がある。
+Neotree 使ってるからちょっとアレだなあ。いずれ乗り換えようとはしていたけども。
+
+
+## web-mode {#web-mode}
+
+とりあえず tsx を弄る上では web-mode が良いという話もあるので入れておく。
+
+```emacs-lisp
+(el-get-bundle web-mode)
+```
+
+
+## メジャーモードの紐付け {#メジャーモードの紐付け}
+
+jsx/tsx ファイルを開いた時には web-mode で動いてほしいので
+auto-mode-alist で関連付けをする
+
+```emacs-lisp
+(add-to-list 'auto-mode-alist '("\\.[jt]sx" . web-mode))
+```
+
+
+## lsp-mode などの有効化 {#lsp-mode-などの有効化}
+
+jsx/tsx ファイルを開く時に web-mode が有効になるようにしているのでその web-mode の hook で
+
+-   display-line-numbers-mode
+-   lsp
+-   lsp-ui-mode
+
+を有効にしている。
+
+```emacs-lisp
+(defun my/web-mode-tsx-hook ()
+  (let ((ext (file-name-extension buffer-file-name)))
+    (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
+      (setq web-mode-markup-indent-offset 2)
+      (setq web-mode-code-indent-offset 2)
+      (display-line-numbers-mode t)
+      (lsp)
+      (lsp-ui-mode 1))))
+
+(add-hook 'web-mode-hook 'my/web-mode-tsx-hook)
+```

--- a/init.org
+++ b/init.org
@@ -3558,6 +3558,7 @@
    - [[*markdown][markdown]] :: Markdown を書く時の設定
    - [[*plantuml-mode][plantuml-mode]] :: PlantUML を書く時のメジャーモードの設定
    - [[*rails][rails]] :: Rails 開発をする上での設定
+   - [[*React.js][React.js]] :: React.js アプリを開発するための設定
    - [[*rspec-mode][rspec-mode]] :: Ruby のテストフレームワーク RSpec を書いたりするのに便利なモード
    - [[*ruby][ruby]] :: Ruby を書く上での設定
    - [[*scss][scss]] :: SCSS を書く上での設定

--- a/init.org
+++ b/init.org
@@ -4069,6 +4069,61 @@
     | G   | Gemfile を開く                                     |                                                           |
     | D   | Schema.rb を開く                                   |                                                           |
 
+** React.js
+*** 概要
+    React.js を書くための設定をここにまとめている
+*** dap-mode
+    Debug Adapter Protocol をサポートするモード。
+    入れておいた方がきっとデバッグしやすいんだろうということで入れている。
+
+    lsp-mode の仲間なので、本当はそっち側で入れるようにした方が良さそうだけど
+    ひとまず React のために入れているので React 用の設定ファイルに書いている。
+    #+begin_src emacs-lisp :tangle inits/41-react.el
+    (el-get-bundle dap-mode)
+    #+end_src
+
+    同時に treemacs や lsp-treemacs も入ってくる罠がある。
+    Neotree 使ってるからちょっとアレだなあ。
+    いずれ乗り換えようとはしていたけども。
+
+*** web-mode
+    とりあえず tsx を弄る上では web-mode が良いという話もあるので入れておく。
+
+    #+begin_src emacs-lisp :tangle inits/41-react.el
+    (el-get-bundle web-mode)
+    #+end_src
+
+*** メジャーモードの紐付け
+    jsx/tsx ファイルを開いた時には web-mode で動いてほしいので
+    auto-mode-alist で関連付けをする
+
+    #+begin_src emacs-lisp :tangle inits/41-react.el
+    (add-to-list 'auto-mode-alist '("\\.[jt]sx" . web-mode))
+    #+end_src
+
+*** lsp-mode などの有効化
+    jsx/tsx ファイルを開く時に web-mode が有効になるようにしているので
+    その web-mode の hook で
+
+    - display-line-numbers-mode
+    - lsp
+    - lsp-ui-mode
+
+    を有効にしている。
+
+    #+begin_src emacs-lisp :tangle inits/41-react.el
+    (defun my/web-mode-tsx-hook ()
+      (let ((ext (file-name-extension buffer-file-name)))
+        (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
+          (setq web-mode-markup-indent-offset 2)
+          (setq web-mode-code-indent-offset 2)
+          (display-line-numbers-mode t)
+          (lsp)
+          (lsp-ui-mode 1))))
+
+    (add-hook 'web-mode-hook 'my/web-mode-tsx-hook)
+    #+end_src
+
 ** rspec-mode
    :PROPERTIES:
    :EXPORT_FILE_NAME: rspec-mode
@@ -4508,6 +4563,7 @@
     #+begin_src emacs-lisp :tangle inits/40-yaml.el
     (add-hook 'yaml-mode-hook 'my/yaml-mode-hook)
     #+end_src
+
 * 外部連携ツール設定
   :PROPERTIES:
   :EXPORT_HUGO_SECTION: external-tool

--- a/init.org
+++ b/init.org
@@ -4070,6 +4070,9 @@
     | D   | Schema.rb を開く                                   |                                                           |
 
 ** React.js
+   :PROPERTIES:
+   :EXPORT_FILE_NAME: react-js
+   :END:
 *** 概要
     React.js を書くための設定をここにまとめている
 *** dap-mode

--- a/inits/41-react.el
+++ b/inits/41-react.el
@@ -1,0 +1,16 @@
+(el-get-bundle dap-mode)
+
+(el-get-bundle web-mode)
+
+(add-to-list 'auto-mode-alist '("\\.[jt]sx" . web-mode))
+
+(defun my/web-mode-tsx-hook ()
+  (let ((ext (file-name-extension buffer-file-name)))
+    (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
+      (setq web-mode-markup-indent-offset 2)
+      (setq web-mode-code-indent-offset 2)
+      (display-line-numbers-mode t)
+      (lsp)
+      (lsp-ui-mode 1))))
+
+(add-hook 'web-mode-hook 'my/web-mode-tsx-hook)


### PR DESCRIPTION
ひとまず TSX ファイルが弄れるように調整している。
快適に開発するには全然足りないだろうけど、
とりあえず一旦動く状態で PR にする

## やったこと

- とりあえず JSX/TSX ファイルを開いた時にweb-mode が動くようにした
  - lsp-mode, lsp-ui, display-line-numbers-mode も同時に動くようにした
  - インデント周りの調整もした
- dap-mode もインストールだけはしておいた
  - どう活用できるかはよくわかってない

## 今後やりたいこと

- typescript-mode の導入
- lsp-mode 周りの調整
- dap-mode をいい感じに使えるようにする
- tide の導入検討