### PR TITLE
my/org-agenda-calendar-files を空でセットしておく

### DIFF
--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -14,6 +14,8 @@
 
 (org-super-agenda-mode 1)
 
+(setq my/org-agenda-calendar-files '()) ;; 今はカレンダー連携していないので空を設定しておく
+
 (setq org-agenda-custom-commands
 '(("h" . "Habits")
   ("hs" "Weekday Start"


### PR DESCRIPTION
この変数は org-agenda の内の2つで利用しているが
未設定で動かないためひとまず空で定義しておくことにした

今はこれに突っ込むような情報も持ってないしね……