### PR TITLE
更新のあったパッケージのリストを抽出するスクリプトを追加した

### DIFF
--- a/count-emacs-obsolute-packages.sh
+++ b/count-emacs-obsolute-packages.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+file="/tmp/emacs-outdated-packages.txt"
+current=`date +%s`
+last_modified=`stat -c "%Y" $file`
+
+if [ $(($current-$last_modified)) -gt 3600 ]; then
+    emacs --batch -Q -l ~/.emacs.d/el-get-lock-update-check.el --eval="(el-get-lock-update-check-print-obsolute-only)" > $file
+fi
+
+wc -l $file | cut -d " " -f 1

--- a/el-get-lock-update-check.el
+++ b/el-get-lock-update-check.el
@@ -2,10 +2,15 @@
 
 (defun el-get-lock-update-check-print-list (title list)
   (unless (= (length list) 0)
-    (message (concat "## " title " ##"))
+    (if title
+        (princ (concat "## " title " ##\n")))
     (dolist (list-item list)
-      (message list-item))
-    (message "")))
+      (princ (concat list-item "\n")))))
+
+(defun el-get-lock-update-check-print-obsolute-only ()
+  (let* ((lists (el-get-lock-update-check-assemble-lists))
+         (obsolute-lists (alist-get 'obsolute lists)))
+    (el-get-lock-update-check-print-list nil obsolute-lists)))
 
 (defun el-get-lock-update-check-verbose-print (message)
   (if el-get-lock-update-check-verbose-flag


### PR DESCRIPTION
まず、更新があったパッケージのリストを作る関数
`el-get-lock-update-check-print-obsolute-only` を追加した。

これを以下のように使用すると

```
emacs --batch -Q -l ~/.emacs.d/el-get-lock-update-check.el --eval="(el-get-lock-update-check-print-obsolute-only)"
```

更新のあったパッケージがリストとして標準出力に出力される。

次にそれを利用して、
更新のあったパッケージの数を出力するスクリプトを用意した。

/tmp/emacs-outdated-packages.txt に
更新のあったパッケージのリストを保存しておき
それが十分に新しければその行数をカウントするようにしている。

もし該当ファイルが1時間以上古ければ
リストを作り直すようになっている。

これを i3block で 5 分毎に呼び出すようにするつもり。
諸々更新した直後に /tmp/emacs-outdated-packages.txt を消せば
5分以内に i3block に表示される数も更新されるってわけ。