### PR TITLE
fix: define-key-on-org-read-date

### DIFF
--- a/hugo/content/org-mode/org-babel.md
+++ b/hugo/content/org-mode/org-babel.md
@@ -110,6 +110,9 @@ windmove-mode とキーバインドがかぶってるのでそれと同居でき
 
 具体的には org-mode のコマンドが動く場所であればそれを実行しそれがないなら windmove のコマンドを実行する
 
+また org-read-date はデフォルトでシフト+カーソルキーで日付を選択できるが、
+windmove にそれを奪われてしまうので、カーソルキー単体でカレンダー選択ができるようにしている。
+
 ```emacs-lisp
 (defun my/org-mode-map-override-windmove-mode-map ()
   (let ((oldmap windmove-mode-map)
@@ -124,7 +127,13 @@ windmove-mode とキーバインドがかぶってるのでそれと同居でき
 
 (add-hook 'org-mode-hook
           (lambda ()
-            (my/org-mode-map-override-windmove-mode-map)))
+            (my/org-mode-map-override-windmove-mode-map)
+
+            ;; http://yitang.uk/2022/07/05/move-between-window-using-builtin-package/
+            (define-key org-read-date-minibuffer-local-map (kbd "<left>") (lambda () (interactive) (org-eval-in-calendar '(calendar-backward-day 1))))
+            (define-key org-read-date-minibuffer-local-map (kbd "<right>") (lambda () (interactive) (org-eval-in-calendar '(calendar-forward-day 1))))
+            (define-key org-read-date-minibuffer-local-map (kbd "<up>") (lambda () (interactive) (org-eval-in-calendar '(calendar-backward-week 1))))
+            (define-key org-read-date-minibuffer-local-map (kbd "<down>") (lambda () (interactive) (org-eval-in-calendar '(calendar-forward-week 1))))))
 
 (with-eval-after-load 'org-mode
   (my/org-mode-map-override-windmove-mode-map))

--- a/init.org
+++ b/init.org
@@ -6337,6 +6337,9 @@
     具体的には org-mode のコマンドが動く場所であればそれを実行し
     それがないなら windmove のコマンドを実行する
 
+    また org-read-date はデフォルトでシフト+カーソルキーで日付を選択できるが、
+    windmove にそれを奪われてしまうので、カーソルキー単体でカレンダー選択ができるようにしている。
+
     #+begin_src emacs-lisp :tangle inits/60-org.el
       (defun my/org-mode-map-override-windmove-mode-map ()
         (let ((oldmap windmove-mode-map)
@@ -6351,7 +6354,13 @@
 
       (add-hook 'org-mode-hook
                 (lambda ()
-                  (my/org-mode-map-override-windmove-mode-map)))
+                  (my/org-mode-map-override-windmove-mode-map)
+
+                  ;; http://yitang.uk/2022/07/05/move-between-window-using-builtin-package/
+                  (define-key org-read-date-minibuffer-local-map (kbd "<left>") (lambda () (interactive) (org-eval-in-calendar '(calendar-backward-day 1))))
+                  (define-key org-read-date-minibuffer-local-map (kbd "<right>") (lambda () (interactive) (org-eval-in-calendar '(calendar-forward-day 1))))
+                  (define-key org-read-date-minibuffer-local-map (kbd "<up>") (lambda () (interactive) (org-eval-in-calendar '(calendar-backward-week 1))))
+                  (define-key org-read-date-minibuffer-local-map (kbd "<down>") (lambda () (interactive) (org-eval-in-calendar '(calendar-forward-week 1))))))
 
       (with-eval-after-load 'org-mode
         (my/org-mode-map-override-windmove-mode-map))

--- a/inits/60-org.el
+++ b/inits/60-org.el
@@ -61,7 +61,13 @@
 
 (add-hook 'org-mode-hook
           (lambda ()
-            (my/org-mode-map-override-windmove-mode-map)))
+            (my/org-mode-map-override-windmove-mode-map)
+
+            ;; http://yitang.uk/2022/07/05/move-between-window-using-builtin-package/
+            (define-key org-read-date-minibuffer-local-map (kbd "<left>") (lambda () (interactive) (org-eval-in-calendar '(calendar-backward-day 1))))
+            (define-key org-read-date-minibuffer-local-map (kbd "<right>") (lambda () (interactive) (org-eval-in-calendar '(calendar-forward-day 1))))
+            (define-key org-read-date-minibuffer-local-map (kbd "<up>") (lambda () (interactive) (org-eval-in-calendar '(calendar-backward-week 1))))
+            (define-key org-read-date-minibuffer-local-map (kbd "<down>") (lambda () (interactive) (org-eval-in-calendar '(calendar-forward-week 1))))))
 
 (with-eval-after-load 'org-mode
   (my/org-mode-map-override-windmove-mode-map))


### PR DESCRIPTION
スケジュール設定の際 org-read-date で日付を選択するが
そのキーバインドが windmove と重複していて
日付の選択にマウスを使わざるを得なかった。

この改修によりカーソルキーで日付を選択できるようになる