### PR TITLE
GitHub で暗号化されてない Git プロトコルは使えなくなったので https に変更

### DIFF
--- a/el-get-lock-update-check.el
+++ b/el-get-lock-update-check.el
@@ -67,7 +67,7 @@
          (type (plist-get recipe :type))
          (pkgname (plist-get recipe :pkgname))
          (url (if (eq type 'github)
-                  (concat "git://github.com/" pkgname ".git")
+                  (concat "https://github.com/" pkgname ".git")
                 (plist-get recipe :url))))
     (if url
         (el-get-lock-update-check-process-hash recipe url checksum)


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/

あたりの影響。

日本語だと
https://naari.hatenablog.com/entry/2022/01/11/140137
あたりが参考になる。

とりあえず https に置き換えておくのが一番安いので
そのように対応した