### PR TITLE
Agenda filtering by level

### DIFF
--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -282,9 +282,9 @@ nil にして表示しないようにしている。
                                             (:name "今日〆切の作業" :deadline today)
                                             (:name "今日予定の作業" :scheduled today)
                                             (:discard (:anything t))))))
-    (tags-todo "-Emacs-org-Env-Hugo" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
+    (tags-todo "-Emacs-org-Env-Hugo&LEVEL=2" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
   ("pN" "No major tags"
-   ((tags-todo "-Emacs-org-Env-Hugo-Kibela-Develop-ReviewLister-HouseWork-Private" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
+   ((tags-todo "-Emacs-org-Env-Hugo-Kibela-Develop-ReviewLister-HouseWork-Private&LEVEL=2" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
   ("P" "Pointers"
    ((todo "DOING" ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))
     (todo "TODO"  ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))))

--- a/init.org
+++ b/init.org
@@ -6717,9 +6717,9 @@
                                                    (:name "今日〆切の作業" :deadline today)
                                                    (:name "今日予定の作業" :scheduled today)
                                                    (:discard (:anything t))))))
-           (tags-todo "-Emacs-org-Env-Hugo" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
+           (tags-todo "-Emacs-org-Env-Hugo&LEVEL=2" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
          ("pN" "No major tags"
-          ((tags-todo "-Emacs-org-Env-Hugo-Kibela-Develop-ReviewLister-HouseWork-Private" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
+          ((tags-todo "-Emacs-org-Env-Hugo-Kibela-Develop-ReviewLister-HouseWork-Private&LEVEL=2" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
          ("P" "Pointers"
           ((todo "DOING" ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))
            (todo "TODO"  ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))))

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -167,9 +167,9 @@
                                             (:name "今日〆切の作業" :deadline today)
                                             (:name "今日予定の作業" :scheduled today)
                                             (:discard (:anything t))))))
-    (tags-todo "-Emacs-org-Env-Hugo" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
+    (tags-todo "-Emacs-org-Env-Hugo&LEVEL=2" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
   ("pN" "No major tags"
-   ((tags-todo "-Emacs-org-Env-Hugo-Kibela-Develop-ReviewLister-HouseWork-Private" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
+   ((tags-todo "-Emacs-org-Env-Hugo-Kibela-Develop-ReviewLister-HouseWork-Private&LEVEL=2" ((org-agenda-files '("~/Documents/org/tasks/projects.org"))))))
   ("P" "Pointers"
    ((todo "DOING" ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))
     (todo "TODO"  ((org-agenda-files '("~/Documents/org/tasks/pointers.org"))))))


### PR DESCRIPTION
Heading level でのフィルタを追加。
これでサブタスクを突っ込んでいてもそれは表示されないようになる