### PR TITLE
org-capture で inbox に入れる時にタグを指定できるようにした

### DIFF
--- a/inits/61-org-capture.el
+++ b/inits/61-org-capture.el
@@ -15,7 +15,7 @@
 (setq org-capture-templates
       `(("g" "Inbox にエントリー" entry
          (file ,my/org-capture-inbox-file)
-         "* TODO %?\n** Ready の定義
+         "* TODO %? %^G\n** Ready の定義
    - Why?, Goal, How? が埋められていること
    - How がある程度具体的に書かれていること
 ** Why?


### PR DESCRIPTION
capture する時にタグ補完ができないのが気になっていたが
capture 起動時に選択できる機能があったのでそれを使うようにした
org-capture-templates のヘルプに書いていた