### PR TITLE
TS では flycheck と auto-fix を使わないようにした

### DIFF
--- a/inits/40-ts.el
+++ b/inits/40-ts.el
@@ -1,28 +1,15 @@
 (el-get-bundle typescript-mode)
 
 (custom-set-variables
- '(typescript-indent-level 2))
-
-(defun my/auto-fix-mode-hook-for-ts ()
-  (add-hook 'before-save-hook 'auto-fix-before-save))
-
-(add-hook 'auto-fix-mode-hook 'my/auto-fix-mode-hook-for-ts)
+ '(typescript-indent-level 2)
+ '(lsp-eslint-auto-fix-on-save t))
 
 (defun my/ts-mode-hook ()
   (company-mode 1)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode t)
   (lsp)
-  (lsp-ui-mode 1)
-  (flycheck-mode 1)
-  (setq flycheck-disabled-checkers '(javascript-standard javascript-jshint))
-  (flycheck-add-next-checker 'lsp '(warning . javascript-eslint))
-
-  (let* ((args (list "run" "eslint" "--fix"))
-         (args-string (mapconcat #'shell-quote-argument args " ")))
-    (setq-local auto-fix-option args-string))
-  (setq-local auto-fix-options '("run" "eslint" "--fix"))
-  (setq-local auto-fix-command "yarn"))
+  (lsp-ui-mode 1))
 
 (add-hook 'typescript-mode-hook 'my/ts-mode-hook)
 


### PR DESCRIPTION
flycheck は lsp-mode から eslint の warning が見れるので不要

auto-fix は lsp-eslint-auto-fix-on-save の方が速くて便利だった