### PR TITLE
el-get.lock が cl に依存していたので読み込むことにした

### DIFF
--- a/init-el-get.el
+++ b/init-el-get.el
@@ -11,4 +11,5 @@
 
 ;; el-get のバージョンロック機構の導入
 (el-get-bundle tarao/el-get-lock)
+(require 'cl)
 (el-get-lock)


### PR DESCRIPTION
el-get.lock を使う際に
(require 'cl) しておかないとエラーになって
インストールなどに失敗するので
とりあえず回避のために require 'cl しておくことにした