### PR TITLE
分報チャンネル設定をしてなくてもエラーにならないように調整

### DIFF
--- a/hugo/content/external-tool/notify-slack.md
+++ b/hugo/content/external-tool/notify-slack.md
@@ -14,6 +14,15 @@ org-clock-in, org-clock-out の時に作業の開始と終了を分報チャン�
 ## 実装 {#実装}
 
 
+### 分報チャンネル設定用の変数 {#分報チャンネル設定用の変数}
+
+通知先のチャンネル名を格納する変数が必要なので `defvar` で定義しておく
+
+```emacs-lisp
+(defvar my/notify-slack-times-channel nil)
+```
+
+
 ### 送信するコマンド {#送信するコマンド}
 
 start-process を使って外部コマンドを叩いている。
@@ -50,7 +59,8 @@ start-process を使って外部コマンドを叩いている。
 
 ```emacs-lisp
 (defun my/notify-slack-times (text)
-  (my/notify-slack my/notify-slack-times-channel text))
+  (if my/notify-slack-times-channel
+      (my/notify-slack my/notify-slack-times-channel text)))
 ```
 
 

--- a/init.org
+++ b/init.org
@@ -4801,6 +4801,12 @@
     作業の開始と終了を分報チャンネルに投稿しているだけである。
     作業の可視化である。
 *** 実装
+**** 分報チャンネル設定用の変数
+     通知先のチャンネル名を格納する変数が必要なので ~defvar~ で定義しておく
+
+     #+begin_src emacs-lisp :tangle inits/30-notify-slack.el
+     (defvar my/notify-slack-times-channel nil)
+     #+end_src
 **** 送信するコマンド
      start-process を使って外部コマンドを叩いている。
 
@@ -4836,7 +4842,8 @@
 
      #+begin_src emacs-lisp :tangle inits/30-notify-slack.el
      (defun my/notify-slack-times (text)
-       (my/notify-slack my/notify-slack-times-channel text))
+       (if my/notify-slack-times-channel
+           (my/notify-slack my/notify-slack-times-channel text)))
      #+end_src
 
 **** 設定

--- a/inits/30-notify-slack.el
+++ b/inits/30-notify-slack.el
@@ -1,3 +1,5 @@
+(defvar my/notify-slack-times-channel nil)
+
 (defun my/notify-slack (channel text)
   (if my/notify-slack-enable-p
       (start-process "my/org-clock-slack-notifier" "*my/org-clock-slack-notifier*" "my-slack-notifier" channel text)))
@@ -9,7 +11,8 @@
     (setq my/notify-slack-enable-p t)))
 
 (defun my/notify-slack-times (text)
-  (my/notify-slack my/notify-slack-times-channel text))
+  (if my/notify-slack-times-channel
+      (my/notify-slack my/notify-slack-times-channel text)))
 
 (my/load-config "my-notify-slack-config")
 


### PR DESCRIPTION
notify-slack という自作スクリプトは
分報チャンネルの設定がないとエラーになる状態だったので
defvar で変数を定義しておくように調整した