### PR TITLE
JSX/TSX のインデントを調整

### DIFF
--- a/inits/20-lsp.el
+++ b/inits/20-lsp.el
@@ -3,3 +3,5 @@
 (add-hook 'lsp-mode-hook 'lsp-ui-mode)
 
 (setq lsp-ui-doc-alignment 'window)
+(with-eval-after-load 'lsp-mode
+  (add-to-list 'lsp--formatting-indent-alist `(web-mode . web-mode-code-indent-offset)))


### PR DESCRIPTION
tab 押下時は web-mode-code-indent-offset 等の設定で動いていたが
indent-region ではそれと違う値(4)でインデントされていて
indent-region を使えずにいた

https://github.com/emacs-lsp/lsp-mode/issues/2915#issuecomment-855156802

を参考に
lsp--formatting-indent-aliat に web-mode の設定を追加することで
良い感じにインデントできるように調整した