### PR TITLE
Swiper では ivy-posframe を使わないようにした

### DIFF
--- a/inits/82-ivy.el
+++ b/inits/82-ivy.el
@@ -23,7 +23,9 @@
 (counsel-mode 1)
 
 (el-get-bundle ivy-posframe)
-(setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display-at-frame-center)))
+(setq ivy-posframe-display-functions-alist
+      '((swiper . ivy-display-function-fallback)
+        (t . ivy-posframe-display-at-frame-center)))
 (ivy-posframe-mode 1)
 
 (el-get-bundle ivy-rich)


### PR DESCRIPTION
Swiper で ivy-posframe を使っていると
探している最中のコードも posframe に隠れるので邪魔だった