### PR TITLE
何故か ghub が読み込めないというエラーが出るようになったので回避

### DIFF
--- a/inits/35-magit.el
+++ b/inits/35-magit.el
@@ -1,1 +1,3 @@
 (el-get-bundle magit)
+(with-eval-after-load 'magit
+                      (add-to-list 'load-path (expand-file-name "~/.emacs.d/el-get/ghub/lisp")))


### PR DESCRIPTION
ghub が読み込めないというエラーが出るようになったので
magit が呼ばれた後に load-path を調整することで
とりあえずエラーを回避するようにした