### PR TITLE
set rspec-use-docker-when-possible t

### DIFF
--- a/inits/42-rspec.el
+++ b/inits/42-rspec.el
@@ -3,3 +3,6 @@
 (add-hook 'after-init-hook 'inf-ruby-switch-setup)
 
 (define-key rspec-mode-map (kbd "C-c C-c") 'rspec-verify-single)
+
+(custom-set-variables
+ '(rspec-use-docker-when-possible t))


### PR DESCRIPTION
Docker 経由で rspec が実行できるならそうする、という設定を書いた

プロジェクトの .dir-locals に
rspec-spec-command などは設定している