### PR TITLE
ivy-migemo を追加した

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((frame-cmds :checksum "7c9a30bae30c113e267dee3364e618a682fbaac8")
+      '((ivy-migemo :checksum "f31a2b314b81e328ce0222d8796b808230ddaa0e")
+        (frame-cmds :checksum "7c9a30bae30c113e267dee3364e618a682fbaac8")
         (diminish :checksum "fd486ef76e4c1d8211ae337a43b8bba106d4bca7")
         (tree-mode :checksum "b06078826d5875d74b0e7b7ac47b0d0917610534")
         (frame-fns :checksum "b675ee568c0133709c2c39a125395486cdf1c610")

--- a/hugo/content/basics/migemo.md
+++ b/hugo/content/basics/migemo.md
@@ -46,6 +46,18 @@ apt で cmigemo を入れているのでそれに合わせて辞書の位置を�
 ```
 
 
+## Manjaro での辞書の位置の指定 {#manjaro-での辞書の位置の指定}
+
+yay で cmigemo-git を入れているのでそれに合わせて辞書の位置を指定している。
+
+```emacs-lisp
+;; Manjaro
+(let ((path "/usr/share/migemo/utf-8/migemo-dict"))
+  (if (file-exists-p path)
+      (setq migemo-dictionary path)))
+```
+
+
 ## cmigemo コマンドの PATH 指定 {#cmigemo-コマンドの-path-指定}
 
 環境で PATH が変わるので which コマンドの結果を migemo-command に設定している。

--- a/hugo/content/ui/ivy.md
+++ b/hugo/content/ui/ivy.md
@@ -224,32 +224,59 @@ yank-pop の区切りをちょっと長めにしている。長い方が区切�
 ```
 
 
-### C-s で migemo れるようにする関数設定 {#c-s-で-migemo-れるようにする関数設定}
+### C-s で migemo れるように ivy-migemo を導入・設定 {#c-s-で-migemo-れるように-ivy-migemo-を導入-設定}
 
 swiper は標準だと migemo れないのだが
 
-<https://www.yewton.net/2020/05/21/migemo-ivy/>
+<https://github.com/ROCKTAKEY/ivy-migemo>
 
-でそれをできるようにしている記事があったので、それを元に入れている関数を追加して使えるようにしている。関数名などは書き換えてる
+でそれをできるようにした。
+
+
+#### インストール {#インストール}
 
 ```emacs-lisp
-(defun my/ivy-migemo-re-builder (str)
-  (let* ((sep " \\|\\^\\|\\.\\|\\*")
-         (splitted (--map (s-join "" it)
-                          (--partition-by (s-matches-p " \\|\\^\\|\\.\\|\\*" it)
-                                          (s-split "" str t)))))
-    (s-join "" (--map (cond ((s-equals? it " ") ".*?")
-                            ((s-matches? sep it) it)
-                            (t (migemo-get-pattern it)))
-                      splitted))))
-
-(setq ivy-re-builders-alist '((t . ivy--regex-plus)
-                              (swiper . my/ivy-migemo-re-builder)))
+(:name ivy-migemo
+       :website "https://github.com/ROCKTAKEY/ivy-migemo"
+       :description "Use migemo on ivy."
+       :type github
+       :pkgname "ROCKTAKEY/ivy-migemo")
 ```
 
-なんだけど
-<https://github.com/ROCKTAKEY/ivy-migemo>
-に乗り換えた方がいいのかな〜とも思っている。検証していきたい。
+でレシピを用意して
+
+```emacs-lisp
+(el-get-bundle ivy-migemo)
+```
+
+で入れている。
+
+
+#### キーバインドの設定 {#キーバインドの設定}
+
+以下を入れておくと migemo を使ったり fuzzy を使ったりを切り替えられるようなのでとりあえず設定している。
+
+```emacs-lisp
+(define-key ivy-minibuffer-map (kbd "M-f") #'ivy-migemo-toggle-fuzzy)
+(define-key ivy-minibuffer-map (kbd "M-m") #'ivy-migemo-toggle-migemo)
+```
+
+なおこれは公式に記載されている設定である。
+
+
+#### デフォルトで migemo を有効にする {#デフォルトで-migemo-を有効にする}
+
+swiper を使う時はデフォで有効になっててほしいのでその設定も入れている。なおこれも公式ページに記述されている設定である。
+
+```emacs-lisp
+(setq ivy-re-builders-alist '((t . ivy--regex-plus)
+                              (swiper . ivy-migemo--regex-plus)
+                              (counsel-find-file . ivy-migemo--regex-plus))
+                              ;(counsel-other-function . ivy-migemo--regex-plus)
+                              )
+```
+
+また fuzzy matchi を有効にする設定も記載されているがそちらは自分は設定していない。なんとなく。
 
 
 ## counsel-osx-app. <span class="tag"><span class="improvement">improvement</span></span> {#counsel-osx-app-dot}

--- a/init.org
+++ b/init.org
@@ -543,6 +543,16 @@
       (if (file-exists-p path)
           (setq migemo-dictionary path)))
     #+end_src
