### PR TITLE
Linux で SKK の L 辞書を読めるようにした

### DIFF
--- a/hugo/content/basics/ddskk.md
+++ b/hugo/content/basics/ddskk.md
@@ -82,7 +82,8 @@ skk-rom-kana-rules-list
 
 ## AquaSKK の L 辞書を使うようにする {#aquaskk-の-l-辞書を使うようにする}
 
-これはもう Mac 用の設定ですね。
+Mac では AquaSKK の L 辞書を、
+Linux では `/usr/share/skk/SKK-JISYO.L` を読むようにしている。
 
 ```emacs-lisp
 (let ((l-dict
@@ -94,10 +95,10 @@ skk-rom-kana-rules-list
 ```
 
 WSL で動かしている Emacs では
-CurvusSKK の辞書を見るように設定した方が良さそう。
+CurvusSKK の辞書を見るように設定した方が良さそうな気もするけどひとまず放置。
 
-そう、WSL2 では L 辞書が使えなくて変換がちょっとだるいけど放置しているのである!
-なのでそういう意味で見直しが必要。
+そもそも今の WSL の Ubuntu 環境の `/usr/share/skk/SKK-JISYO.L` に辞書あるんだっけ……?
+ま、今度調べる……
 
 
 ## ddskk-posframe {#ddskk-posframe}

--- a/hugo/content/basics/ddskk.md
+++ b/hugo/content/basics/ddskk.md
@@ -85,7 +85,10 @@ skk-rom-kana-rules-list
 これはもう Mac 用の設定ですね。
 
 ```emacs-lisp
-(let ((l-dict (expand-file-name "~/Library/Application Support/AquaSKK/SKK-JISYO.L")))
+(let ((l-dict
+       (if (eq window-system 'ns)
+           (expand-file-name "~/Library/Application Support/AquaSKK/SKK-JISYO.L")
+         "/usr/share/skk/SKK-JISYO.L")))
   (if (file-exists-p l-dict)
       (setq skk-large-jisyo l-dict)))
 ```

--- a/init.org
+++ b/init.org
@@ -301,7 +301,8 @@
     #+end_src
 
 *** AquaSKK の L 辞書を使うようにする                           :improvement:
-    これはもう Mac 用の設定ですね。
+    Mac では AquaSKK の L 辞書を、
+    Linux では ~/usr/share/skk/SKK-JISYO.L~ を読むようにしている。
 
     #+begin_src emacs-lisp :tangle inits/30-skk.el
     (let ((l-dict
@@ -313,10 +314,10 @@
     #+end_src
 
     WSL で動かしている Emacs では
-    CurvusSKK の辞書を見るように設定した方が良さそう。
+    CurvusSKK の辞書を見るように設定した方が良さそうな気もするけどひとまず放置。
 
-    そう、WSL2 では L 辞書が使えなくて変換がちょっとだるいけど放置しているのである!
-    なのでそういう意味で見直しが必要。
+    そもそも今の WSL の Ubuntu 環境の ~/usr/share/skk/SKK-JISYO.L~ に辞書あるんだっけ……?
+    ま、今度調べる……
 
 *** ddskk-posframe
     [[https://github.com/conao3/ddskk-posframe.el/][ddskk-posframe]] は ddskk ツールチップを posframe で表示してくれるやつ。便利。

--- a/init.org
+++ b/init.org
@@ -304,7 +304,10 @@
     これはもう Mac 用の設定ですね。
 
     #+begin_src emacs-lisp :tangle inits/30-skk.el
-    (let ((l-dict (expand-file-name "~/Library/Application Support/AquaSKK/SKK-JISYO.L")))
+    (let ((l-dict
+           (if (eq window-system 'ns)
+               (expand-file-name "~/Library/Application Support/AquaSKK/SKK-JISYO.L")
+             "/usr/share/skk/SKK-JISYO.L")))
       (if (file-exists-p l-dict)
           (setq skk-large-jisyo l-dict)))
     #+end_src

--- a/inits/30-skk.el
+++ b/inits/30-skk.el
@@ -23,7 +23,10 @@
 
 (setq skk-extra-jisyo-file-list (list '("~/.emacs.d/skk-jisyo/SKK-JISYO.lisp" . japanese-iso-8bit-unix)))
 
-(let ((l-dict (expand-file-name "~/Library/Application Support/AquaSKK/SKK-JISYO.L")))
+(let ((l-dict
+       (if (eq window-system 'ns)
+           (expand-file-name "~/Library/Application Support/AquaSKK/SKK-JISYO.L")
+         "/usr/share/skk/SKK-JISYO.L")))
   (if (file-exists-p l-dict)
       (setq skk-large-jisyo l-dict)))
 


### PR DESCRIPTION
L 辞書を読む設定自体は存在していたけど
Mac 用に記載されていたので
Mac/Linux 両方に対応できるように修正した