### PR TITLE
key-chord でセミコロン+alphabet 大文字入力になる設定を辞めた

### DIFF
--- a/inits/70-key-chord.el
+++ b/inits/70-key-chord.el
@@ -6,10 +6,6 @@
 
 (key-chord-mode 1)
 
-(mapc (lambda (key)
-        (key-chord-define-global (concat ";" (char-to-string key)) (char-to-string (- key 32))))
-      (number-sequence ?a ?z))
-
 (key-chord-define-global ";;"
                          'event-apply-shift-modifier)
 


### PR DESCRIPTION
JavaScript でセミコロンを書くことが多いけども
弊害が大きかった

あと SKK との相性もよくなかった