### PR TITLE
feat: my/org-reviews-execute 実行時に記録ファイルを開くようにした

### DIFF
--- a/inits/65-org-reviews.el
+++ b/inits/65-org-reviews.el
@@ -156,6 +156,7 @@
 
 (defun my/org-reviews-execute ()
   (interactive)
+  (find-file-other-window my/org-reviews-file)
   (let* ((saved-prs (my/org-reviews-pr-headlines))
          (fetched-prs (my/org-reviews-prs))
          (merged-prs (my/org-reviews-merge-prs saved-prs fetched-prs))


### PR DESCRIPTION
いつも開いてから実行してたけど、その手間を減らしたい