### PR TITLE
Change skk-tooltip color

### DIFF
--- a/inits/30-skk.el
+++ b/inits/30-skk.el
@@ -21,6 +21,8 @@
                   `(,(expand-file-name "~/.config/ibus-skk/user.dict")
                     "/usr/share/skk/SKK-JISYO.propernoun"
                     "/usr/share/skk/SKK-JISYO.lisp"))
+            (setq skk-tooltip-parameters
+                  '((background-color . "#323445")))
 
             ;; ;; 半角で入力したい文字
             ;; (setq skk-rom-kana-rule-list


### PR DESCRIPTION
背景色と文字色が近くて読めなかったので読めるようにしている。
Emacs の全体の背景色がダーク系なのでそれに合わせている