### PR TITLE
Add nerd-fonts

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((copilot :checksum "8256377a77b1268a9ea5d470c59a05d26ff5b432")
+      '((nerd-icons :checksum "aec48fe8e5296fa8367fcdc988ab846651d9e82a")
+        (copilot :checksum "8256377a77b1268a9ea5d470c59a05d26ff5b432")
         (json-rpc :checksum "81a5a520072e20d18aeab2aac4d66c046b031e56")
         (editorconfig :checksum "ed3defaad8d83f77cfee581cfaa19aaea016664d")
         (emacs-sqlite3-api :checksum "b513b71012f61895f771fc6948d6511ea8ded0a6")

--- a/inits/20-nerd-icons.el
+++ b/inits/20-nerd-icons.el
@@ -1,0 +1,2 @@
+(el-get-bundle nerd-icons)
+(require 'nerd-icons)

--- a/recipes/nerd-icons.rcp
+++ b/recipes/nerd-icons.rcp
@@ -1,0 +1,6 @@
+(:name nerd-icons
+       :website "https://github.com/rainstormstudio/nerd-icons.el"
+       :description "A Library for Nerd Font icons."
+       :type github
+       :branch "main"
+       :pkgname "rainstormstudio/nerd-icons.el")


### PR DESCRIPTION
doom-modeline が all-the-icons から nerd-icons に乗り換えるようなので
nerd-icons を入れることにした
https://github.com/seagle0128/doom-modeline/commit/0cf0fa43b16e7e49f6dff7ac53220ede6fd11eec