### PR TITLE
fix: error handling on org-reviews

### DIFF
--- a/inits/65-org-reviews.el
+++ b/inits/65-org-reviews.el
@@ -31,7 +31,11 @@
                                     " "))
          (result (shell-command-to-string cmd-with-args)))
     (sleep-for 1)
-    (json-parse-string result)))
+    (condition-case err
+        (json-parse-string result)
+      (error
+       (format "error: %s\ncmd:%s\nresult:%s" err cmd-with-args result)
+       nil))))
 
 (defun my/org-reviews-prs ()
   "レビュー依頼されている PR 全てを取得して flat な emacs lisp の array として返すやつ"


### PR DESCRIPTION
多くのリポジトリを指定しているとエラーになることがあったので。

本当はちゃんとエラーの中に含まれる reset かなんかの値を見て
それまではリクエストを待つとかすべきだけど
一旦はエラーを大体無視するようにしている