### PR TITLE
fix: Switch counsel-locate-cmd

### DIFF
--- a/custom.el
+++ b/custom.el
@@ -8,7 +8,6 @@
  '(aw-background t)
  '(column-number-mode t)
  '(company-show-quick-access t)
- '(counsel-locate-cmd 'counsel-locate-cmd-mdfind)
  '(counsel-projectile-switch-project-action
    '(1
      ("o" counsel-projectile-switch-project-action "jump to a project buffer or file")

--- a/hugo/content/ui/ivy.md
+++ b/hugo/content/ui/ivy.md
@@ -58,6 +58,23 @@ counsel は ivy で提供されているやつで、既存の Emacs のコマン
 ```
 
 
+### counsel-locate-cmd の設定 {#counsel-locate-cmd-の設定}
+
+環境によってシステム全体を検索するコマンドが異なるのでここで指定している。
+Mac は mdfind を使いそれ以外ではデフォルトの locate を使う。
+
+```emacs-lisp
+(custom-set-variables '(counsel-locate-cmd (if (eq window-system 'mac)
+                                               'counsel-locate-cmd-mdfind
+                                             'counsel-locate-cmd-default)))
+```
+
+counsel.el を見てると
+Windows では counsel-locate-cmd-es が使われるようだけど
+Windows 環境を使ってないので無視。
+<https://github.com/abo-abo/swiper/blob/d28225e86f8dfb3825809ad287f759f95ee9e479/counsel.el#L2567-L2573>
+
+
 ## ivy-posframe {#ivy-posframe}
 
 ivy-posframe は ivy を posframe で表示してくれるようにするやつ。

--- a/init.org
+++ b/init.org
@@ -2866,6 +2866,20 @@
     #+begin_src emacs-lisp :tangle inits/82-ivy.el
     (counsel-mode 1)
     #+end_src
+**** counsel-locate-cmd の設定
+     環境によってシステム全体を検索するコマンドが異なるのでここで指定している。
+     Mac は mdfind を使いそれ以外ではデフォルトの locate を使う。
+
+     #+begin_src emacs-lisp :tangle inits/82-ivy.el
+       (custom-set-variables '(counsel-locate-cmd (if (eq window-system 'mac)
+                                                      'counsel-locate-cmd-mdfind
+                                                    'counsel-locate-cmd-default)))
+     #+end_src
+
+     counsel.el を見てると
+     Windows では counsel-locate-cmd-es が使われるようだけど
+     Windows 環境を使ってないので無視。
+     https://github.com/abo-abo/swiper/blob/d28225e86f8dfb3825809ad287f759f95ee9e479/counsel.el#L2567-L2573
 *** ivy-posframe
     :PROPERTIES:
     :ID:       adfdebc7-0ba7-4850-84de-c623287dadf9

--- a/inits/82-ivy.el
+++ b/inits/82-ivy.el
@@ -22,6 +22,10 @@
 
 (counsel-mode 1)
 
+(custom-set-variables '(counsel-locate-cmd (if (eq window-system 'mac)
+                                               'counsel-locate-cmd-mdfind
+                                             'counsel-locate-cmd-default)))
+
 (el-get-bundle ivy-posframe)
 (setq ivy-posframe-display-functions-alist
       '((swiper . ivy-display-function-fallback)


### PR DESCRIPTION
counsel-locate-cmd で
Mac では mdfind を
それ以外では locate を使うようにした

counsel.el を見てると
Windows だと counsel-locate-cmd-es が使われるようだけど
Windows 環境を使ってないので無視。
https://github.com/abo-abo/swiper/blob/d28225e86f8dfb3825809ad287f759f95ee9e479/counsel.el#L2567-L2573