### PR TITLE
org-protocol を org-modules に追加

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -11,6 +11,8 @@
 (setq org-log-into-drawer "LOGBOOK")
 
 (with-eval-after-load 'org
+  (require 'org-protocol)
+  (add-to-list 'org-modules 'org-protocol)
   (add-to-list 'org-file-apps '("\\.xlsx?\\'" . default)))
 
 (org-babel-do-load-languages 'org-babel-load-languages


### PR DESCRIPTION
Firefox から org-capture で突っ込みあかったが
それがうまく設定できていなかった。

原因は org-mode で org-protocol が使えるようになっていなかったため