### PR TITLE
find-file-hooks で ddskk を有効にするようにした

### DIFF
--- a/hugo/content/basics/ddskk.md
+++ b/hugo/content/basics/ddskk.md
@@ -20,6 +20,18 @@ SKK ではその自動認識がおかしくておかしな変換になるとこ�
 ```
 
 
+## 常時有効化 {#常時有効化}
+
+find-file-hooks で有効化することでファイルを開いた時には常に skk が使える状態にしている。また skk-latin-mode にしておくことで、基本は英語入力ですぐに日本語入力に切り替えられる状態にしている。
+
+```emacs-lisp
+(defun my/always-enable-skk-latin-mode-hook ()
+  (skk-latin-mode 1))
+
+(add-hook 'find-file-hooks 'my/always-enable-skk-latin-mode-hook)
+```
+
+
 ## hook の設定 {#hook-の設定}
 
 ddskk が呼び出された時に色々設定されるようにしている。

--- a/init.org
+++ b/init.org
@@ -255,6 +255,18 @@
     #+begin_src emacs-lisp :tangle inits/30-skk.el
     (el-get-bundle ddskk)
     #+end_src
+
+*** 常時有効化
+    find-file-hooks で有効化することでファイルを開いた時には常に skk が使える状態にしている。
+    また skk-latin-mode にしておくことで、
+    基本は英語入力ですぐに日本語入力に切り替えられる状態にしている。
+
+    #+begin_src emacs-lisp :tangle inits/30-skk.el
+    (defun my/always-enable-skk-latin-mode-hook ()
+      (skk-latin-mode 1))
+
+    (add-hook 'find-file-hooks 'my/always-enable-skk-latin-mode-hook)
+    #+end_src
 *** hook の設定
     ddskk が呼び出された時に色々設定されるようにしている。
 

--- a/inits/30-skk.el
+++ b/inits/30-skk.el
@@ -1,5 +1,10 @@
 (el-get-bundle ddskk)
 
+(defun my/always-enable-skk-latin-mode-hook ()
+  (skk-latin-mode 1))
+
+(add-hook 'find-file-hooks 'my/always-enable-skk-latin-mode-hook)
+
 (add-hook 'skk-load-hook
           (lambda ()
             ;; コード中では自動的に英字にする。


### PR DESCRIPTION
どのファイルを弄る時にも ddskk が有効である方が便利なので
find-file-hooks で有効化するようにした

ただし今これを書いている
magit/forge のプルリクエストを作るための
new-pullreq というやつでは有効になってなかったので
別途対応が必要な可能性あり