+*** Manjaro での辞書の位置の指定
+    yay で cmigemo-git を入れているので
+    それに合わせて辞書の位置を指定している。
+
+    #+begin_src emacs-lisp :tangle inits/10-migemo.el
+    ;; Manjaro
+    (let ((path "/usr/share/migemo/utf-8/migemo-dict"))
+      (if (file-exists-p path)
+          (setq migemo-dictionary path)))
+    #+end_src
 *** cmigemo コマンドの PATH 指定
     環境で PATH が変わるので which コマンドの結果を migemo-command に設定している。
 
@@ -2645,34 +2655,55 @@
      (ivy-rich-mode 1)
      #+end_src
 
-**** C-s で migemo れるようにする関数設定
+**** C-s で migemo れるように ivy-migemo を導入・設定
      swiper は標準だと migemo れないのだが
 
-     https://www.yewton.net/2020/05/21/migemo-ivy/
-
-     でそれをできるようにしている記事があったので、
-     それを元に入れている関数を追加して使えるようにしている。
-     関数名などは書き換えてる
-
-     #+begin_src emacs-lisp :tangle inits/82-ivy.el
-     (defun my/ivy-migemo-re-builder (str)
-       (let* ((sep " \\|\\^\\|\\.\\|\\*")
-              (splitted (--map (s-join "" it)
-                               (--partition-by (s-matches-p " \\|\\^\\|\\.\\|\\*" it)
-                                               (s-split "" str t)))))
-         (s-join "" (--map (cond ((s-equals? it " ") ".*?")
-                                 ((s-matches? sep it) it)
-                                 (t (migemo-get-pattern it)))
-                           splitted))))
-
-     (setq ivy-re-builders-alist '((t . ivy--regex-plus)
-                                   (swiper . my/ivy-migemo-re-builder)))
-     #+end_src
-
-     なんだけど
      https://github.com/ROCKTAKEY/ivy-migemo
-     に乗り換えた方がいいのかな〜とも思っている。
-     検証していきたい。
+
+     でそれをできるようにした。
+
+***** インストール
+      #+begin_src emacs-lisp :tangle recipes/ivy-migemo.rcp
+      (:name ivy-migemo
+             :website "https://github.com/ROCKTAKEY/ivy-migemo"
+             :description "Use migemo on ivy."
+             :type github
+             :pkgname "ROCKTAKEY/ivy-migemo")
+      #+end_src
+
+      でレシピを用意して
+
+      #+begin_src emacs-lisp :tangle inits/82-ivy.el
+      (el-get-bundle ivy-migemo)
+      #+end_src
+
+      で入れている。
+
+***** キーバインドの設定
+      以下を入れておくと migemo を使ったり fuzzy を使ったりを切り替えられるようなので
+      とりあえず設定している。
+
+      #+begin_src emacs-lisp :tangle inits/82-ivy.el
+      (define-key ivy-minibuffer-map (kbd "M-f") #'ivy-migemo-toggle-fuzzy)
+      (define-key ivy-minibuffer-map (kbd "M-m") #'ivy-migemo-toggle-migemo)
+      #+end_src
+
+      なおこれは公式に記載されている設定である。
+
+***** デフォルトで migemo を有効にする
+      swiper を使う時はデフォで有効になっててほしいのでその設定も入れている。
+      なおこれも公式ページに記述されている設定である。
+
+      #+begin_src emacs-lisp :tangle inits/82-ivy.el
+      (setq ivy-re-builders-alist '((t . ivy--regex-plus)
+                                    (swiper . ivy-migemo--regex-plus)
+                                    (counsel-find-file . ivy-migemo--regex-plus))
+                                    ;(counsel-other-function . ivy-migemo--regex-plus)
+                                    )
+      #+end_src
+
+      また fuzzy matchi を有効にする設定も記載されているが
+      そちらは自分は設定していない。なんとなく。
 
 *** counsel-osx-app.                                            :improvement:
     Mac で Emacs を使ってる時に ivy でアプリケーションを起動するためのパッケージ。

--- a/inits/10-migemo.el
+++ b/inits/10-migemo.el
@@ -11,6 +11,11 @@
   (if (file-exists-p path)
       (setq migemo-dictionary path)))
 
