### PR TITLE
enh-ruby を copilot-major-mode-alist に入れるタイミングの調整

### DIFF
--- a/inits/30-copilot.el
+++ b/inits/30-copilot.el
@@ -1,7 +1,8 @@
 (el-get-bundle copilot)
 
 (add-hook 'prog-mode-hook 'copilot-mode)
-(add-to-list 'copilot-major-mode-alist '("enh-ruby" . "ruby"))
+(with-eval-after-load 'copilot
+  (add-to-list 'copilot-major-mode-alist '("enh-ruby" . "ruby")))
 
 (with-eval-after-load 'company
   ;; disable inline previews


### PR DESCRIPTION
copilot-mode が読み込まれる前に入れようとすると
変数がないよってエラーになるので