### PR TITLE
org-gcal の sync の unlock がされた時に appt を更新するようにした

### DIFF
--- a/inits/61-org-gcal.el
+++ b/inits/61-org-gcal.el
@@ -14,3 +14,5 @@
     (alert msg :title title)))
 
 (setq appt-disp-window-function 'my/appt-alert)
+
+(advice-add #'org-gcal--sync-unlock :after #'my/org-refresh-appt)


### PR DESCRIPTION
org-gcal-fetch で情報を取得する際には
deffered で非同期処理されるので
その非同期処理の中で呼び出される関数に advice を付けることで
org-gcal-fetch でカレンダーの情報が登録された後に
自動で appt を更新するようにした