### PR TITLE
Flyspell の設定を追加した

### DIFF
--- a/inits/30-flyspell.el
+++ b/inits/30-flyspell.el
@@ -2,3 +2,10 @@
 (with-eval-after-load "ispell"
   (setenv "DICTIONARY" "en_US")
   (add-to-list 'ispell-skip-region-alist '("[^\000-\377]+")))
+
+;; Original: https://takaxp.github.io/init.html#orgdd65fc08
+(defun my/flyspell-ignore-nonascii (beg end _info)
+  "incorrect判定をASCIIに限定"
+  (string-match "[^!-~]" (buffer-substring beg end)))
+
+(add-hook 'flyspell-incorrect-hook #'my/flyspell-ignore-nonascii)

--- a/inits/30-flyspell.el
+++ b/inits/30-flyspell.el
@@ -1,0 +1,4 @@
+;; for hunspell
+(with-eval-after-load "ispell"
+  (setenv "DICTIONARY" "en_US")
+  (add-to-list 'ispell-skip-region-alist '("[^\000-\377]+")))


### PR DESCRIPTION
typo 抑制のため flyspell, ispell を使う設定を追加した。

ispell では裏側で hunspell を使うようにしているため

- hunspell
- hunspell-en_us

を pacman で導入している。