### PR TITLE
GitHub Actions で使う Emacs のバージョンを調整

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 28.1
+        version: 28.2
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
           - 26.3
           - 27.1
           - 27.2
+          - 28.1
+          - 28.2
 
     steps:
     - uses: purcell/setup-emacs@master

--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 28.1
+        version: 28.2
 
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
手元の Emacs が 28.2 になっているので
基本的にはそれを使うようにした。
テストではとりあえず 28.1 と 28.2 を追加している