### PR TITLE
もうインストールしていない xml-rpc を el-get.lock から消した

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -87,7 +87,6 @@
         (helm-ag :checksum "7cfed5d3e861717466ae6d3f76c759548a9fad04")
         (helm-descbinds :checksum "b72515982396b6e336ad7beb6767e95a80fca192")
         (helm-projectile :checksum "58123f14c392021714fc5d23b9f95c7f95ce07f1")
-        (hexmode--xml-rpc :checksum "8020ccd176986d8e49e0bb5dd9f4e756cf12eafc")
         (ht :checksum "c4c1be487d6ecb353d07881526db05d7fc90ea87")
         (hydra :checksum "9e9e00cb240ea1903ffd36a54956b3902c379d29")
         (hydra-posframe :checksum "94405b5fbec1ae9447c976c3deef41043b9b7de3")


### PR DESCRIPTION
hexmode--xml-rpc は
https://github.com/mugijiru/.emacs.d/pull/335
で消した recipe の中で依存していて
このレシピで入れていた seesaa-blog-mode は
https://github.com/mugijiru/.emacs.d/pull/332
で消したので、完全に不要になっている。

なのに el-get.lock には残っていたので消した