### PR TITLE
Do not kill reviews.org

### DIFF
--- a/hugo/content/buffer-management/tempbuf.md
+++ b/hugo/content/buffer-management/tempbuf.md
@@ -25,7 +25,7 @@ org-clock を使うようなファイルは
 kill されると org-clock が狂って面倒なことになるのでそれらのファイルは勝手に kill されないように ignore リストに突っ込んでいる
 
 ```emacs-lisp
-(setq my/tempbuf-ignore-files '("~/Documents/org/tasks/gtd.org"
+(setq my/tempbuf-ignore-files '("~/Documents/org/tasks/reviews.org"
                                 "~/Documents/org/tasks/interrupted.org"
                                 "~/Documents/org/tasks/next-actions.org"
                                 ))

--- a/init.org
+++ b/init.org
@@ -885,10 +885,10 @@
     それらのファイルは勝手に kill されないように ignore リストに突っ込んでいる
 
     #+begin_src emacs-lisp :tangle inits/70-tempbuf.el
-    (setq my/tempbuf-ignore-files '("~/Documents/org/tasks/gtd.org"
-                                    "~/Documents/org/tasks/interrupted.org"
-                                    "~/Documents/org/tasks/next-actions.org"
-                                    ))
+      (setq my/tempbuf-ignore-files '("~/Documents/org/tasks/reviews.org"
+                                      "~/Documents/org/tasks/interrupted.org"
+                                      "~/Documents/org/tasks/next-actions.org"
+                                      ))
     #+end_src
 *** find-file への hook
     :PROPERTIES:

--- a/inits/70-tempbuf.el
+++ b/inits/70-tempbuf.el
@@ -1,6 +1,6 @@
 (el-get-bundle tempbuf-mode)
 
-(setq my/tempbuf-ignore-files '("~/Documents/org/tasks/gtd.org"
+(setq my/tempbuf-ignore-files '("~/Documents/org/tasks/reviews.org"
                                 "~/Documents/org/tasks/interrupted.org"
                                 "~/Documents/org/tasks/next-actions.org"
                                 ))


### PR DESCRIPTION
reviews.org も org-clock で使ってるので
tempbuf-mode で kill されないようにした