### PR TITLE
JSX/TSX で smartparens-mode が有効になるようにした

### DIFF
--- a/hugo/content/programming/react-js.md
+++ b/hugo/content/programming/react-js.md
@@ -57,6 +57,7 @@ jsx/tsx ファイルを開く時に web-mode が有効になるようにして�
     (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
       (setq web-mode-markup-indent-offset 2)
       (setq web-mode-code-indent-offset 2)
+      (turn-on-smartparens-strict-mode)
       (display-line-numbers-mode t)
       (lsp)
       (lsp-ui-mode 1))))

--- a/hugo/content/programming/react-js.md
+++ b/hugo/content/programming/react-js.md
@@ -57,7 +57,7 @@ jsx/tsx ファイルを開く時に web-mode が有効になるようにして�
     (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
       (setq web-mode-markup-indent-offset 2)
       (setq web-mode-code-indent-offset 2)
-      (turn-on-smartparens-strict-mode)
+      (turn-on-smartparens-mode)
       (display-line-numbers-mode t)
       (lsp)
       (lsp-ui-mode 1))))

--- a/init.org
+++ b/init.org
@@ -4121,6 +4121,7 @@
         (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
           (setq web-mode-markup-indent-offset 2)
           (setq web-mode-code-indent-offset 2)
+          (turn-on-smartparens-strict-mode)
           (display-line-numbers-mode t)
           (lsp)
           (lsp-ui-mode 1))))

--- a/init.org
+++ b/init.org
@@ -4121,7 +4121,7 @@
         (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
           (setq web-mode-markup-indent-offset 2)
           (setq web-mode-code-indent-offset 2)
-          (turn-on-smartparens-strict-mode)
+          (turn-on-smartparens-mode)
           (display-line-numbers-mode t)
           (lsp)
           (lsp-ui-mode 1))))

--- a/inits/41-react.el
+++ b/inits/41-react.el
@@ -9,7 +9,7 @@
     (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
       (setq web-mode-markup-indent-offset 2)
       (setq web-mode-code-indent-offset 2)
-      (turn-on-smartparens-strict-mode)
+      (turn-on-smartparens-mode)
       (display-line-numbers-mode t)
       (lsp)
       (lsp-ui-mode 1))))

--- a/inits/41-react.el
+++ b/inits/41-react.el
@@ -9,6 +9,7 @@
     (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
       (setq web-mode-markup-indent-offset 2)
       (setq web-mode-code-indent-offset 2)
+      (turn-on-smartparens-strict-mode)
       (display-line-numbers-mode t)
       (lsp)
       (lsp-ui-mode 1))))


### PR DESCRIPTION
JSX/TSX ファイルを開いた時に
smartparens-mode が有効になるようにした

smartparens-strict-mode を有効にしたかったが
Arrow Function `() => {}` と相性が悪くて
期待した動きをしてくれないから
smartparens-mode にしている。