### PR TITLE
ivy では常に migemo が使われるようにした

### DIFF
--- a/hugo/content/ui/ivy.md
+++ b/hugo/content/ui/ivy.md
@@ -287,13 +287,16 @@ swiper は標準だと migemo れないのだが
 
 swiper を使う時はデフォで有効になっててほしいのでその設定も入れている。なおこれも公式ページに記述されている設定である。
 
+というか全体を ivy-migemo-regex-plus にしている。これは completing-read-function で指定されている ivy-completing-read でも migemo りたかったため。
+completing-read や ivy-completing-read を指定してもうまくいかないのでもうエイヤで全部 migemo に倒した
+
 ```emacs-lisp
-(setq ivy-re-builders-alist '((t . ivy--regex-plus)
+(setq ivy-re-builders-alist '((t . ivy-migemo-regex-plus)
                               (swiper . ivy-migemo-regex-plus)
                               (counsel-find-file . ivy-migemo-regex-plus)))
 ```
 
-また fuzzy matchi を有効にする設定も記載されているがそちらは自分は設定していない。なんとなく。
+また fuzzy match を有効にする設定も記載されているがそちらは自分は設定していない。なんとなく。
 
 
 ## counsel-osx-app. <span class="tag"><span class="improvement">improvement</span></span> {#counsel-osx-app-dot}

--- a/init.org
+++ b/init.org
@@ -3118,13 +3118,17 @@
       swiper を使う時はデフォで有効になっててほしいのでその設定も入れている。
       なおこれも公式ページに記述されている設定である。
 
+      というか全体を ivy-migemo-regex-plus にしている。
+      これは completing-read-function で指定されている ivy-completing-read でも migemo りたかったため。
+      completing-read や ivy-completing-read を指定してもうまくいかないのでもうエイヤで全部 migemo に倒した
+
       #+begin_src emacs-lisp :tangle inits/82-ivy.el
-      (setq ivy-re-builders-alist '((t . ivy--regex-plus)
+      (setq ivy-re-builders-alist '((t . ivy-migemo-regex-plus)
                                     (swiper . ivy-migemo-regex-plus)
                                     (counsel-find-file . ivy-migemo-regex-plus)))
       #+end_src
 
-      また fuzzy matchi を有効にする設定も記載されているが
+      また fuzzy match を有効にする設定も記載されているが
       そちらは自分は設定していない。なんとなく。
 
 *** counsel-osx-app.                                            :improvement:

--- a/inits/82-ivy.el
+++ b/inits/82-ivy.el
@@ -101,6 +101,6 @@
 (define-key ivy-minibuffer-map (kbd "M-f") #'ivy-migemo-toggle-fuzzy)
 (define-key ivy-minibuffer-map (kbd "M-m") #'ivy-migemo-toggle-migemo)
 
-(setq ivy-re-builders-alist '((t . ivy--regex-plus)
+(setq ivy-re-builders-alist '((t . ivy-migemo-regex-plus)
                               (swiper . ivy-migemo-regex-plus)
                               (counsel-find-file . ivy-migemo-regex-plus)))


### PR DESCRIPTION
completing-read だけ設定できれば十分だったけど
それをうまくやる方法が見つからないので
もう全部 ivy-migemo-regex-plus にしちゃった

ivy-completing-read, completing-read あたりは試したけど
migemo 対応にならなかったのよね〜