### PR TITLE
fork した el-get に依存先を切り替えたので不要なコードを削除した

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -140,7 +140,7 @@
         (counsel-osx-app :checksum "b1c54cbc033c4939966910d85ce035503079e108")
         (frame-cmds :checksum "3911fbe2b11b8494a14a4d99e989e7e07b243b69")
         (frame-fns :checksum "251f37fe805af7a8b3e0e5af9af76263f663a366")
-        (el-get :checksum "b5a5a405d04f61ec9c5fcb19357a50a4b9e36a25")
+        (el-get :checksum "fb613a5b6dd7f54022bb94fccdb7002c51cdb4cd")
         (dashboard :checksum "f7287f026103a44cf290fe737b6b9d841eddcaca")
         (page-break-lines :checksum "3b8549cd414d4d7ee0168ab9917124133566d3db")
         (org-trello :checksum "9c1c94dff1a46631669023286078b887d077c305")

--- a/inits/36-forge.el
+++ b/inits/36-forge.el
@@ -1,4 +1,3 @@
-(el-get-bundle yaml)
 (el-get-bundle forge)
 
 (with-eval-after-load 'magit

--- a/recipes/el-get.rcp
+++ b/recipes/el-get.rcp
@@ -1,0 +1,22 @@
+(:name el-get
+       :website "https://github.com/dimitri/el-get#readme"
+       :description "Manage the external elisp bits and pieces you depend upon."
+       :type github
+       :branch  "update-forge-recipe-and-add-yaml-recipe"
+       :pkgname "mugijiru/el-get"
+       :info    "."
+       :compile ("el-get.*\\.el$" "methods/")
+       :features el-get
+       :post-init (when (memq 'el-get (bound-and-true-p package-activated-list))
+                    (message "Deleting melpa bootstrap el-get")
+                    (unless package--initialized
+                      (package-initialize t))
+                    (when (package-installed-p 'el-get)
+                      (let ((feats (delete-dups
+                                    (el-get-package-features
+                                     (el-get-elpa-package-directory 'el-get)))))
+                        (el-get-elpa-delete-package 'el-get)
+                        ;; unload so we don't have any leftovers
+                        (dolist (feat feats)
+                          (unload-feature feat t))))
+                    (require 'el-get)))

--- a/recipes/yaml.rcp
+++ b/recipes/yaml.rcp
@@ -1,6 +1,0 @@
-(:name yaml
-:type github
-:description "yaml.el is a YAML parser written in Emacs List without any external dependencies."
-:pkgname "zkry/yaml.el"
-:minimum-emacs-version (25 1)
-)


### PR DESCRIPTION
forge の依存に yaml.el が追加されたので
一時的に自分の設定ファイル内に
yaml.el の recipe を追加して
明示的にインストールすることで動かない問題を解決していたが
el-get を fork してその中で解決するようにしたので
こちらの設定ファイルに加えた変更は元に戻しておいた