### PR TITLE
fix: Add sleep after fetch pull requests

### DIFF
--- a/inits/65-org-reviews.el
+++ b/inits/65-org-reviews.el
@@ -30,6 +30,7 @@
                                     (list cmd "-m" "json" "--ignore-title" "Deploy" org-or-user repo)
                                     " "))
          (result (shell-command-to-string cmd-with-args)))
+    (sleep-for 1)
     (json-parse-string result)))
 
 (defun my/org-reviews-prs ()


### PR DESCRIPTION
リポジトリが多いと短時間に多くリクエストを飛ばすことになり
エラーが返って来ていたので sleep を入れて回避した