### PR TITLE
Enable org on org-babel

### DIFF
--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -22,6 +22,7 @@
                                (emacs-lisp . t)
                                (shell . t)
                                (js . t)
+                               (org . t)
                                (ruby . t)))
 
 (add-hook 'org-babel-after-execute-hook 'org-redisplay-inline-images)

--- a/inits/65-org-reviews.el
+++ b/inits/65-org-reviews.el
@@ -79,7 +79,6 @@
 
 (defun my/org-reviews-done (saved)
   (plist-put saved :todo-keyword "DONE")
-  (message "done")
   saved)
 
 (defun my/org-reviews-merge (saved fetched)


### PR DESCRIPTION
org-babel-load-language で
org-mode も明示的に有効化した

あとついでに不要な message を削除した