### PR TITLE
JSON 編集用に設定を弄った

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,8 @@
 (setq el-get-lock-package-versions
-      '((orgit :checksum "fc40397f7b36fa513d41f3119b7430cb236de9dd")
+      '((json-mode :checksum "eedb4560034f795a7950fa07016bd4347c368873")
+        (json-snatcher :checksum "b28d1c0670636da6db508d03872d96ffddbc10f2")
+        (json-reformat :checksum "9120ab67c5379c44bc7a7a07ca858670cea4f32f")
+        (orgit :checksum "fc40397f7b36fa513d41f3119b7430cb236de9dd")
         (org-contrib :checksum "223390ea2c2f728ca4bfd1c4a33cac25d003693a")
         (mocha :checksum "6a72fa20e7be6e55c09b1bc9887ee09c5df28e45")
         (pdf-tools :checksum "bc2ba117e8c3196ff9adf0da4fa1e63a8da3d7c8")

--- a/inits/40-json.el
+++ b/inits/40-json.el
@@ -1,1 +1,14 @@
 (el-get-bundle json-mode)
+
+(defun my/json-mode-hook ()
+  (company-mode 1)
+  (lsp)
+  (lsp-ui-mode 1)
+  (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)
+  (turn-on-smartparens-strict-mode)
+  (flycheck-mode 1)
+  (flycheck-select-checker 'json-jq)
+  (highlight-indent-guides-mode 1)
+  (display-line-numbers-mode 1))
+
+(add-hook 'json-mode-hook 'my/json-mode-hook)

--- a/inits/40-json.el
+++ b/inits/40-json.el
@@ -1,0 +1,1 @@
+(el-get-bundle json-mode)


### PR DESCRIPTION
これまで JSON を弄る時は javascript-mode 任せだったが
まあ色々つらいので色々なサポートを受けられるようにした

- lsp-mode で現在位置の key を header に表示させるようにした
- smartparens-strict-mode の利用。これでカッコが崩れない
- flycheck で json-jq を使うようにした。lsp では微妙だったので
- highlight-indent-guides-mode を使う。どこにいるかわからんので
- 行数も表示するようにした