### PR TITLE
更新確認スクリプトを修正

### DIFF
--- a/el-get-lock-update-check.el
+++ b/el-get-lock-update-check.el
@@ -35,7 +35,7 @@
                              (hash (if (>= (string-width result) 40)
                                        (substring result 0 40)
                                      nil)))
-                        (if hash
+                        (if (and hash (string-match-p "^[0-9a-z]\\{40\\}$" hash))
                             (if (string-equal checksum hash)
                                 (progn
                                   (princ "no updates."))


### PR DESCRIPTION
既存の実装だと URL は推測で生成できても
hash が取れないことがあった

ちゃんと調べてないけどそのパターンにかかるのは
大体デフォルトブランチが main になっているパターン。

デフォルトブランチを正確に取れる手段を構築したいが
一旦はちゃんと URL が取れてないということがわかる状態にした