### PR TITLE
Use ace-window-posframe-mode

### DIFF
--- a/inits/20-ace-window.el
+++ b/inits/20-ace-window.el
@@ -1,1 +1,4 @@
 (el-get-bundle ace-window)
+
+(with-eval-after-load 'ace-window
+  (ace-window-posframe-mode t))


### PR DESCRIPTION
ace-window-posframe-mode が気に入ったので
Emacs 起動時に有効にするようにした