### PR TITLE
Use stylelint

### DIFF
--- a/hugo/content/programming/scss.md
+++ b/hugo/content/programming/scss.md
@@ -44,6 +44,28 @@ scss-mode は Emacs 組込みの css-mode の中で定義されているメジ�
 `custom-set-variables` を使うように修正した方が良さそう
 
 
+## flycheck の scss-stylelint を上書き {#flycheck-の-scss-stylelint-を上書き}
+
+stylelint v14 以降は --style オプションが使えないので上書き
+<https://github.com/flycheck/flycheck/pull/1944> が取り込まれたらこれも要らなさそうだけど。
+
+```emacs-lisp
+(with-eval-after-load 'flycheck
+  (flycheck-define-checker scss-stylelint
+    "A SCSS syntax and style checker using stylelint.
+
+See URL `http://stylelint.io/'."
+    :command ("stylelint"
+              (eval flycheck-stylelint-args)
+              (option-flag "--quiet" flycheck-stylelint-quiet)
+              (config-file "--config" flycheck-stylelintrc))
+    :standard-input t
+    :error-parser flycheck-parse-stylelint
+    :predicate flycheck-buffer-nonempty-p
+    :modes (scss-mode)))
+```
+
+
 ## hook <span class="tag"><span class="improvement">improvement</span></span> {#hook}
 
 scss を使う上で hook を使って色々有効化したりしている。

--- a/init.org
+++ b/init.org
@@ -5202,6 +5202,26 @@
      ~with-eval-after-load~ を使っているが
      ~css-indent-offset~ は ~defcustom~ で定義されているので
      ~custom-set-variables~ を使うように修正した方が良さそう
+
+*** flycheck の scss-stylelint を上書き
+    stylelint v14 以降は --style オプションが使えないので上書き
+    https://github.com/flycheck/flycheck/pull/1944 が取り込まれたらこれも要らなさそうだけど。
+
+     #+begin_src emacs-lisp :tangle inits/40-scss.el
+       (with-eval-after-load 'flycheck
+         (flycheck-define-checker scss-stylelint
+           "A SCSS syntax and style checker using stylelint.
+
+       See URL `http://stylelint.io/'."
+           :command ("stylelint"
+                     (eval flycheck-stylelint-args)
+                     (option-flag "--quiet" flycheck-stylelint-quiet)
+                     (config-file "--config" flycheck-stylelintrc))
+           :standard-input t
+           :error-parser flycheck-parse-stylelint
+           :predicate flycheck-buffer-nonempty-p
+           :modes (scss-mode)))
+     #+end_src
 *** hook                                                        :improvement:
     :PROPERTIES:
     :ID:       338cf09b-87b0-47bb-8cf7-080aa5cc2f85

--- a/inits/40-scss.el
+++ b/inits/40-scss.el
@@ -3,6 +3,20 @@
 (with-eval-after-load 'scss-mode
   (setq css-indent-offset 2))
 
+(with-eval-after-load 'flycheck
+  (flycheck-define-checker scss-stylelint
+    "A SCSS syntax and style checker using stylelint.
+
+See URL `http://stylelint.io/'."
+    :command ("stylelint"
+              (eval flycheck-stylelint-args)
+              (option-flag "--quiet" flycheck-stylelint-quiet)
+              (config-file "--config" flycheck-stylelintrc))
+    :standard-input t
+    :error-parser flycheck-parse-stylelint
+    :predicate flycheck-buffer-nonempty-p
+    :modes (scss-mode)))
+
 (defun my/scss-mode-hook ()
   (flycheck-mode 1)
 


### PR DESCRIPTION
stylelint の v14 以降を使えるように
scss-stylelint の定義を上書きした。

Emacs の外では
`npm i -g` で
stylelint と stylelint-config-standard-scss を入れておいて
プロジェクトルートに適当に .stylelintrc.yml を置いといた