### PR TITLE
appt を使って org-gcal で取得した予定の通知がされるようにした

### DIFF
--- a/hugo/content/org-mode/org-commands.md
+++ b/hugo/content/org-mode/org-commands.md
@@ -9,7 +9,7 @@ weight = 13
 org-mode を使う上で、標準で用意されているコマンド以外に自分でも適当にコマンドを用意しているのでここにまとめている。
 
 
-## org-mode 用のファイルを作成するコマンド {#org-mode-用のファイルを作成するコマンド}
+## org-mode 用のファイルを作成するコマンド <span class="tag"><span class="unused">unused</span></span> {#org-mode-用のファイルを作成するコマンド}
 
 指定したフォルダに org-mode なファイルを作るためのコマンドを用意している。
 
@@ -86,6 +86,18 @@ Hydra から利用するために定義している。"
 (defun my/org-tags-view-only-todo ()
   (interactive)
   (org-tags-view t))
+```
+
+
+## org-gcal で取得した情報を appt に登録 {#org-gcal-で取得した情報を-appt-に登録}
+
+appt.el で通知されるように登録する必要があるのでコマンドを定義している。
+
+```emacs-lisp
+(defun my/org-gcal-refresh-appt ()
+  (interactive)
+  (let ((org-agenda-files my/org-agenda-calendar-files))
+    (org-agenda-to-appt t)))
 ```
 
 

--- a/hugo/content/org-mode/org-gcal.md
+++ b/hugo/content/org-mode/org-gcal.md
@@ -45,6 +45,43 @@ org-gcal が依存しているので [parsist](https://elpa.gnu.org/packages/per
 隠したい部分だけ .authinfo.gpg にでも分離したら公開できるようになるかもしれない。
 
 
+## appt {#appt}
+
+Emacs にはデフォルトで約束の通知ができる機能が appt.el で定義されている。
+org-gcal で取得したデータをそれで通知できるように
+appt の設定をここで行っている
+
+
+### 通知形式の設定 {#通知形式の設定}
+
+window 通知を使う設定にしている。
+
+```emacs-lisp
+(setq appt-display-format 'window)
+```
+
+これだけだと、通知する時間になったらピョコッと window が生えて来るのだけど、後の方で、この設定の時に使う関数を差し替えている
+
+
+### 通知用関数の定義 {#通知用関数の定義}
+
+通知には [alert.el]({{< relref "alert" >}}) を使いたいので自前で関数を定義。
+alert.el は別のところで設定していてそこで dunst を使って通知するようにしている。
+
+```emacs-lisp
+(defun my/appt-alert (min-to-app _new-time msg)
+  (interactive)
+  (let ((title (format "あと %s 分" min-to-app)))
+    (alert msg :title title)))
+```
+
+この関数を使うように `appt-disp-window-function` を変更している。
+
+```emacs-lisp
+(setq appt-disp-window-function 'my/appt-alert)
+```
+
+
 ## その他 {#その他}
 
 [gcal-org](https://github.com/misohena/gcal) に乗り換えようかと思ってるがそっちの中身もよくわからないので躊躇している。自分の用途に合うのだろうか?

--- a/hugo/content/org-mode/org-mode-keybinds.md
+++ b/hugo/content/org-mode/org-mode-keybinds.md
@@ -72,7 +72,7 @@ major-mode-hydra で、org-mode のファイルを開いている時によく使
 | P   | プロパティ設定              | よく使う                            |
 | .   | タイムスタンプ挿入          | 使ってない。使い慣れると便利かも    |
 | !   | アジェンダのエントリに反映されないタイムスタンプ挿入 | 使ってない。こっちも慣れると便利かも? |
-| S   | <s TAB とかのテンプレートの挿入 | 使ってないなあ。慣れたら便利かも    |
+| S   | &lt;s TAB とかのテンプレートの挿入 | 使ってないなあ。慣れたら便利かも    |
 | a   | サブツリーをアーカイブ      | よく使う                            |
 | r   | サブツリーの移動(refile)    | よく使う                            |
 | Q   | タグ設定                    | 時々使う。C-c C-q の方が使うか      |
@@ -116,7 +116,8 @@ pretty-hydra を使って Global に使える org-mode のコマンドを叩け�
 
      "Calendar"
      (("F" org-gcal-fetch "Fetch Calendar")
-      ("C" my/open-calendar "Calendar"))
+      ("C" my/open-calendar "Calendar")
+      ("A" my/org-gcal-refresh-appt "Appt"))
 
      "Clock"
      (("i" org-clock-in       "In")
@@ -132,21 +133,22 @@ pretty-hydra を使って Global に使える org-mode のコマンドを叩け�
      (("p" org-pomodoro "Pomodoro")))))
 ```
 
-| Key | 効果                    | 使用頻度                                      |
-|-----|-----------------------|-------------------------------------------|
-| a   | Agenda 選択             | よく使う                                      |
-| c   | Capture                 | よく使う                                      |
-| l   | その場所へのリンクを保存 | 使ってない                                    |
+| Key | 効果                        | 使用頻度                                      |
+|-----|---------------------------|-------------------------------------------|
+| a   | Agenda 選択                 | よく使う                                      |
+| c   | Capture                     | よく使う                                      |
+| l   | その場所へのリンクを保存    | 使ってない                                    |
 | t   | 選択したタグが付与された TODO のみ表示 | 使ってない。使うと便利かもなあ                |
-| F   | Google Calendar の情報取得 | 平日は毎日使っている                          |
-| C   | カレンダーを calfw で開く | 最近使ってない                                |
-| i   | Clock In                | 使ってないというか major-mode-hydra の方があれば良い |
-| o   | Clock Out               | 使ってない。使ってもいい気がする              |
+| F   | Google Calendar の情報取得  | 平日は毎日使っている                          |
+| C   | カレンダーを calfw で開く   | 最近使ってない                                |
+| A   | org-gcal で拾って来た情報を appt に登録 | appt.el 経由で通知できるようにしている        |
+| i   | Clock In                    | 使ってないというか major-mode-hydra の方があれば良い |
+| o   | Clock Out                   | 使ってない。使ってもいい気がする              |
 | r   | 最後に Clock In したやつを再開 | 使ってない。大体常に Clock しているから最後がいつも切り替わってるので使う機会がない |
-| x   | Clock Cancel            | 作業は発生しているからキャンセルしないで普通に Clock out しているなあ |
+| x   | Clock Cancel                | 作業は発生しているからキャンセルしないで普通に Clock out しているなあ |
 | j   | 最後に Clock In したやつの場所に移動 | ちょくちょく使う。便利                        |
-| H   | Heading の検索          | 使ってない。インクリメンタルに検索できればいいのに |
-| p   | ポモドーロタイマー      | これも major-mode-hydra にあれば十分かな      |
+| H   | Heading の検索              | 使ってない。インクリメンタルに検索できればいいのに |
+| p   | ポモドーロタイマー          | これも major-mode-hydra にあれば十分かな      |
 
 
 ## その他 {#その他}

--- a/hugo/content/ui/alert.md
+++ b/hugo/content/ui/alert.md
@@ -22,14 +22,16 @@ Linux だと libnotify だったりを使ってその環境での標準的な通
 
 ## 設定 {#設定}
 
-業務では Mac を使ってるので terminal-notifier を設定している。他の環境では大人しく message にしている。
+業務では Mac を使ってるので terminal-notifier を設定している。他の環境では libnotify にしている。
 
 ```emacs-lisp
 (if (or (eq window-system 'ns) (eq window-system 'mac))
     (setq alert-default-style 'notifier) ;; use terminal-notifier
-  (setq alert-default-style 'message))
+  (setq alert-default-style 'libnotify))
 ```
+
+「他の環境」が WSL 上の Emacs と Manjaro 上の Emacs なのだけども、後者は最近使ってないので無視して libnotify で通知するように設定を変えた。
 
 本当は WSL2 でもいい感じに通知されるようにしたいが
 [WSLで通知を出すメモ - cobodoのブログ](https://cobodo.hateblo.jp/entry/2018/03/08/160247)
-とかを見てるとちょっと面倒そうなのでまた今度にする。
+とかを見てるとちょっと面倒そう。

--- a/init.org
+++ b/init.org
@@ -1787,17 +1787,20 @@
     #+end_src
 *** 設定
     業務では Mac を使ってるので terminal-notifier を設定している。
-    他の環境では大人しく message にしている。
+    他の環境では libnotify にしている。
 
     #+begin_src emacs-lisp :tangle inits/20-alert.el
     (if (or (eq window-system 'ns) (eq window-system 'mac))
         (setq alert-default-style 'notifier) ;; use terminal-notifier
-      (setq alert-default-style 'message))
+      (setq alert-default-style 'libnotify))
     #+end_src
+
+    「他の環境」が WSL 上の Emacs と Manjaro 上の Emacs なのだけども、
+    後者は最近使ってないので無視して libnotify で通知するように設定を変えた。
 
     本当は WSL2 でもいい感じに通知されるようにしたいが
     [[https://cobodo.hateblo.jp/entry/2018/03/08/160247][WSLで通知を出すメモ - cobodoのブログ]]
-    とかを見てるとちょっと面倒そうなのでまた今度にする。
+    とかを見てるとちょっと面倒そう。
 
 ** all-the-icons
    :PROPERTIES:
@@ -5961,6 +5964,38 @@
 
     隠したい部分だけ .authinfo.gpg にでも分離したら公開できるようになるかもしれない。
 
+*** appt
+    Emacs にはデフォルトで約束の通知ができる機能が appt.el で定義されている。
+    org-gcal で取得したデータをそれで通知できるように
+    appt の設定をここで行っている
+
+**** 通知形式の設定
+     window 通知を使う設定にしている。
+
+     #+begin_src emacs-lisp :tangle inits/61-org-gcal.el
+     (setq appt-display-format 'window)
+     #+end_src
+
+     これだけだと、通知する時間になったらピョコッと window が生えて来るのだけど、
+     後の方で、この設定の時に使う関数を差し替えている
+
+**** 通知用関数の定義
+     通知には [[*alert][alert.el]] を使いたいので自前で関数を定義。
+     alert.el は別のところで設定していて
+     そこで dunst を使って通知するようにしている。
+
+     #+begin_src emacs-lisp :tangle inits/61-org-gcal.el
+     (defun my/appt-alert (min-to-app _new-time msg)
+       (interactive)
+       (let ((title (format "あと %s 分" min-to-app)))
+         (alert msg :title title)))
+     #+end_src
+
+     この関数を使うように ~appt-disp-window-function~ を変更している。
+
+     #+begin_src emacs-lisp :tangle inits/61-org-gcal.el
+     (setq appt-disp-window-function 'my/appt-alert)
+     #+end_src
 *** その他
     [[https://github.com/misohena/gcal][gcal-org]] に乗り換えようかと思ってるが
     そっちの中身もよくわからないので躊躇している。
@@ -6221,6 +6256,17 @@
       (org-tags-view t))
     #+end_src
 
+*** org-gcal で取得した情報を appt に登録
+    appt.el で通知されるように登録する必要があるのでコマンドを定義している。
+
+    #+begin_src emacs-lisp :tangle inits/68-my-org-commands.el
+    (defun my/org-gcal-refresh-appt ()
+      (interactive)
+      (let ((org-agenda-files my/org-agenda-calendar-files))
+        (org-agenda-to-appt t)))
+    #+end_src
+
+
 *** calfw で選択したカレンダーを表示
     #+begin_src emacs-lisp :tangle inits/68-my-org-commands.el
     (defun my/open-calendar ()
@@ -6351,53 +6397,55 @@
     pretty-hydra を使って Global に使える org-mode のコマンドを叩けるようにしている
 
     #+begin_src emacs-lisp :tangle inits/69-org-mode-hydra.el
-    (with-eval-after-load 'pretty-hydra
-      (pretty-hydra-define
-        global-org-hydra
-        (:separator "-"
-                    :color teal
-                    :foreign-key warn
-                    :title (concat (all-the-icons-fileicon "org") " Global Org commands")
-                    :quit-key "q")
-        ("Main"
-         (("a" org-agenda "Agenda")
-          ("c" counsel-org-capture "Capture")
-          ("l" org-store-link "Store link")
-          ("t" my/org-tags-view-only-todo "Tagged Todo"))
+          (with-eval-after-load 'pretty-hydra
+            (pretty-hydra-define
+              global-org-hydra
+              (:separator "-"
+                          :color teal
+                          :foreign-key warn
+                          :title (concat (all-the-icons-fileicon "org") " Global Org commands")
+                          :quit-key "q")
+              ("Main"
+               (("a" org-agenda "Agenda")
+                ("c" counsel-org-capture "Capture")
+                ("l" org-store-link "Store link")
+                ("t" my/org-tags-view-only-todo "Tagged Todo"))
 
-         "Calendar"
-         (("F" org-gcal-fetch "Fetch Calendar")
-          ("C" my/open-calendar "Calendar"))
+               "Calendar"
+               (("F" org-gcal-fetch "Fetch Calendar")
+                ("C" my/open-calendar "Calendar")
+                ("A" my/org-gcal-refresh-appt "Appt"))
 
-         "Clock"
-         (("i" org-clock-in       "In")
-          ("o" org-clock-out      "Out")
-          ("r" org-clock-in-last  "Restart")
-          ("x" org-clock-cancel   "Cancel")
-          ("j" org-clock-goto     "Goto"))
+               "Clock"
+               (("i" org-clock-in       "In")
+                ("o" org-clock-out      "Out")
+                ("r" org-clock-in-last  "Restart")
+                ("x" org-clock-cancel   "Cancel")
+                ("j" org-clock-goto     "Goto"))
 
-         "Search"
-         (("H" org-search-view "Heading"))
+               "Search"
+               (("H" org-search-view "Heading"))
 
-         "Pomodoro"
-         (("p" org-pomodoro "Pomodoro")))))
+               "Pomodoro"
+               (("p" org-pomodoro "Pomodoro")))))
     #+end_src
 
-    | Key | 効果                                   | 使用頻度                                                                            |
-    |-----+----------------------------------------+-------------------------------------------------------------------------------------|
-    | a   | Agenda 選択                            | よく使う                                                                            |
-    | c   | Capture                                | よく使う                                                                            |
-    | l   | その場所へのリンクを保存               | 使ってない                                                                          |
-    | t   | 選択したタグが付与された TODO のみ表示 | 使ってない。使うと便利かもなあ                                                      |
-    | F   | Google Calendar の情報取得             | 平日は毎日使っている                                                                |
-    | C   | カレンダーを calfw で開く              | 最近使ってない                                                                      |
-    | i   | Clock In                               | 使ってないというか major-mode-hydra の方があれば良い                                |
-    | o   | Clock Out                              | 使ってない。使ってもいい気がする                                                    |
-    | r   | 最後に Clock In したやつを再開         | 使ってない。大体常に Clock しているから最後がいつも切り替わってるので使う機会がない |
-    | x   | Clock Cancel                           | 作業は発生しているからキャンセルしないで普通に Clock out しているなあ               |
-    | j   | 最後に Clock In したやつの場所に移動   | ちょくちょく使う。便利                                                              |
-    | H   | Heading の検索                         | 使ってない。インクリメンタルに検索できればいいのに                                  |
-    | p   | ポモドーロタイマー                     | これも major-mode-hydra にあれば十分かな                                            |
+    | Key | 効果                                    | 使用頻度                                                                            |
+    |-----+-----------------------------------------+-------------------------------------------------------------------------------------|
+    | a   | Agenda 選択                             | よく使う                                                                            |
+    | c   | Capture                                 | よく使う                                                                            |
+    | l   | その場所へのリンクを保存                | 使ってない                                                                          |
+    | t   | 選択したタグが付与された TODO のみ表示  | 使ってない。使うと便利かもなあ                                                      |
+    | F   | Google Calendar の情報取得              | 平日は毎日使っている                                                                |
+    | C   | カレンダーを calfw で開く               | 最近使ってない                                                                      |
+    | A   | org-gcal で拾って来た情報を appt に登録 | appt.el 経由で通知できるようにしている                                              |
+    | i   | Clock In                                | 使ってないというか major-mode-hydra の方があれば良い                                |
+    | o   | Clock Out                               | 使ってない。使ってもいい気がする                                                    |
+    | r   | 最後に Clock In したやつを再開          | 使ってない。大体常に Clock しているから最後がいつも切り替わってるので使う機会がない |
+    | x   | Clock Cancel                            | 作業は発生しているからキャンセルしないで普通に Clock out しているなあ               |
+    | j   | 最後に Clock In したやつの場所に移動    | ちょくちょく使う。便利                                                              |
+    | H   | Heading の検索                          | 使ってない。インクリメンタルに検索できればいいのに                                  |
+    | p   | ポモドーロタイマー                      | これも major-mode-hydra にあれば十分かな                                            |
 
 *** その他
     org-agenda 用の Hydra も用意しておいた方が良さそうだなというのが最近の実感。

--- a/inits/20-alert.el
+++ b/inits/20-alert.el
@@ -2,4 +2,4 @@
 
 (if (or (eq window-system 'ns) (eq window-system 'mac))
     (setq alert-default-style 'notifier) ;; use terminal-notifier
-  (setq alert-default-style 'message))
+  (setq alert-default-style 'libnotify))

--- a/inits/61-org-gcal.el
+++ b/inits/61-org-gcal.el
@@ -5,3 +5,13 @@
 (require 'org-gcal)
 
 (my/load-config "my-org-gcal-config")
+
+(setq appt-display-format 'window)
+
+(defun my/appt-alert (min-to-app _new-time msg)
+  (interactive)
+  (let ((title (format "あと %s 分" min-to-app)))
+    (message title)
+    (alert msg :title title)))
+
+(setq appt-disp-window-function 'my/appt-alert)

--- a/inits/61-org-gcal.el
+++ b/inits/61-org-gcal.el
@@ -11,7 +11,6 @@
 (defun my/appt-alert (min-to-app _new-time msg)
   (interactive)
   (let ((title (format "あと %s 分" min-to-app)))
-    (message title)
     (alert msg :title title)))
 
 (setq appt-disp-window-function 'my/appt-alert)

--- a/inits/68-my-org-commands.el
+++ b/inits/68-my-org-commands.el
@@ -34,6 +34,11 @@ Hydra から利用するために定義している。"
   (interactive)
   (org-tags-view t))
 
+(defun my/org-gcal-refresh-appt ()
+  (interactive)
+  (let ((org-agenda-files my/org-agenda-calendar-files))
+    (org-agenda-to-appt t)))
+
 (defun my/open-calendar ()
   (interactive)
   (ivy-read "Calendar: "

--- a/inits/69-org-mode-hydra.el
+++ b/inits/69-org-mode-hydra.el
@@ -61,7 +61,8 @@
 
      "Calendar"
      (("F" org-gcal-fetch "Fetch Calendar")
-      ("C" my/open-calendar "Calendar"))
+      ("C" my/open-calendar "Calendar")
+      ("A" my/org-gcal-refresh-appt "Appt"))
 
      "Clock"
      (("i" org-clock-in       "In")


### PR DESCRIPTION
## 課題

org-gcal で org-mode に連携して org-agenda で確認することはできていた。
しかし予定の時間になってもそれに気付かず作業を続けてしまうことがあった。
そのため通知される必要性を感じたので通知されるようにした

## 解決方法

Emacs 標準で appt.el というものがあり
これを使って時間前になったら通知する、ということができたのでそれを使うようにした。

通知処理は alert.el を使い、そこから dunst を連携させて通知が表示されるようにしている。

## その他

最初は [org-alert](https://github.com/spegoraro/org-alert) を使おうとしたが

- org-alert-check で固まってしまう
- それを無理矢理回避しても実装的に org-gcal のスケジュールを登録してくれない

という罠があったので諦めた。

結果的に、依存が増えずに済んだので良かったとは思う