### PR TITLE
Add emacs-openai and codes

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,8 @@
 (setq el-get-lock-package-versions
-      '((keypression :checksum "9427241f3fa539e4b5ad7581a05eb7e49f2cf518")
+      '((emacs-openai :checksum "b7d0a0b8e701afd40e0031707f845072679d0232")
+        (tblui :checksum "bb29323bb3e27093d50cb42db3a9329a096b6e4d")
+        (magit-popup :checksum "d8585fa39f88956963d877b921322530257ba9f5")
+        (keypression :checksum "9427241f3fa539e4b5ad7581a05eb7e49f2cf518")
         (noflet :checksum "7ae84dc3257637af7334101456dafe1759c6b68a")
         (emacs-kibela :checksum "d368594c6f908a1cc7bac0b4234330cc2e4b22ec")
         (which-key :checksum "8093644032854b1cdf3245ce4e3c7b6673f741bf")

--- a/inits/50-openai.el
+++ b/inits/50-openai.el
@@ -1,1 +1,46 @@
 (el-get-bundle emacs-openai)
+
+(setq openai-user (plist-get (nth 0 (auth-source-search :host "api.openai.com")) :user))
+(setq openai-key (funcall (plist-get (nth 0 (auth-source-search :host "api.openai.com")) :secret)))
+
+(defvar-local my/openai-result nil)
+
+(defun my/openai-completion-from-prompt (input)
+  (interactive "sText: ")
+  (openai-completion input
+                     (lambda (data)
+                       (let* ((choices (openai--data-choices data))
+                              (result (openai--get-choice choices)))
+                         (message "result: %s" result))) :max-tokens 2000))
+
+(defun my/openai-observe (buf end)
+  (cond
+   (my/openai-result
+    (save-current-buffer
+      (set-buffer (get-buffer buf))
+      (goto-char end)
+      (insert my/openai-result)
+      (setq my/openai-result nil)
+      (my/openai-stop-observe)))
+   (t
+    nil)))
+
+(defvar my/openai-observe-timer nil)
+
+(defun my/openai-start-observe (buf end)
+  (setq my/openai-observe-timer
+        (run-with-idle-timer 0.5 t 'my/openai-observe buf end)))
+
+(defun my/openai-stop-observe ()
+  (cancel-timer my/openai-observe-timer))
+
+(defun my/openai-completion-from-region (begin end)
+  (interactive "r")
+  (my/openai-start-observe (current-buffer) end)
+  (openai-completion (buffer-substring-no-properties begin end)
+                     (lambda (data)
+                       (let* ((choices (openai--data-choices data))
+                              (result (openai--get-choice choices)))
+                         (setq my/openai-result result)))
+                     :max-tokens 4000)
+  (deactivate-mark t))

--- a/inits/50-openai.el
+++ b/inits/50-openai.el
@@ -1,0 +1,1 @@
+(el-get-bundle emacs-openai)

--- a/recipes/emacs-openai.rcp
+++ b/recipes/emacs-openai.rcp
@@ -1,0 +1,7 @@
+(:name emacs-openai
+       :website "https://github.com/emacs-openai/openai"
+       :description "Elisp library for the OpenAI API."
+       :type github
+       :branch "master"
+       :pkgname "emacs-openai/openai"
+       :depends (request tblui))

--- a/recipes/tblui.rcp
+++ b/recipes/tblui.rcp
@@ -1,0 +1,7 @@
+(:name tblui
+       :website "https://github.com/Yuki-Inoue/tblui.el"
+       :description "Define tabulated-list based UI easily."
+       :type github
+       :branch "master"
+       :pkgname "Yuki-Inoue/tblui.el"
+       :depends (dash magit-popup tablist))


### PR DESCRIPTION
Emacs から OpenAI の API を叩くため
emacs-openai を導入した。

そして実際に叩いて補完処理ができるように
設定とコードを書いておいた