+;; Manjaro
+(let ((path "/usr/share/migemo/utf-8/migemo-dict"))
+  (if (file-exists-p path)
+      (setq migemo-dictionary path)))
+
 (let ((path (s-chomp (shell-command-to-string "which cmigemo"))))
   (if (s-ends-with? "not found" path)
       (message "cmigemo not found")

--- a/inits/82-ivy.el
+++ b/inits/82-ivy.el
@@ -90,14 +90,11 @@
 
 (ivy-rich-mode 1)
 
-;; ivy-migemo
 (el-get-bundle ivy-migemo)
 
-;; Toggle migemo and fuzzy by command.
 (define-key ivy-minibuffer-map (kbd "M-f") #'ivy-migemo-toggle-fuzzy)
 (define-key ivy-minibuffer-map (kbd "M-m") #'ivy-migemo-toggle-migemo)
 
-;; If you want to defaultly use migemo on swiper and counsel-find-file:
 (setq ivy-re-builders-alist '((t . ivy--regex-plus)
                               (swiper . ivy-migemo--regex-plus)
                               (counsel-find-file . ivy-migemo--regex-plus))

--- a/inits/82-ivy.el
+++ b/inits/82-ivy.el
@@ -90,18 +90,16 @@
 
 (ivy-rich-mode 1)
 
-(defun my/ivy-migemo-re-builder (str)
-  (let* ((sep " \\|\\^\\|\\.\\|\\*")
-         (splitted (--map (s-join "" it)
-                          (--partition-by (s-matches-p " \\|\\^\\|\\.\\|\\*" it)
-                                          (s-split "" str t)))))
-    (s-join "" (--map (cond ((s-equals? it " ") ".*?")
-                            ((s-matches? sep it) it)
-                            (t (migemo-get-pattern it)))
-                      splitted))))
-
 ;; ivy-migemo
 (el-get-bundle ivy-migemo)
 
+;; Toggle migemo and fuzzy by command.
+(define-key ivy-minibuffer-map (kbd "M-f") #'ivy-migemo-toggle-fuzzy)
+(define-key ivy-minibuffer-map (kbd "M-m") #'ivy-migemo-toggle-migemo)
+
+;; If you want to defaultly use migemo on swiper and counsel-find-file:
 (setq ivy-re-builders-alist '((t . ivy--regex-plus)
-                              (swiper . my/ivy-migemo-re-builder)))
+                              (swiper . ivy-migemo--regex-plus)
+                              (counsel-find-file . ivy-migemo--regex-plus))
+                              ;(counsel-other-function . ivy-migemo--regex-plus)
+                              )

--- a/inits/82-ivy.el
+++ b/inits/82-ivy.el
@@ -100,5 +100,8 @@
                             (t (migemo-get-pattern it)))
                       splitted))))
 
+;; ivy-migemo
+(el-get-bundle ivy-migemo)
+
 (setq ivy-re-builders-alist '((t . ivy--regex-plus)
                               (swiper . my/ivy-migemo-re-builder)))

--- a/recipes/ivy-migemo.rcp
+++ b/recipes/ivy-migemo.rcp
@@ -1,0 +1,5 @@
+(:name ivy-migemo
+       :website "https://github.com/ROCKTAKEY/ivy-migemo"
+       :description "Use migemo on ivy."
+       :type github
+       :pkgname "ROCKTAKEY/ivy-migemo")


### PR DESCRIPTION
swiper で migemo が使えてなかったので
ivy-migemo を入れることで解決を図った。

で、その際に migemo 自体、
Manjaro の  Emacs でうまく扱えるように設定できてなかったので
それも合わせて直している

これで日本語の検索も楽になる。やったねっ