### PR TITLE
SKK の個人辞書保存時にサイズ比較をしないようにした

### DIFF
--- a/inits/30-skk.el
+++ b/inits/30-skk.el
@@ -17,6 +17,8 @@
             (setq skk-henkan-strict-okuri-precedence t)
             (setq skk-show-annotation t) ;; 単語の意味をアノテーションとして表示。例) いぜん /以前;previous/依然;still/
             (setq skk-compare-jisyo-size-when-saving nil)
+            (setq skk-extra-jisyo-file-list
+                  `(,(expand-file-name "~/.config/ibus-skk/user.dict")))
 
             ;; ;; 半角で入力したい文字
             ;; (setq skk-rom-kana-rule-list

--- a/inits/30-skk.el
+++ b/inits/30-skk.el
@@ -16,6 +16,7 @@
             (setq skk-sticky-key ";")
             (setq skk-henkan-strict-okuri-precedence t)
             (setq skk-show-annotation t) ;; 単語の意味をアノテーションとして表示。例) いぜん /以前;previous/依然;still/
+            (setq skk-compare-jisyo-size-when-saving nil)
 
             ;; ;; 半角で入力したい文字
             ;; (setq skk-rom-kana-rule-list


### PR DESCRIPTION
最近やたら出て来て邪魔なので……。

最近やたら出るのは多分 ibus-skk からも
ユーザー辞書として参照するようにしたからだと思うけどね……

----

追加で ddskk の個人辞書を ibus-skk からはシステム辞書として参照するようにして
ddskk からは ibus-skk の個人辞書を extra 辞書として参照するようにした。

これで互いの辞書を勝手に書き換えずに、互いの変換候補を参照できるようになる。はず