### PR TITLE
org-mode を 9.4.4 に上げた

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -146,6 +146,6 @@
         (org-trello :checksum "fc63ed580101e6160edfb6f43215fb3200ce1ea7")
         (undo-fu :checksum "71c474e29f6ad726386604a5058761892951782e")
         (emacs-todoist :checksum "3662c323f02e89d48c206103b43a185b930220e7")
-        (org-mode :checksum "66810d2121aa1d936238fc53cc155e6eda425313")))
+        (org-mode :checksum "abedf386b3f13af2769728755d00c4698ac5d3b0")))
 (setq el-get-lock-locked-packages 'nil)
 (setq el-get-lock-unlocked-packages 'nil)

--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -3,7 +3,7 @@
        :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
        :type git
        :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
-       :checkout "release_9.3.6"
+       :checkout "release_9.4.4"
        :info "doc"
        :build/berkeley-unix `,(mapcar
                                (lambda (target)


### PR DESCRIPTION
元々 9.3.6 で固定していたが
Manjaro でインストールできる Emacs に入ってる org-mode が
9.4.4 だったのでそれに合わせてバージョンを上げた

9.4 のリリースノートはこれ
https://orgmode.org/worg/org-release-notes.html#org9a8d955