### PR TITLE
設定ファイルに直接書き込んでいた設定をドキュメントに反映させた

### DIFF
--- a/hugo/content/basics/ddskk.md
+++ b/hugo/content/basics/ddskk.md
@@ -39,13 +39,14 @@ ddskk が呼び出された時に色々設定されるようにしている。
             (setq skk-henkan-strict-okuri-precedence t)
             (setq skk-show-annotation t) ;; 単語の意味をアノテーションとして表示。例) いぜん /以前;previous/依然;still/
 
-            ;; 半角で入力したい文字
-            (setq skk-rom-kana-rule-list
-                  (nconc skk-rom-kana-rule-list
-                         '((";" nil nil)
-                           (":" nil nil)
-                           ("?" nil nil)
-                           ("!" nil nil))))))
+            ;; ;; 半角で入力したい文字
+            ;; (setq skk-rom-kana-rule-list
+            ;;       (nconc skk-rom-kana-rule-list
+            ;;              '((";" nil nil)
+            ;;                (":" nil nil)
+            ;;                ("?" nil nil)
+            ;;                ("!" nil nil))))
+            ))
 ```
 
 skk-comp-mode

--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -148,6 +148,20 @@ nil にして表示しないようにしている。
    ((agenda "会議など"
             ((org-agenda-span 'day)
              (org-agenda-files my/org-agenda-calendar-files)))
+    (alltodo ""
+               ((org-agenda-prefix-format " ")
+                (org-agenda-overriding-header "予定作業")
+                (org-habit-show-habits nil)
+                (org-agenda-span 'day)
+                (org-agenda-todo-keyword-format "-")
+                (org-overriding-columns-format "%25ITEM %TODO")
+                (org-agenda-files '("~/Documents/org/tasks/projects.org"))
+                (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :and (:deadline past :not (:category "Private")))
+                                           (:name "予定が過ぎてる作業" :and (:scheduled past :not (:category "Private")))
+                                           (:name "今日〆切の作業" :and (:deadline today :not (:category "Private")))
+                                           (:name "今日予定の作業" :and (:scheduled today :not (:category "Private")))
+                                           ;; (:name "今後1週間の作業" :and (:and (:scheduled (before ,(format-time-string "%Y-%m-%d" (time-add (current-time) (* 60 60 24 7)))) (:scheduled (after (format-time-string "%Y-%m-%d" (current-time))))) :not (:category "Private")))
+                                           (:discard (:anything t))))))
     (tags-todo "-Weekday-Daily-Holiday-Weekly-Weekend"
                ((org-agenda-prefix-format " ")
                 (org-agenda-overriding-header "今日の作業")
@@ -160,20 +174,7 @@ nil にして表示しないようにしている。
                                            (:name "TODO" :todo "TODO")
                                            (:name "待ち" :todo "WAIT")
                                            (:discard (:anything t))))))
-    (alltodo ""
-               ((org-agenda-prefix-format " ")
-                (org-agenda-overriding-header "予定作業")
-                (org-habit-show-habits nil)
-                (org-agenda-span 'day)
-                (org-agenda-todo-keyword-format "-")
-                (org-overriding-columns-format "%25ITEM %TODO")
-                (org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
-                                           (:name "予定が過ぎてる作業" :scheduled past)
-                                           (:name "今日〆切の作業" :deadline today)
-                                           (:name "今日予定の作業" :scheduled today)
-                                           (:discard (:anything t))))))
-    (tags-todo "Weekday|Daily|Weekly"
+    (tags-todo "Weekday-Finish|Daily"
                ((org-agenda-overriding-header "習慣")
                 (org-habit-show-habits t)
                 (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))

--- a/hugo/content/org-mode/base.md
+++ b/hugo/content/org-mode/base.md
@@ -15,7 +15,7 @@ Emacs に標準で入っている org-mode は大体古過ぎるのでとりあ�
 el-get でインストールしている。
 
 ```emacs-lisp
