### PR TITLE
Use ivy--regexp-plus on counsel-M-x

### DIFF
--- a/hugo/content/ui/ivy.md
+++ b/hugo/content/ui/ivy.md
@@ -292,6 +292,7 @@ completing-read や ivy-completing-read を指定してもうまくいかない�
 
 ```emacs-lisp
 (setq ivy-re-builders-alist '((t . ivy-migemo-regex-plus)
+                              (counsel-M-x . ivy--regex-plus)
                               (swiper . ivy-migemo-regex-plus)
                               (counsel-find-file . ivy-migemo-regex-plus)))
 ```

--- a/init.org
+++ b/init.org
@@ -3123,9 +3123,10 @@
       completing-read や ivy-completing-read を指定してもうまくいかないのでもうエイヤで全部 migemo に倒した
 
       #+begin_src emacs-lisp :tangle inits/82-ivy.el
-      (setq ivy-re-builders-alist '((t . ivy-migemo-regex-plus)
-                                    (swiper . ivy-migemo-regex-plus)
-                                    (counsel-find-file . ivy-migemo-regex-plus)))
+        (setq ivy-re-builders-alist '((t . ivy-migemo-regex-plus)
+                                      (counsel-M-x . ivy--regex-plus)
+                                      (swiper . ivy-migemo-regex-plus)
+                                      (counsel-find-file . ivy-migemo-regex-plus)))
       #+end_src
 
       また fuzzy match を有効にする設定も記載されているが

--- a/inits/82-ivy.el
+++ b/inits/82-ivy.el
@@ -102,5 +102,6 @@
 (define-key ivy-minibuffer-map (kbd "M-m") #'ivy-migemo-toggle-migemo)
 
 (setq ivy-re-builders-alist '((t . ivy-migemo-regex-plus)
+                              (counsel-M-x . ivy--regex-plus)
                               (swiper . ivy-migemo-regex-plus)
                               (counsel-find-file . ivy-migemo-regex-plus)))


### PR DESCRIPTION
ivy-migemo-regex-plus だと ^ とか $ とかが使えなかったので
元の挙動になるように調整