### PR TITLE
ruby-end も既に入れてないので el-get.lock から削除

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -38,7 +38,6 @@
         (emacs-hide-mode-line :checksum "bc5d293576c5e08c29e694078b96a5ed85631942")
         (highlight-indent-guides :checksum "cf352c85cd15dd18aa096ba9d9ab9b7ab493e8f6")
         (org-export-blocks-format-plantuml :checksum "9d8b93ae4f30e61ef6dbbf6d24118aa577c501ec")
-        (ruby-end :checksum "a136f75abb6d5577ce40d61dfeb778c2e9bb09c0")
         (scratch-log :checksum "1168f7f16d36ca0f4ddf2bb98881f8db62cc5dc0")
         (tempbuf :checksum "5222c25acc2e60539af0f4d30e2e263ec56c43fc")
         (vue-mode :checksum "031edd1f97db6e7d8d6c295c0e6d58dd128b9e71")


### PR DESCRIPTION
https://github.com/mugijiru/.emacs.d/pull/250
で消しているが el-get.lock に残っていた