-(el-get-bundle org-mode :checkout "release_9.3.6")
+(el-get-bundle org-mode)
 ```
 
 なんか入れてるパッケージの問題か、依存関係が解決できなかったので

--- a/init.org
+++ b/init.org
@@ -5357,194 +5357,195 @@
      |------+----------------------------------------------+--------------------------------------------------------------------------|
 
      #+begin_src emacs-lisp :tangle inits/61-org-agenda.el
-     (setq org-agenda-custom-commands
-     '(("h" . "Habits")
-       ("hs" "Weekday Start"
-        ((tags "Weekday&Start|Daily"
-               ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                           (:name "今日の作業" :scheduled today)
-                                           (:discard (:anything t))))))))
-       ("hf" "Weekday Finish"
-        ((tags "Weekday&Finish"
-               ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                           (:name "今日の作業" :scheduled today)
-                                           (:discard (:anything t))))))))
-       ("hw" "Weekly"
-        ((tags "Weekly"
-               ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                           (:name "今週の作業" :scheduled today)
-                                           (:discard (:anything t))))))))
-       ("hh" "Holiday"
-        ((tags "Weekend|Holiday|Daily"
-               ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                           (:name "今日の作業" :scheduled today)
-                                           (:discard (:anything t))))))))
-       ("d" "Today"
-        ((agenda "会議など"
-                 ((org-agenda-span 'day)
-                  (org-agenda-files my/org-agenda-calendar-files)))
-         (tags-todo "-Weekday-Daily-Holiday-Weekly-Weekend"
-                    ((org-agenda-prefix-format " ")
-                     (org-agenda-overriding-header "今日の作業")
-                     (org-habit-show-habits nil)
-                     (org-agenda-span 'day)
-                     (org-agenda-todo-keyword-format "-")
-                     (org-overriding-columns-format "%25ITEM %TODO")
-                     (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
-                     (org-super-agenda-groups '((:name "仕掛かり中" :todo "DOING")
-                                                (:name "TODO" :todo "TODO")
-                                                (:name "待ち" :todo "WAIT")
-                                                (:discard (:anything t))))))
-         (alltodo ""
-                    ((org-agenda-prefix-format " ")
-                     (org-agenda-overriding-header "予定作業")
-                     (org-habit-show-habits nil)
-                     (org-agenda-span 'day)
-                     (org-agenda-todo-keyword-format "-")
-                     (org-overriding-columns-format "%25ITEM %TODO")
-                     (org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                     (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
-                                                (:name "予定が過ぎてる作業" :scheduled past)
-                                                (:name "今日〆切の作業" :deadline today)
-                                                (:name "今日予定の作業" :scheduled today)
-                                                (:discard (:anything t))))))
-         (tags-todo "Weekday|Daily|Weekly"
-                    ((org-agenda-overriding-header "習慣")
-                     (org-habit-show-habits t)
-                     (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
-                     (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                                (:name "今日予定" :scheduled today)
-                                                (:discard (:anything t))))))))
-       ("D" "Holiday"
-        ((tags-todo "-Weekday-Daily-Holiday-Weekly-Weekend"
-                    ((org-agenda-prefix-format " ")
-                     (org-agenda-overriding-header "休日の作業")
-                     (org-habit-show-habits nil)
-                     (org-agenda-span 'day)
-                     (org-agenda-todo-keyword-format "-")
-                     (org-overriding-columns-format "%25ITEM %TODO")
-                     (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
-                     (org-super-agenda-groups '((:name "仕掛かり中" :todo "DOING")
-                                                (:name "TODO" :todo "TODO")
-                                                (:name "待ち" :todo "WAIT")
-                                                (:discard (:anything t))))))
-         (tags-todo "Holiday|Weekend|Daily"
-                    ((org-agenda-overriding-header "習慣")
-                     (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
-                     (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                                (:name "今日予定の作業" :scheduled today)
-                                                (:discard (:anything t))))))))
-       ("p" . "Projects")
-       ("pp" "Projects"
-        ((alltodo "" ((org-agenda-prefix-format " ")
-                      (org-agenda-overriding-header "今日のタスク")
-                      (org-habit-show-habits nil)
-                      (org-agenda-span 'day)
-                      (org-agenda-todo-keyword-format "-")
-                      (org-overriding-columns-format "%25ITEM %TODO")
-                      (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
-                      (org-super-agenda-groups (append
-                                                (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
-                                                '((:name "その他" :scheduled nil)
-                                                  (:discard (:anything t)))))))
-         (alltodo "" ((org-agenda-prefix-format " ")
-                      (org-agenda-overriding-header "予定に入ってる作業")
-                      (org-habit-show-habits nil)
-                      (org-agenda-span 'day)
-                      (org-agenda-todo-keyword-format "-")
-                      (org-overriding-columns-format "%25ITEM %TODO")
-                      (org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                      (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
-                                                 (:name "予定が過ぎてる作業" :scheduled past)
-                                                 (:name "今日〆切の作業" :deadline today)
-                                                 (:name "今日予定の作業" :scheduled today)
-                                                 (:discard (:anything t))))))
-         (todo "DOING" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))
-         (todo "TODO"  ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
-       ("pP" "Projects without Env"
-        ((alltodo "" ((org-agenda-prefix-format " ")
-                      (org-agenda-overriding-header "今日のタスク")
-                      (org-habit-show-habits nil)
-                      (org-agenda-span 'day)
-                      (org-agenda-todo-keyword-format "-")
-                      (org-overriding-columns-format "%25ITEM %TODO")
-                      (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
-                      (org-super-agenda-groups (append
-                                                (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
-                                                '((:name "その他" :scheduled nil)
-                                                  (:discard (:anything t)))))))
-         (alltodo "" ((org-agenda-prefix-format " ")
-                      (org-agenda-overriding-header "予定に入ってる作業")
-                      (org-habit-show-habits nil)
-                      (org-agenda-span 'day)
-                      (org-agenda-todo-keyword-format "-")
-                      (org-overriding-columns-format "%25ITEM %TODO")
-                      (org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                      (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
-                                                 (:name "予定が過ぎてる作業" :scheduled past)
-                                                 (:name "今日〆切の作業" :deadline today)
-                                                 (:name "今日予定の作業" :scheduled today)
-                                                 (:discard (:anything t))))))
-         (tags-todo "-Emacs-org-Env-Hugo" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
-       ("P" "Pointers"
-        ((todo "DOING" ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))
-         (todo "TODO"  ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))))
-       ("X" "Finished"
-        ((todo "DONE"    ((org-agenda-files '("~/Documents/org/tasks/projects.org"
-                                              "~/Documents/org/tasks/inbox.org"
-                                              "~/Documents/org/tasks/shopping.org"
-                                              "~/Documents/org/tasks/next-actions.org"))))
-         (todo "SOMEDAY" ((org-agenda-files '("~/Documents/org/tasks/projects.org"
-                                              "~/Documents/org/tasks/inbox.org"
-                                              "~/Documents/org/tasks/shopping.org"
-                                              "~/Documents/org/tasks/next-actions.org"))))))
-
-       ("z" "日報"
-        ((agenda "" ((org-agenda-span 'day)
-                     (org-agenda-overriding-header "")
-                     (org-habit-show-habits nil)
-                     (org-agenda-format-date "## %Y/%m/%d (%a) 日報")
-                     (org-agenda-prefix-format " %?-12t")
-                     (org-agenda-files my/org-agenda-calendar-files)
-                     (org-super-agenda-groups
-                      '((:name "会議など" :time-grid t)
-                        (:discard (:anything t))))))
-         (todo "DONE" ((org-agenda-prefix-format " ")
-                       (org-agenda-overriding-header "対応済")
+       (setq org-agenda-custom-commands
+       '(("h" . "Habits")
+         ("hs" "Weekday Start"
+          ((tags "Weekday&Start|Daily"
+                 ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                             (:name "今日の作業" :scheduled today)
+                                             (:discard (:anything t))))))))
+         ("hf" "Weekday Finish"
+          ((tags "Weekday&Finish"
+                 ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                             (:name "今日の作業" :scheduled today)
+                                             (:discard (:anything t))))))))
+         ("hw" "Weekly"
+          ((tags "Weekly"
+                 ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                             (:name "今週の作業" :scheduled today)
+                                             (:discard (:anything t))))))))
+         ("hh" "Holiday"
+          ((tags "Weekend|Holiday|Daily"
+                 ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                             (:name "今日の作業" :scheduled today)
+                                             (:discard (:anything t))))))))
+         ("d" "Today"
+          ((agenda "会議など"
+                   ((org-agenda-span 'day)
+                    (org-agenda-files my/org-agenda-calendar-files)))
+           (alltodo ""
+                      ((org-agenda-prefix-format " ")
+                       (org-agenda-overriding-header "予定作業")
                        (org-habit-show-habits nil)
                        (org-agenda-span 'day)
                        (org-agenda-todo-keyword-format "-")
-                       ;; (org-overriding-columns-format "%25ITEM %TODO %CATEGORY")
-                       (org-columns-default-format-for-agenda "%25ITEM %TODO %3PRIORITY")
+                       (org-overriding-columns-format "%25ITEM %TODO")
+                       (org-agenda-files '("~/Documents/org/tasks/projects.org"))
+                       (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :and (:deadline past :not (:category "Private")))
+                                                  (:name "予定が過ぎてる作業" :and (:scheduled past :not (:category "Private")))
+                                                  (:name "今日〆切の作業" :and (:deadline today :not (:category "Private")))
+                                                  (:name "今日予定の作業" :and (:scheduled today :not (:category "Private")))
+                                                  ;; (:name "今後1週間の作業" :and (:and (:scheduled (before ,(format-time-string "%Y-%m-%d" (time-add (current-time) (* 60 60 24 7)))) (:scheduled (after (format-time-string "%Y-%m-%d" (current-time))))) :not (:category "Private")))
+                                                  (:discard (:anything t))))))
+           (tags-todo "-Weekday-Daily-Holiday-Weekly-Weekend"
+                      ((org-agenda-prefix-format " ")
+                       (org-agenda-overriding-header "今日の作業")
+                       (org-habit-show-habits nil)
+                       (org-agenda-span 'day)
+                       (org-agenda-todo-keyword-format "-")
+                       (org-overriding-columns-format "%25ITEM %TODO")
                        (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
-                       (org-super-agenda-groups (append
-                                                 (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DONE")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
-                                                 '((:discard (:anything t :name "discard")))))))
-         (alltodo "" ((org-agenda-prefix-format " ")
-                      (org-agenda-overriding-header "仕掛かり中")
-                      (org-habit-show-habits nil)
-                      (org-agenda-span 'day)
-                      (org-agenda-todo-keyword-format "-")
-                      (org-overriding-columns-format "%25ITEM %TODO")
-                      (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
-                      (org-super-agenda-groups (append
-                                                (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
-                                                '((:discard (:anything t :name "discard")))))))))
+                       (org-super-agenda-groups '((:name "仕掛かり中" :todo "DOING")
+                                                  (:name "TODO" :todo "TODO")
+                                                  (:name "待ち" :todo "WAIT")
+                                                  (:discard (:anything t))))))
+           (tags-todo "Weekday-Finish|Daily"
+                      ((org-agenda-overriding-header "習慣")
+                       (org-habit-show-habits t)
+                       (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
+                       (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                                  (:name "今日予定" :scheduled today)
+                                                  (:discard (:anything t))))))))
+         ("D" "Holiday"
+          ((tags-todo "-Weekday-Daily-Holiday-Weekly-Weekend"
+                      ((org-agenda-prefix-format " ")
+                       (org-agenda-overriding-header "休日の作業")
+                       (org-habit-show-habits nil)
+                       (org-agenda-span 'day)
+                       (org-agenda-todo-keyword-format "-")
+                       (org-overriding-columns-format "%25ITEM %TODO")
+                       (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
+                       (org-super-agenda-groups '((:name "仕掛かり中" :todo "DOING")
+                                                  (:name "TODO" :todo "TODO")
+                                                  (:name "待ち" :todo "WAIT")
+                                                  (:discard (:anything t))))))
+           (tags-todo "Holiday|Weekend|Daily"
+                      ((org-agenda-overriding-header "習慣")
+                       (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
+                       (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                                  (:name "今日予定の作業" :scheduled today)
+                                                  (:discard (:anything t))))))))
+         ("p" . "Projects")
+         ("pp" "Projects"
+          ((alltodo "" ((org-agenda-prefix-format " ")
+                        (org-agenda-overriding-header "今日のタスク")
+                        (org-habit-show-habits nil)
+                        (org-agenda-span 'day)
+                        (org-agenda-todo-keyword-format "-")
+                        (org-overriding-columns-format "%25ITEM %TODO")
+                        (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
+                        (org-super-agenda-groups (append
+                                                  (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
+                                                  '((:name "その他" :scheduled nil)
+                                                    (:discard (:anything t)))))))
+           (alltodo "" ((org-agenda-prefix-format " ")
+                        (org-agenda-overriding-header "予定に入ってる作業")
+                        (org-habit-show-habits nil)
+                        (org-agenda-span 'day)
+                        (org-agenda-todo-keyword-format "-")
+                        (org-overriding-columns-format "%25ITEM %TODO")
+                        (org-agenda-files '("~/Documents/org/tasks/projects.org"))
+                        (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
+                                                   (:name "予定が過ぎてる作業" :scheduled past)
+                                                   (:name "今日〆切の作業" :deadline today)
+                                                   (:name "今日予定の作業" :scheduled today)
+                                                   (:discard (:anything t))))))
+           (todo "DOING" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))
+           (todo "TODO"  ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
+         ("pP" "Projects without Env"
+          ((alltodo "" ((org-agenda-prefix-format " ")
+                        (org-agenda-overriding-header "今日のタスク")
+                        (org-habit-show-habits nil)
+                        (org-agenda-span 'day)
+                        (org-agenda-todo-keyword-format "-")
+                        (org-overriding-columns-format "%25ITEM %TODO")
+                        (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
+                        (org-super-agenda-groups (append
+                                                  (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
+                                                  '((:name "その他" :scheduled nil)
+                                                    (:discard (:anything t)))))))
+           (alltodo "" ((org-agenda-prefix-format " ")
+                        (org-agenda-overriding-header "予定に入ってる作業")
+                        (org-habit-show-habits nil)
+                        (org-agenda-span 'day)
+                        (org-agenda-todo-keyword-format "-")
+                        (org-overriding-columns-format "%25ITEM %TODO")
+                        (org-agenda-files '("~/Documents/org/tasks/projects.org"))
+                        (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
+                                                   (:name "予定が過ぎてる作業" :scheduled past)
+                                                   (:name "今日〆切の作業" :deadline today)
+                                                   (:name "今日予定の作業" :scheduled today)
+                                                   (:discard (:anything t))))))
+           (tags-todo "-Emacs-org-Env-Hugo" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
+         ("P" "Pointers"
+          ((todo "DOING" ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))
+           (todo "TODO"  ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))))
+         ("X" "Finished"
+          ((todo "DONE"    ((org-agenda-files '("~/Documents/org/tasks/projects.org"
+                                                "~/Documents/org/tasks/inbox.org"
+                                                "~/Documents/org/tasks/shopping.org"
+                                                "~/Documents/org/tasks/next-actions.org"))))
+           (todo "SOMEDAY" ((org-agenda-files '("~/Documents/org/tasks/projects.org"
+                                                "~/Documents/org/tasks/inbox.org"
+                                                "~/Documents/org/tasks/shopping.org"
+                                                "~/Documents/org/tasks/next-actions.org"))))))
 
-       ("H" "HouseWork" ((tags "HouseWork")))
-       ("E" . "Env")
-       ("EO" "org"
-        ((tags-todo "+org"
-                    ((org-agenda-files '("~/Documents/org/tasks/projects.org"
-                                         "~/Documents/org/tasks/inbox.org"))))))
-       ("EE" "Emacs without org"
-        ((tags-todo "+Emacs-org"
-                    ((org-agenda-files '("~/Documents/org/tasks/projects.org"
-                                         "~/Documents/org/tasks/inbox.org"))))))
-       ("Ee" "without Emacs"
-        ((tags-todo "+Env-Emacs-org"
-                    ((org-agenda-files '("~/Documents/org/tasks/projects.org"
-                                         "~/Documents/org/tasks/inbox.org"))))))))
+         ("z" "日報"
+          ((agenda "" ((org-agenda-span 'day)
+                       (org-agenda-overriding-header "")
+                       (org-habit-show-habits nil)
+                       (org-agenda-format-date "## %Y/%m/%d (%a) 日報")
+                       (org-agenda-prefix-format " %?-12t")
+                       (org-agenda-files my/org-agenda-calendar-files)
+                       (org-super-agenda-groups
+                        '((:name "会議など" :time-grid t)
+                          (:discard (:anything t))))))
+           (todo "DONE" ((org-agenda-prefix-format " ")
+                         (org-agenda-overriding-header "対応済")
+                         (org-habit-show-habits nil)
+                         (org-agenda-span 'day)
+                         (org-agenda-todo-keyword-format "-")
+                         ;; (org-overriding-columns-format "%25ITEM %TODO %CATEGORY")
+                         (org-columns-default-format-for-agenda "%25ITEM %TODO %3PRIORITY")
+                         (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
+                         (org-super-agenda-groups (append
+                                                   (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DONE")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
+                                                   '((:discard (:anything t :name "discard")))))))
+           (alltodo "" ((org-agenda-prefix-format " ")
+                        (org-agenda-overriding-header "仕掛かり中")
+                        (org-habit-show-habits nil)
+                        (org-agenda-span 'day)
+                        (org-agenda-todo-keyword-format "-")
+                        (org-overriding-columns-format "%25ITEM %TODO")
+                        (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
+                        (org-super-agenda-groups (append
+                                                  (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
+                                                  '((:discard (:anything t :name "discard")))))))))
+
+         ("H" "HouseWork" ((tags "HouseWork")))
+         ("E" . "Env")
+         ("EO" "org"
+          ((tags-todo "+org"
+                      ((org-agenda-files '("~/Documents/org/tasks/projects.org"
+                                           "~/Documents/org/tasks/inbox.org"))))))
+         ("EE" "Emacs without org"
+          ((tags-todo "+Emacs-org"
+                      ((org-agenda-files '("~/Documents/org/tasks/projects.org"
+                                           "~/Documents/org/tasks/inbox.org"))))))
+         ("Ee" "without Emacs"
+          ((tags-todo "+Env-Emacs-org"
+                      ((org-agenda-files '("~/Documents/org/tasks/projects.org"
+                                           "~/Documents/org/tasks/inbox.org"))))))))
      #+end_src
 
 ** org-capture

--- a/init.org
+++ b/init.org
@@ -262,25 +262,26 @@
     今度見直した方が良さそう。
 
     #+begin_src emacs-lisp :tangle inits/30-skk.el
-    (add-hook 'skk-load-hook
-              (lambda ()
-                ;; コード中では自動的に英字にする。
-                (require 'context-skk)
+      (add-hook 'skk-load-hook
+                (lambda ()
+                  ;; コード中では自動的に英字にする。
+                  (require 'context-skk)
 
-                (setq skk-comp-mode t) ;; 動的自動補完
-                (setq skk-auto-insert-paren t)
-                (setq skk-delete-implies-kakutei nil)
-                (setq skk-sticky-key ";")
-                (setq skk-henkan-strict-okuri-precedence t)
-                (setq skk-show-annotation t) ;; 単語の意味をアノテーションとして表示。例) いぜん /以前;previous/依然;still/
+                  (setq skk-comp-mode t) ;; 動的自動補完
+                  (setq skk-auto-insert-paren t)
+                  (setq skk-delete-implies-kakutei nil)
+                  (setq skk-sticky-key ";")
+                  (setq skk-henkan-strict-okuri-precedence t)
+                  (setq skk-show-annotation t) ;; 単語の意味をアノテーションとして表示。例) いぜん /以前;previous/依然;still/
 
-                ;; 半角で入力したい文字
-                (setq skk-rom-kana-rule-list
-                      (nconc skk-rom-kana-rule-list
-                             '((";" nil nil)
-                               (":" nil nil)
-                               ("?" nil nil)
-                               ("!" nil nil))))))
+                  ;; ;; 半角で入力したい文字
+                  ;; (setq skk-rom-kana-rule-list
+                  ;;       (nconc skk-rom-kana-rule-list
+                  ;;              '((";" nil nil)
+                  ;;                (":" nil nil)
+                  ;;                ("?" nil nil)
+                  ;;                ("!" nil nil))))
+                  ))
     #+end_src
 
     - skk-comp-mode :: 自動補完関係らしいが、ググっても出て来ないし死んだ設定かもしれない

--- a/init.org
+++ b/init.org
@@ -5054,7 +5054,7 @@
     el-get でインストールしている。
 
     #+begin_src emacs-lisp :tangle inits/60-org.el
-    (el-get-bundle org-mode :checkout "release_9.3.6")
+    (el-get-bundle org-mode)
     #+end_src
 
     なんか入れてるパッケージの問題か、依存関係が解決できなかったので


### PR DESCRIPTION
いちいちドキュメントから反映するのがだるくて
直接設定ファイルに書き込んでいた設定をドキュメント側に反映した

方法としては

1. ドキュメントから設定ファイルを出力
2. ドキュメントに反映してなかった部分がマイナスの差分として表示される
3. 差分がなくなるようにドキュメントを調整

ということをしただけ。

ドキュメント内のコードを変更しただけなので
日本語テキスト部分は何も変更していない。