### PR TITLE
todoist の token を authinfo から読むようにした

### DIFF
--- a/inits/50-todoist.el
+++ b/inits/50-todoist.el
@@ -1,4 +1,4 @@
 (el-get-bundle emacs-todoist)
 
-(with-eval-after-load 'org
-  (my/load-config "my-todoist-config"))
+(with-eval-after-load 'todoist
+  (setq todoist-token (funcall (plist-get (nth 0 (auth-source-search :host "todoist.com" :max 1)) :secret))))


### PR DESCRIPTION
emacs-todoist を再活用しようと思って対応