### PR TITLE
org-agenda の設定を更新

### DIFF
--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -166,11 +166,9 @@
   ("X" "Finished"
    ((todo "DONE"    ((org-agenda-files '("~/Documents/org/tasks/projects.org"
                                          "~/Documents/org/tasks/inbox.org"
-                                         "~/Documents/org/tasks/shopping.org"
                                          "~/Documents/org/tasks/next-actions.org"))))
     (todo "SOMEDAY" ((org-agenda-files '("~/Documents/org/tasks/projects.org"
                                          "~/Documents/org/tasks/inbox.org"
-                                         "~/Documents/org/tasks/shopping.org"
                                          "~/Documents/org/tasks/next-actions.org"))))))
   ("S" "Stocks"
    ((alltodo ""

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -108,6 +108,7 @@
                 (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                            (:name "今日予定の作業" :scheduled today)
                                            (:discard (:anything t))))))))
+
   ("p" . "Projects")
   ("pp" "Projects"
    ((alltodo "" ((org-agenda-prefix-format " ")

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -170,19 +170,6 @@
     (todo "SOMEDAY" ((org-agenda-files '("~/Documents/org/tasks/projects.org"
                                          "~/Documents/org/tasks/inbox.org"
                                          "~/Documents/org/tasks/next-actions.org"))))))
-  ("S" "Stocks"
-   ((alltodo ""
-             ((org-agenda-prefix-format " ")
-              (org-agenda-overriding-header "ストック確認")
-              (org-habit-show-habits nil)
-              (org-agenda-span 'day)
-              (org-agenda-todo-keyword-format "-")
-              (org-overriding-columns-format "%25ITEM %TODO")
-              (org-agenda-files '("~/Documents/org/tasks/stocks.org"))
-              (org-super-agenda-groups '((:name "チェック日が過ぎているもの" :scheduled past)
-                                         (:name "今日チェック予定のもの" :scheduled today)
-                                         (:discard (:anything t))))))))
-
   ("z" "日報"
    ((agenda "" ((org-agenda-span 'day)
                 (org-agenda-overriding-header "")


### PR DESCRIPTION
買い物リストやストックの確認は todoist で行うことにしたので
org-agenda から見ないようにした