### PR TITLE
mocha を Emacs 上から実行できるようにした

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((pdf-tools :checksum "b8079e4ebc2936f9772657332d50936350a65825")
+      '((mocha :checksum "6a72fa20e7be6e55c09b1bc9887ee09c5df28e45")
+        (pdf-tools :checksum "b8079e4ebc2936f9772657332d50936350a65825")
         (tablist :checksum "faab7a035ef2258cc4ea2182f67e3aedab7e2af9")
         (aio :checksum "da93523e235529fa97d6f251319d9e1d6fc24a41")
         (git-messenger :checksum "eade986ef529aa2dac6944ad61b18de55cee0b76")

--- a/inits/40-mocha.el
+++ b/inits/40-mocha.el
@@ -1,0 +1,6 @@
+(el-get-bundle mocha)
+
+(defun my/mocha-test-file ()
+  (interactive)
+  (if my/mocha-enable-p
+      (mocha-test-file)))

--- a/inits/40-ts.el
+++ b/inits/40-ts.el
@@ -4,6 +4,10 @@
  '(typescript-indent-level 2)
  '(lsp-eslint-auto-fix-on-save t))
 
+(defun my/setup-ts-mode-keymap ()
+  (let ((keymap typescript-mode-map))
+    (define-key keymap (kbd "C-c C-c") 'my/mocha-test-file)))
+
 (defun my/ts-mode-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "ts")
     (lsp-eslint-fix-all)))
@@ -14,7 +18,8 @@
   (display-line-numbers-mode t)
   (lsp)
   (lsp-ui-mode 1)
-  (add-hook 'before-save-hook #'my/ts-mode-auto-fix-hook nil 'local))
+  (add-hook 'before-save-hook #'my/ts-mode-auto-fix-hook nil 'local)
+  (my/setup-ts-mode-keymap))
 
 (add-hook 'typescript-mode-hook 'my/ts-mode-hook)
 

--- a/inits/41-react.el
+++ b/inits/41-react.el
@@ -4,6 +4,10 @@
 
 (add-to-list 'auto-mode-alist '("\\.[jt]sx" . web-mode))
 
+(defun my/setup-web-mode-map ()
+  (let ((keymap web-mode-map))
+    (define-key keymap (kbd "C-c C-c") 'my/mocha-test-file)))
+
 (defun my/web-mode-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "tsx")
     (lsp-eslint-fix-all)))
@@ -19,8 +23,7 @@
       (display-line-numbers-mode t)
       (lsp)
       (lsp-ui-mode 1)
-      (add-hook 'before-save-hook 'my/web-mode-auto-fix-hook nil 'local))))
-
-
+      (add-hook 'before-save-hook 'my/web-mode-auto-fix-hook nil 'local)
+      (my/setup-web-mode-map))))
 
 (add-hook 'web-mode-hook 'my/web-mode-tsx-hook)


### PR DESCRIPTION
# 概要

mocha のテストファイル上で `C-c C-c` と叩いたら
mocha のテストが実行できるようにした

# 課題

mocha でテストを書いている環境があるが
Emacs 上からは実行ができず
毎度 Terminal 上から実行していて、面倒だった

# 解決方法

mocha.el を導入し、テストファイルの上で `C-c C-c` を叩くことで
そのテストファイルが実行されるようにした

# 使い方

各プロジェクトで適切に

- mocha-which-node
- mocha-command
- mocha-environment-variables

を設定した上で
テストファイル上で `my/mocha-enable-p` が `t` になるようにする。

typescript-mode 及び web-mode で
`my/mocha-enable-p` が有効な場合は `C-c C-c` で `mocha-test-file` が実行できるようにしているので
それらのあたりでそうやってテストが走れば OK

# 対応してないこと

本当は mocha-test-at-point でその部分だけ実行したかったが
mocha.el は構文解析を js2-mode に頼っていて
それが使える環境じゃないと mocha-test-at-point が使えない様子。

js2-mode は minor-mode もあるので
もしかしたら typescript-mode と併用することもできるかもしれないが
一旦はそこまで調査するのは諦めている。面倒なので。