### PR TITLE
forge-post-mode 起動時に flycheck を有効にする

### DIFF
--- a/inits/36-forge.el
+++ b/inits/36-forge.el
@@ -2,3 +2,9 @@
 
 (with-eval-after-load 'magit
   (require 'forge))
+
+(defun my/forge-post-mode-hook ()
+  (flycheck-mode 1))
+
+(with-eval-after-load 'forge
+  (add-hook 'forge-post-mode-hook 'my/forge-post-mode-hook))


### PR DESCRIPTION
PR 作る時に textlint でチェックしてほしいので

今この PR を書く時にも有効になっているので良き