### PR TITLE
auto-fix-mode を導入

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,7 @@
 (setq el-get-lock-package-versions
-      '((typescript-mode :checksum "e82416205158d4b21d42d6b60c4385f68f0ae1b1")
+      '((auto-fix :checksum "783e78f601d0ca42792aff40d6a72434be167900")
+        (auto-fix\.el :checksum "2a52bfefd446814e6f93748821ccde151c00136b")
+        (typescript-mode :checksum "e82416205158d4b21d42d6b60c4385f68f0ae1b1")
         (yaml :checksum "84b88c9ed178af16da18b230c1f61c57cefedf28")
         (tree-mode :checksum "56a765fe2023909b37d430ab1fc70963fb41c845")
         (web-mode :checksum "4f1c96381a96000358b6621782d79c79b05ca5da")

--- a/inits/10-auto-format.el
+++ b/inits/10-auto-format.el
@@ -1,0 +1,1 @@
+(el-get-bundle auto-fix)


### PR DESCRIPTION
先のプルリクで React 向けに auto-fix-mode の設定を入れたけど
肝心のインストール部分がなかった。

ところで el-get.lock ではなぜか2つ入れてるがどっちかが間違い。
本家だとうまく動かなかったので fork して使ってるのよね。
ま、あとで調整する……。