### PR TITLE
org-todo-keywords に EXAMINATION と READY を追加した

### DIFF
--- a/hugo/content/org-mode/base.md
+++ b/hugo/content/org-mode/base.md
@@ -59,7 +59,7 @@ org-mode といえば TODO 管理で使ってる人も多いと思う。自分�
 
 ```emacs-lisp
 (setq org-todo-keywords
-      '((sequence "TODO" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)")))
+      '((sequence "TODO" "EXAMINATION(e)" "READY(r)" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)")))
 ```
 
 初期状態は TODO で、作業開始時点で DOING にして待ちが発生したら WAIT にして完了したら DONE にしている。

--- a/init.org
+++ b/init.org
@@ -5096,7 +5096,7 @@
 
     #+begin_src emacs-lisp :tangle inits/60-org.el
     (setq org-todo-keywords
-          '((sequence "TODO" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)")))
+          '((sequence "TODO" "EXAMINATION(e)" "READY(r)" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)")))
     #+end_src
 
     初期状態は TODO で、作業開始時点で DOING にして

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -5,7 +5,7 @@
 (setq my/org-tasks-directory (concat org-directory "tasks/"))
 
 (setq org-todo-keywords
-      '((sequence "TODO" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)")))
+      '((sequence "TODO" "EXAMINATION(e)" "READY(r)" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)")))
 
 (setq org-log-done 'time)
 (setq org-log-into-drawer "LOGBOOK")


### PR DESCRIPTION
EXAMINATION は詳細を検討している時の状態。

Why, Goal, How が inbox の capture template に定義されているので
それらをキチンと埋めていく作業をしている最中という扱い。
それらの項目を埋めたら下の READY に移行できる。

READY は詳細検討が終わり、あとは How に従い手を動かすだけの状態。
Why, Goal, How がキチンと埋められている状態なので
作業ができる状態のタスクなのでとりあえず手を動かせるやつ。
TODO と別でこれを設けることで、
「着手しようと思ってたけど考えるところからじゃん」
ってのがなくなるはず、という見込みである