### PR TITLE
update magit, closql and ghub

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -49,7 +49,7 @@
         (all-the-icons :checksum "68365b48f142d75ef4bdc3a274256d97752e3b65")
         (alert :checksum "7046393272686c7a1a9b3e7f7b1d825d2e5250a6")
         (calfw :checksum "03abce97620a4a7f7ec5f911e669da9031ab9088")
-        (closql :checksum "522cc52a4df6b55099888e89a18f48f7c9275c3d")
+        (closql :checksum "6f4af0fc87fa0a1734480d6a4b72797c0916bc12")
         (company-mode :checksum "d5145006b948f93e673f439a766da01f636d39fc")
         (counsel-projectile :checksum "40d1e1d4bb70acb00fddd6f4df9778bf2c52734b")
         (dash :checksum "7fd71338dce041b352f84e7939f6966f4d379459")

--- a/el-get.lock
+++ b/el-get.lock
@@ -71,7 +71,7 @@
         (flycheck :checksum "55f25fd98abc145c0c464756504132c271f0f039")
         (forge :checksum "bc99603b5a0cd5b3a5f209772b7f818d205b8a3f")
         (fringe-helper :checksum "ef4a9c023bae18ec1ddd7265f1f2d6d2e775efdd")
-        (ghub :checksum "bd6e02b884368f26aeef9fd67107809f355c2c3d")
+        (ghub :checksum "f3a26544575303e86b423a3406656f0e5a576d67")
         (git-gutter :checksum "a50672b62a678922b8c0cab95225d520f493439b")
         (git-gutter-fringe :checksum "648cb5b57faec55711803cdc9434e55a733c3eba")
         (google-this :checksum "8a2e3ca5da6a8c89bfe99a21486c6c7db125dc84")

--- a/el-get.lock
+++ b/el-get.lock
@@ -89,7 +89,7 @@
         (lsp-mode :checksum "f7b363082f28aaf54b354912cd3ad3253a1e5fe4")
         (lsp-ui :checksum "6cd0409de6ca59c02d752b8e543bb5eaa61357e4")
         (major-mode-hydra\.el :checksum "84c1929a5153be169ca5c36737439d51dffde505")
-        (magit :checksum "1b249d4b3dc51b99840e4eb78ba22d9f7d15eee7")
+        (magit :checksum "2235876dd86f24530ec415c30e41a34cec2a8520")
         (markdown-mode :checksum "d2a3d5b8625a7c6be21f19f9146745cd5c791a6a")
         (memoize :checksum "51b075935ca7070f62fae1d69fe0ff7d8fa56fdd")
         (migemo :checksum "f756cba3d5268968da361463c2e29b3a659a3de7")

--- a/recipes/closql.rcp
+++ b/recipes/closql.rcp
@@ -1,0 +1,6 @@
+(:name closql
+       :description "Store EIEIO objects using EmacSQL"
+       :type github
+       :pkgname "emacscollective/closql"
+       :minimum-emacs-version "25.1"
+       :depends (esqlite compat))

--- a/recipes/ghub.rcp
+++ b/recipes/ghub.rcp
@@ -1,0 +1,5 @@
+(:name ghub
+       :type github
+       :description "Minuscule client for the Github API"
+       :pkgname "magit/ghub"
+       :depends (treepy compat))

--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -1,0 +1,21 @@
+(:name magit
+       :website "https://github.com/magit/magit#readme"
+       :description "It's Magit! An Emacs mode for Git."
+       :type github
+       :pkgname "magit/magit"
+       :branch "master"
+       :minimum-emacs-version "25.1"
+       :depends (dash transient with-editor compat)
+       :info "Documentation"
+       :load-path "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.  Create an
+       ;; empty autoloads file because magit.el explicitly checks for
+       ;; a file of that name.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+                ("touch" "lisp/magit-autoloads.el"))
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+                              ("touch" "lisp/magit-autoloads.el"))
+       ;; assume windows lacks make and makeinfo
+       :build/windows-nt (with-temp-file "lisp/magit-autoloads.el" nil))


### PR DESCRIPTION
magit だけ上げようとしたけどエラー吐くようになったから
関連してそうなのを2つ一緒に上げた。

まあその段階でもエラー吐いてたけど Emacs を再起動したら大丈夫だったという……

- [ ] https://github.com/magit/magit/compare/1b249d4b3dc51b99840e4eb78ba22d9f7d15eee7...235876dd86f24530ec415c30e41a34cec2a8520
- [ ] https://github.com/emacscollective/closql/compare/522cc52a4df6b55099888e89a18f48f7c9275c3d...6f4af0fc87fa0a1734480d6a4b72797c0916bc12
- [ ] https://github.com/magit/ghub/compare/bd6e02b884368f26aeef9fd67107809f355c2c3d...f3a26544575303e86b423a3406656f0e5a576d67

あと magit 本体が compat というのに依存しているから
elpa から入れている。
elpa 系は el-get.lock では管理できないので
今後どうしたらいいか悩み中 :thinking: