### PR TITLE
set-output を使うのは deprecated なので修正した

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         packages=$(cat /tmp/emacs-outdated-packages.txt | jq -R -s -c 'split("\n")[:-1]')
         echo $packages
-        echo "::set-output name=value::${packages}"
+        echo "packages=${packages}" >> $GITHUB_OUTPUT
 
   call-update-workflow:
     needs: check-updates

--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -41,7 +41,7 @@ jobs:
         body="${body//'%'/'%25'}"
         body="${body//$'\n'/'%0A'}"
         body="${body//$'\r'/'%0D'}"
-        echo ::set-output name=body::$body
+        echo "body=${body}" >> $GITHUB_OUTPUT
 
     - if: env.found_update == 1
       name: Create PR


### PR DESCRIPTION
ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/