### PR TITLE
自動インデントで deep indent にならないようにした

### DIFF
--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -7,7 +7,8 @@
 (with-eval-after-load 'enh-ruby-mode
   (setq enh-ruby-add-encoding-comment-on-save nil)
   (setq enh-ruby-deep-indent-paren nil)
-  (setq enh-ruby-bounce-deep-indent t))
+  (setq enh-ruby-deep-indent-construct nil)
+  (setq enh-ruby-bounce-deep-indent nil))
 
 (defun my/enh-ruby-mode-hook ()
   (company-mode 1)


### PR DESCRIPTION
bounce-deep-indent を t にしていると
deep/shallow を行き来できて便利かと思っていたが
最初は deep indent にされるのでむしろ不便だった

deep-indent-construct は nil にすることで

```
private def hoge
  # ここのインデントの調整
end
```

のような場合に deep indent にならないようにするため