### PR TITLE
refile-target の projects 設定を Headline 変更に伴い変更

### DIFF
--- a/hugo/content/org-mode/org-refile.md
+++ b/hugo/content/org-mode/org-refile.md
@@ -39,7 +39,7 @@ nil だと移動先候補PATHの最後の部分しか表示されないのでど
 いくつかの org ファイルを使っているのでターゲットを以下のように設定している。
 
 ```emacs-lisp
-(setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 2)
+(setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 1)
                            (,(concat org-directory "tasks/pointers.org") :level . 1)
                            (,(concat org-directory "work/scrum/impediments.org") :level . 3)
                            (,(concat org-directory "tasks/next-actions.org") :regexp . "today")

--- a/init.org
+++ b/init.org
@@ -5893,7 +5893,7 @@
      ターゲットを以下のように設定している。
 
      #+begin_src emacs-lisp :tangle inits/61-org-refile.el
-     (setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 2)
+     (setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 1)
                                 (,(concat org-directory "tasks/pointers.org") :level . 1)
                                 (,(concat org-directory "work/scrum/impediments.org") :level . 3)
                                 (,(concat org-directory "tasks/next-actions.org") :regexp . "today")

--- a/inits/61-org-refile.el
+++ b/inits/61-org-refile.el
@@ -2,7 +2,7 @@
 
 (setq org-refile-use-outline-path 'file)
 
-(setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 2)
+(setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 1)
                            (,(concat org-directory "tasks/pointers.org") :level . 1)
                            (,(concat org-directory "work/scrum/impediments.org") :level . 3)
                            (,(concat org-directory "tasks/next-actions.org") :regexp . "today")


### PR DESCRIPTION
タスク管理などに使ってる org-mode のファイルで
不要に Headline が深くなっていることに気付いて
先日、1つ不要な Headline を取り除いておいた

それに伴い org-refile-target の設定も
変更せんとならないことに気付いたので
projects の target の深さを1つ浅くした