### PR TITLE
Override windmove-mode map on org-mode

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -45,3 +45,21 @@
         (my/org-refresh-appt))))
 
 (add-hook 'org-trigger-hook 'my/org-refresh-appt-on-complete-habit)
+
+(defun my/org-mode-map-override-windmove-mode-map ()
+  (let ((oldmap windmove-mode-map)
+        (newmap (make-sparse-keymap)))
+    (make-local-variable 'minor-mode-overriding-map-alist)
+    (add-to-list 'minor-mode-overriding-map-alist `(windmove-mode . ,newmap))
+
+    (add-hook 'org-shiftup-final-hook 'windmove-up)
+    (add-hook 'org-shiftleft-final-hook 'windmove-left)
+    (add-hook 'org-shiftdown-final-hook 'windmove-down)
+    (add-hook 'org-shiftright-final-hook 'windmove-right)))
+
+(add-hook 'org-mode-hook
+          (lambda ()
+            (my/org-mode-map-override-windmove-mode-map)))
+
+(with-eval-after-load 'org-mode
+  (my/org-mode-map-override-windmove-mode-map))


### PR DESCRIPTION
org-mode 内でも windmove の機能を使いつつ
priority の変更などができるようにしたかったので調整した

org-mode で org-shiftup などで
何かしら機能が提供されている場合はそれを動かし、
そうでない場合は windmove が動くようにしている