### PR TITLE
インストールされてない websocket の情報を el-get.lock から削除

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -119,7 +119,6 @@
         (treepy :checksum "3ac940e97f3d03e48ca9d7fcd74916a9b01c72f3")
         (twittering-mode :checksum "114891e8fdb4f06b1326a6cf795e49c205cf9e29")
         (wakatime-mode :checksum "0f94ac2dd4fa125fc5f152700779edce75a6b03b")
-        (websocket :checksum "be99c4636ad72bcea535392d9097c32b98ec0056")
         (with-editor :checksum "f514f23258af67a10fc8e1c431bfe94702b6e65b")
         (yaml-mode :checksum "535273d5a1eb76999d20afbcf4d9f056d8ffd2da")
         (yascroll :checksum "d8674bbbc9d4d7bdba374f0c0473ebb1912bcac2")


### PR DESCRIPTION
昔 slack.el を入れていた依存関係で登録されていたっぽい
https://github.com/mugijiru/.emacs.d/pull/132