### PR TITLE
ci: Run check-updates action at dawn

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -2,7 +2,7 @@ name: Check updates
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 20 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
パッケージ更新処理は明け方に実行する。
そうすると朝イチでも更新ができるようになる