### PR TITLE
よく使うタグがついてない projects を抽出する agenda を追加

### DIFF
--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -161,6 +161,8 @@
                                             (:name "今日予定の作業" :scheduled today)
                                             (:discard (:anything t))))))
     (tags-todo "-Emacs-org-Env-Hugo" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
+  ("pN" "No major tags"
+   ((tags-todo "-Emacs-org-Env-Hugo-Kibela-Develop-ReviewLister-HouseWork-Private" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
   ("P" "Pointers"
    ((todo "DOING" ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))
     (todo "TODO"  ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))))


### PR DESCRIPTION
タグが付与されてないやつを抽出したかったけど
それはちょっと厳しそうだったのでこれで対応

タグが付与されてないやつを抽出したかったのは、
タグがついてないやつにタグをつけてまわりたかったので