### PR TITLE
使いやすいように普段見る agenda の表示を変更した

### DIFF
--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -40,6 +40,20 @@
    ((agenda "会議など"
             ((org-agenda-span 'day)
              (org-agenda-files my/org-agenda-calendar-files)))
+    (alltodo ""
+               ((org-agenda-prefix-format " ")
+                (org-agenda-overriding-header "予定作業")
+                (org-habit-show-habits nil)
+                (org-agenda-span 'day)
+                (org-agenda-todo-keyword-format "-")
+                (org-overriding-columns-format "%25ITEM %TODO")
+                (org-agenda-files '("~/Documents/org/tasks/projects.org"))
+                (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :and (:deadline past :not (:category "Private")))
+                                           (:name "予定が過ぎてる作業" :and (:scheduled past :not (:category "Private")))
+                                           (:name "今日〆切の作業" :and (:deadline today :not (:category "Private")))
+                                           (:name "今日予定の作業" :and (:scheduled today :not (:category "Private")))
+                                           ;; (:name "今後1週間の作業" :and (:and (:scheduled (before ,(format-time-string "%Y-%m-%d" (time-add (current-time) (* 60 60 24 7)))) (:scheduled (after (format-time-string "%Y-%m-%d" (current-time))))) :not (:category "Private")))
+                                           (:discard (:anything t))))))
     (tags-todo "-Weekday-Daily-Holiday-Weekly-Weekend"
                ((org-agenda-prefix-format " ")
                 (org-agenda-overriding-header "今日の作業")
@@ -52,20 +66,7 @@
                                            (:name "TODO" :todo "TODO")
                                            (:name "待ち" :todo "WAIT")
                                            (:discard (:anything t))))))
-    (alltodo ""
-               ((org-agenda-prefix-format " ")
-                (org-agenda-overriding-header "予定作業")
-                (org-habit-show-habits nil)
-                (org-agenda-span 'day)
-                (org-agenda-todo-keyword-format "-")
-                (org-overriding-columns-format "%25ITEM %TODO")
-                (org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
-                                           (:name "予定が過ぎてる作業" :scheduled past)
-                                           (:name "今日〆切の作業" :deadline today)
-                                           (:name "今日予定の作業" :scheduled today)
-                                           (:discard (:anything t))))))
-    (tags-todo "Weekday|Daily|Weekly"
+    (tags-todo "Weekday-Finish|Daily"
                ((org-agenda-overriding-header "習慣")
                 (org-habit-show-habits t)
                 (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))


### PR DESCRIPTION
- private の予定が表示されないようにした
- 予定作業の方を上に配置して予定が目につきやすくした
- 除外するタグを調整し普段は見ないで良いやつは出なくした