### PR TITLE
新しく取得した PR に TODO keyword を追加

### DIFF
--- a/inits/65-org-reviews.el
+++ b/inits/65-org-reviews.el
@@ -87,7 +87,7 @@
   (if (eq (plist-get saved :number) (plist-get fetched :number))
       (let* ((number (plist-get saved :number))
              (title (plist-get fetched :title))
-             (todo-keyword (plist-get saved :todo-keyword))
+             (todo-keyword (or (plist-get saved :todo-keyword) (plist-get fetched :todo-keyword)))
              (text (or (plist-get saved :text) (plist-get fetched :text)))
              (tags (or (plist-get saved :tags) (plist-get fetched :tags)))
              (source (plist-get saved :source)))


### PR DESCRIPTION
バグ修正。
merge 前は設定していたけど merge 時に捨てちゃっていた