### PR TITLE
frame-fns, frame-cmds, tree-mode の source を GitHub にした

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,11 +1,11 @@
 (setq el-get-lock-package-versions
-      '((frame-fns :checksum "b675ee568c0133709c2c39a125395486cdf1c610")
+      '((tree-mode :checksum "b06078826d5875d74b0e7b7ac47b0d0917610534")
+        (frame-fns :checksum "b675ee568c0133709c2c39a125395486cdf1c610")
         (frame-cmds :checksum "3911fbe2b11b8494a14a4d99e989e7e07b243b69")
         (tempbuf-mode :checksum "17a005da886436090d3812899d553deb7bdbebb2")
         (auto-fix :checksum "783e78f601d0ca42792aff40d6a72434be167900")
         (typescript-mode :checksum "88f317f0b6aef8f8d232e912fdbc679799580c56")
         (yaml :checksum "84b88c9ed178af16da18b230c1f61c57cefedf28")
-        (tree-mode :checksum "56a765fe2023909b37d430ab1fc70963fb41c845")
         (web-mode :checksum "f70277774a725e177774cc81ecbd228792cd6656")
         (dap-mode :checksum "6933fca0b53ea5d2d65a0545e5a4ae6424d32e9b")
         (lsp-treemacs :checksum "72d367757a89453a712f6ba1df9b6e789ece2bbd")

--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,7 @@
 (setq el-get-lock-package-versions
-      '((tempbuf-mode :checksum "17a005da886436090d3812899d553deb7bdbebb2")
+      '((frame-fns :checksum "b675ee568c0133709c2c39a125395486cdf1c610")
+        (frame-cmds :checksum "3911fbe2b11b8494a14a4d99e989e7e07b243b69")
+        (tempbuf-mode :checksum "17a005da886436090d3812899d553deb7bdbebb2")
         (auto-fix :checksum "783e78f601d0ca42792aff40d6a72434be167900")
         (typescript-mode :checksum "88f317f0b6aef8f8d232e912fdbc679799580c56")
         (yaml :checksum "84b88c9ed178af16da18b230c1f61c57cefedf28")
@@ -126,8 +128,6 @@
         (pcsv :checksum "798e0933f8d0818beb17aebf3b1056bbf74e03d0")
         (google-translate :checksum "0f7f48a09bca064999ecea03102a7c96f52cbd1b")
         (counsel-osx-app :checksum "b1c54cbc033c4939966910d85ce035503079e108")
-        (frame-cmds :checksum "3911fbe2b11b8494a14a4d99e989e7e07b243b69")
-        (frame-fns :checksum "251f37fe805af7a8b3e0e5af9af76263f663a366")
         (el-get :checksum "9353309744e4f8a7c9b1adf22ec99536fb2146b0")
         (dashboard :checksum "7ae46300df5d22d3941ff9f10bc52d232985b628")
         (page-break-lines :checksum "28783cd6b86b3cd41e51e6b2486173e2485a76cc")

--- a/recipes/frame-cmds.rcp
+++ b/recipes/frame-cmds.rcp
@@ -1,0 +1,6 @@
+(:name frame-cmds
+       :website "https://github.com/emacsmirror/frame-cmds"
+       :description "Frame and window commands (interactive functions)."
+       :type github
+       :depends (frame-fns)
+       :pkgname "emacsmirror/frame-cmds")

--- a/recipes/frame-fns.rcp
+++ b/recipes/frame-fns.rcp
@@ -1,0 +1,5 @@
+(:name frame-fns
+       :website "https://github.com/emacsmirror/frame-fns"
+       :description "Non-interactive frame and window functions."
+       :type github
+       :pkgname "emacsmirror/frame-fns")

--- a/recipes/tree-mode.rcp
+++ b/recipes/tree-mode.rcp
@@ -1,0 +1,5 @@
+(:name tree-mode
+       :website "https://github.com/emacsorphanage/tree-mode"
+       :description "A mode to manage tree widgets"
+       :type github
+       :pkgname "emacsorphanage/tree-mode")


### PR DESCRIPTION
本来は EmacsWiki が source なのだが
そうそう更新されなさそうなのと、
GitHub のリポジトリから取得の方が更新チェックしやすいので
そっちから取得されるようにした