### PR TITLE
WSL でのみ Emacs がフルスクリーンになるようにした

### DIFF
--- a/hugo/content/ui/fullscreen.md
+++ b/hugo/content/ui/fullscreen.md
@@ -20,16 +20,17 @@ Mac の場合にフルスクリーンにする設定を入れていた。けど 
 ```
 
 
-## Linux(X Window system) の設定 {#linux--x-window-system--の設定}
+## WSL の設定 {#wsl-の設定}
 
-X Window system の場合にはフルスクリーンにする。まあ Linux って書いているけど WSL2 用なのである。
+X Window system の場合かつ WSLENV という環境変数が設定されている場合にはフルスクリーンにする。新しく Linux マシンを導入したらこれの影響を受けていたので後から WSLENV による判定を追加した次第。
 
 ```emacs-lisp
-(if (eq window-system 'x)
+(if (and (eq window-system 'x) (getenv "WSLENV"))
     (add-hook 'window-setup-hook
               (lambda ()
                 (set-frame-parameter nil 'fullscreen 'fullboth)
                 (set-frame-position nil 0 0))))
 ```
 
-微妙に画面の下の方がちゃんとフルになってくれてないけどそこは今は我慢して使っている。
+微妙に画面の下の方がちゃんとフルになってくれてないけどそこは今は我慢して使っている。ちなみにその病はどうやら WSLg になっても残りそう。
+<https://w.atwiki.jp/ntemacs/pages/69.html>

--- a/init.org
+++ b/init.org
@@ -1986,7 +1986,6 @@
    :PROPERTIES:
    :EXPORT_FILE_NAME: fullscreen
    :END:
-
 *** 概要
     起動時にフルスクリーンにする設定はここにまとめている
 
@@ -2001,12 +2000,13 @@
                   (lambda ()
                     (set-frame-parameter nil 'fullscreen 'fullboth))))
     #+end_src
-*** Linux(X Window system) の設定
-    X Window system の場合にはフルスクリーンにする。
-    まあ Linux って書いているけど WSL2 用なのである。
+*** WSL の設定
+    X Window system の場合かつ WSLENV という環境変数が設定されている場合にはフルスクリーンにする。
+    新しく Linux マシンを導入したらこれの影響を受けていたので
+    後から WSLENV による判定を追加した次第。
 
     #+begin_src emacs-lisp :tangle inits/90-fullscreen.el
-    (if (eq window-system 'x)
+    (if (and (eq window-system 'x) (getenv "WSLENV"))
         (add-hook 'window-setup-hook
                   (lambda ()
                     (set-frame-parameter nil 'fullscreen 'fullboth)
@@ -2015,6 +2015,8 @@
 
     微妙に画面の下の方がちゃんとフルになってくれてないけど
     そこは今は我慢して使っている。
+    ちなみにその病はどうやら WSLg になっても残りそう。
+    https://w.atwiki.jp/ntemacs/pages/69.html
 
 ** git-gutter-fringe                                            :improvement:
    :PROPERTIES:

--- a/inits/90-fullscreen.el
+++ b/inits/90-fullscreen.el
@@ -1,4 +1,4 @@
-(if (eq window-system 'x)
+(if (and (eq window-system 'x) (getenv "WSLENV"))
     (add-hook 'window-setup-hook
               (lambda ()
                 (set-frame-parameter nil 'fullscreen 'fullboth)


### PR DESCRIPTION
Manjaro では i3wm 側に Window の制御を任せたいので
フルスクリーンになるのは WSL 環境のみになるように調整した。