### PR TITLE
update magit

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -98,7 +98,7 @@
         (lsp-mode :checksum "6b01d49757994c09c90623bf67f072d02f00f8e9")
         (lsp-ui :checksum "295d8984da06a745b0a36c56e28ce915bc389adb")
         (major-mode-hydra\.el :checksum "84c1929a5153be169ca5c36737439d51dffde505")
-        (magit :checksum "8fd16d34068c54c1a0a6edcdccf60be1075a6915")
+        (magit :checksum "b908c79b44f5c282eec44f19fc1d9967f041dd5c")
         (markdown-mode :checksum "0f7eae811308f92b8681b5411f7a5035d1fcd5a7")
         (memoize :checksum "51b075935ca7070f62fae1d69fe0ff7d8fa56fdd")
         (migemo :checksum "f756cba3d5268968da361463c2e29b3a659a3de7")


### PR DESCRIPTION
https://github.com/magit/magit/compare/8fd16d34068c54c1a0a6edcdccf60be1075a6915...b908c79b44f5c282eec44f19fc1d9967f041dd5c

compat 29 対応版にとりあえず上げる。