### PR TITLE
Enable flycheck-textlint for forge-post-mode/magit-commit-create

### DIFF
--- a/inits/40-textlint.el
+++ b/inits/40-textlint.el
@@ -1,5 +1,42 @@
 (custom-set-variables
   '(flycheck-textlint-config "~/.config/textlint/textlintrc_ja.json"))
 
+(defun my/magit-commit-create-after ()
+  (flycheck-select-checker 'textlint-no-extension))
+
 (with-eval-after-load 'flycheck
-  (flycheck-add-mode 'textlint 'forge-post-mode))
+  (flycheck-add-mode 'textlint 'forge-post-mode)
+  (flycheck-define-checker textlint-no-extension
+  "A text prose linter using textlint.
+
+See URL `https://textlint.github.io/'."
+  :command ("textlint"
+            "--stdin"
+            "--stdin-filename" (eval (concat buffer-file-name ".txt"))
+            (config-file "--config" flycheck-textlint-config)
+            "--format" "json"
+            ;; get the first matching plugin from plugin-alist
+            "--plugin"
+            (eval (flycheck--textlint-get-plugin)))
+  :standard-input t
+  ;; textlint seems to say that its json output is compatible with ESLint.
+  ;; https://textlint.github.io/docs/formatter.html
+  :error-parser flycheck-parse-eslint
+  ;; textlint can support different formats with textlint plugins, but
+  ;; only text and markdown formats are installed by default. Ask the
+  ;; user to add mode->plugin mappings manually in
+  ;; `flycheck-textlint-plugin-alist'.
+  :modes
+  (forge-post-mode text-mode)
+  :enabled
+  (lambda () (and (flycheck--textlint-get-plugin) (null (file-name-extension buffer-file-name))))
+  :verify
+  (lambda (_)
+    (let ((plugin (flycheck--textlint-get-plugin)))
+      (list
+       (flycheck-verification-result-new
+        :label "textlint plugin"
+        :message plugin
+        :face 'success)))))
+  (add-to-list 'flycheck-checkers 'textlint-no-extension)
+  (advice-add 'magit-commit-create :after 'my/magit-commit-create-after))

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -47,6 +47,7 @@
    "Behavior"
    (("S" my/notify-slack-toggle    "Notify Slack"   :toggle my/notify-slack-enable-p)
     ("v" my/toggle-view-mode       "Readonly"       :toggle view-mode)
+    ("f" flycheck-mode             "Flycheck"       :toggle flycheck-mode)
     ("A" auto-fix-mode             "Auto fix"       :toggle auto-fix-mode)
     ("E" toggle-debug-on-error     "Debug on error" :toggle debug-on-error))))
 


### PR DESCRIPTION
# 概要

forge-post-mode や magit-commit-create の時にも
flycheck で textlint を走らせることができるようにした

ただし自動で flycheck が ON になるわけではないので
ひとまずは toggle-hydra で toggle する運用とする

# 目的

commit message を書く時とか PR を作る時などに
flycheck でチェックしてもらえると便利そうだなって。

# 対応内容詳細

## forge-post-mode や magit-commit-create の時にも flycheck で textlint を動かせるようにした

こっちが変更の中心。

magit-commit-create で動くバッファは text-mode だし
forge-post-mode も gfm-mode ベースなので
textlint は動かしてもまあ問題ないはず。

なのだけどそれらの時に編集されるのは COMMIT_MESSAGE とか new-pullreq とかいうファイル名なため
それらは拡張子がない。

textlint 自体が拡張子のないファイルでは動かない、という制限があるので
回避策としてバッファの内容は標準入力で渡しておいて
`--stdin` と `--stdin-filename` オプションを使うことで回避する、というのが提示されていた
ref: `textlint/textlint/issues/577`

というわけで拡張子がないそれらのファイルのために
その回避策を取り入れた textlint-no-extension という flycheck の checker を追加することで
flycheck を使えるようにした

## toggle-hydra で flycheck を toggle できるようにした

これは flycheck を自動で ON にする方法を調べるのが面倒だったので
とりあえず運用ができるようにしようということで入れておいた

まああれですよ。
toggle できると便利なはずなので OK

# 対応してないこと

上にも書いているけど自動で flycheck-mode が ON になるようにはしてない。
そこまで調べる気力はもうないのだ