### PR TITLE
更新チェックの対象になるように ddskk-posframe のrecipe を追加した

### DIFF
--- a/inits/30-skk.el
+++ b/inits/30-skk.el
@@ -33,5 +33,5 @@
   (if (file-exists-p l-dict)
       (setq skk-large-jisyo l-dict)))
 
-(el-get-bundle conao3/ddskk-posframe.el)
+(el-get-bundle ddskk-posframe.el)
 (ddskk-posframe-mode 1)

--- a/recipes/ddskk-posframe.el.rcp
+++ b/recipes/ddskk-posframe.el.rcp
@@ -1,0 +1,5 @@
+(:name ddskk-posframe.el
+       :website "https://github.com/conao3/ddskk-posframe.el"
+       :description "ddskk-posframe.el provides Henkan tooltip for ddskk via posframe."
+       :type github
+       :pkgname "conao3/ddskk-posframe.el")


### PR DESCRIPTION
自作の el-get-lock-update-check.el では
`(el-get-bundle conao3/ddskk-posframe.el)`
のように書いて入れてるものは更新チェックができないので
更新チェックできるように recipe を追加した

また、それに合わせて el-get-bundle の記述も変更した