### PR TITLE
Ruby のファイルを保存する時に自動フォーマットするようにした

### DIFF
--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -14,6 +14,7 @@
   (company-mode 1)
   (lsp)
   (lsp-ui-mode 1)
+  (add-hook 'before-save-hook #'lsp-format-buffer)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode 1))
 

--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -23,7 +23,7 @@
 (add-to-list 'context-skk-programming-mode 'enh-ruby-mode)
 
 (with-eval-after-load 'major-mode-hydra
-  (major-mode-hydra-define enh-ruby-mode (:quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
+  (major-mode-hydra-define enh-ruby-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
     ("Enh Ruby"
      (("{" enh-ruby-toggle-block "Toggle block")
       ("e" enh-ruby-insert-end "Insert end"))


### PR DESCRIPTION
# 課題

Ruby のファイル編集後に自動で整形されなかったので自分で修正していた。

まあ lsp-format-buffer を叩けば format されるんだけど
そんなコマンド存在を忘れますしおすし。

# その他

Emacs の外の世界の話になるけど
solargraph がちゃんと立ち上がるように
プロジェクトのフォルダで bundle install しておいた

あとついでに major-mode-hydra の separator を扱いやすいやつに変えておいた。