### PR TITLE
Add origami

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((company-posframe :checksum "18d6641bba72cba3c00018cee737ea8b454f64a8")
+      '((origami :checksum "a8300d79f8ba7429f656ea81ae74dd9ec7f9c894")
+        (company-posframe :checksum "18d6641bba72cba3c00018cee737ea8b454f64a8")
         (nerd-icons :checksum "a6999ddd8b85043bb24547611524a7ec86c6a21f")
         (copilot :checksum "a68f1ce94addc45984ba5bb1972bfba95c8b7f96")
         (json-rpc :checksum "81a5a520072e20d18aeab2aac4d66c046b031e56")

--- a/hugo/content/editing/_index.md
+++ b/hugo/content/editing/_index.md
@@ -23,6 +23,9 @@ disableToc = true
 [multiple-cursors]({{< relref "global-keybinds#multiple-cursors" >}})
 : カーソルを増やして複数箇所を同時に編集できるようになるやつ
 
+[origami]({{< relref "origami" >}})
+: コードの折り畳みができるようになるやつ
+
 [smartparens]({{< relref "smartparens" >}})
 : カッコや引用符などのペアになるやつの入力補助をしてくれるやつ
 

--- a/hugo/content/editing/origami.md
+++ b/hugo/content/editing/origami.md
@@ -1,0 +1,75 @@
++++
+title = "origami"
+draft = false
++++
+
+## 概要 {#概要}
+
+[origami](https://github.com/elp-revive/origami.el) はコードの折り畳み機能を提供するやつ。メジャーな言語は大体サポートしている感じ。大きいファイルを見る時に便利。
+
+
+## インストール {#インストール}
+
+el-get 公式にはレシピがないので自前でレシピを用意している。
+
+```emacs-lisp
+(:name origami
+       :website "https://github.com/elp-revive/origami.el"
+       :description "A text folding minor mode for Emacs."
+       :type github
+       :pkgname "elp-revive/origami.el"
+       :depends (s dash))
+```
+
+そしてそれを使ってインストール
+
+```emacs-lisp
+(el-get-bundle origami)
+```
+
+
+## キーバインド {#キーバインド}
+
+origami-mode-map では以下のように動くように設定している。
+
+| Key               | 効果                                     |
+|-------------------|----------------------------------------|
+| &lt;backtab&gt;   | 再帰的に折り畳んだり開いたりするやつ。org-mode の fold と似た感じ |
+| M-&lt;backtab&gt; | そのノードだけ表示する                   |
+
+```emacs-lisp
+(with-eval-after-load 'origami
+  (define-key origami-mode-map (kbd "<backtab>") 'origami-recursively-toggle-node)
+  (define-key origami-mode-map (kbd "M-<backtab>") 'origami-show-only-node))
+```
+
+ただこれだけだと多分足りないので Hydra で色々定義している。
+
+```emacs-lisp
+(with-eval-after-load 'pretty-hydra
+  (pretty-hydra-define origami-hydra
+    (:separator "-" :quit-key "q" :title "Origami")
+    ("Node"
+     (("o" origami-open-node "Open")
+      ("c" origami-close-node "Close")
+      ("s" origami-show-node "Show")
+      ("t" origami-toggle-node "Toggle")
+      ("S" origami-forward-toggle-node "Foward toggle")
+      ("r" origami-recursively-toggle-node "Recursive toggle"))
+
+     "All"
+     (("O" origami-open-all-nodes "Open")
+      ("C" origami-close-all-nodes "Close")
+      ("T" origami-toggle-all-nodes "Toggle"))
+
+     "Move"
+     (("n" origami-next-fold "Next")
+      ("p" origami-previous-fold "Previous"))
+
+     "Undo/Redo"
+     (("/" origami-undo "Undo")
+      ("?" origami-redo "Redo")
+      ("X" origami-reset "Reset")))))
+```
+
+この設定は [jk で起動する Hydra]({{< relref "hydra#main" >}}) から呼び出せるようにしている

--- a/hugo/content/programming/emacs-lisp.md
+++ b/hugo/content/programming/emacs-lisp.md
@@ -21,6 +21,7 @@ Hook 用の関数を定義してその中に色々書いている。
 ```emacs-lisp
 (defun my/emacs-lisp-mode-hook ()
   (display-line-numbers-mode 1)
+  (origami-mode 1)
   (company-mode 1)
   (smartparens-mode 1)
   (turn-on-smartparens-strict-mode))

--- a/hugo/content/programming/react-js.md
+++ b/hugo/content/programming/react-js.md
@@ -94,6 +94,7 @@ lsp-mode から eslint を使うことでやりたいことの対応ができる
       (setq web-mode-markup-indent-offset 2)
       (setq web-mode-code-indent-offset 2)
       (setq web-mode-enable-auto-indentation nil)
+      (origami-mode 1)
       (company-mode 1)
       (turn-on-smartparens-mode)
       (display-line-numbers-mode t)

--- a/hugo/content/programming/ruby.md
+++ b/hugo/content/programming/ruby.md
@@ -106,6 +106,7 @@ hook 用の関数で補完などの機能を有効にしている
 
 ```emacs-lisp
 (defun my/enh-ruby-mode-hook ()
+  (origami-mode 1)
   (company-mode 1)
   (lsp)
   (lsp-ui-mode 1)

--- a/hugo/content/programming/ruby.md
+++ b/hugo/content/programming/ruby.md
@@ -165,7 +165,8 @@ Ruby を使ってる時にコメント部分はクォートの外以外では自
      (("I" inf-ruby "inf-ruby"))
 
      "Other"
-     (("j" dumb-jump-go "Dumb Jump")))))
+     (("j" dumb-jump-go "Dumb Jump")
+      ("o" origami-hydra/body "Origami")))))
 ```
 
 | Key | 効果                                                |

--- a/hugo/content/programming/scss.md
+++ b/hugo/content/programming/scss.md
@@ -84,6 +84,7 @@ scss を使う上で hook を使って色々有効化したりしている。
   (setq-local flycheck-checker 'scss-stylelint)
   (setq-local flycheck-check-syntax-automatically '(save new-line idle-change))
 
+  (origami-mode 1)
   (company-mode 1)
   (display-line-numbers-mode 1)
 

--- a/hugo/content/programming/typescript.md
+++ b/hugo/content/programming/typescript.md
@@ -77,6 +77,7 @@ hook を使って有効化している
 
 ```emacs-lisp
 (defun my/ts-mode-hook ()
+  (origami-mode 1)
   (company-mode 1)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode t)

--- a/hugo/content/ui/hydra.md
+++ b/hugo/content/ui/hydra.md
@@ -239,6 +239,7 @@ el-get の Hydra はここで定義してしまっている。その内 el-get �
 
    "Edit"
    (("a" align-regexp "Align Regexp")
+    ("[" origami-hydra/body "Origami")
     (";" comment-dwim "Comment"))
 
    "Code"

--- a/init.org
+++ b/init.org
@@ -1463,6 +1463,7 @@
    - [[*company-mode][company-mode]] :: プラグイン拡張方式を採用した、入力補完インターフェースを提供してくれるやつ
    - [[*emojify][emojify]] :: Slack や GitHub みたいに ~:smile:~ とか入れると笑顔の絵文字を表示する、みたいなやつ
    - [[*multiple-cursors][multiple-cursors]] :: カーソルを増やして複数箇所を同時に編集できるようになるやつ
+   - [[id:f309e8bd-8e1d-4a91-ae4d-9a960373969b][origami]] :: コードの折り畳みができるようになるやつ
    - [[*smartparens][smartparens]] :: カッコや引用符などのペアになるやつの入力補助をしてくれるやつ
    - [[*undo-fu][undo-fu]] :: シンプルな undo/redo の機能を提供してくれるやつ
    - [[*view-mode][view-mode]] :: Emacs に組込まれてる閲覧専用のモード。コードリーディングの時に有効にすると便利
@@ -1701,6 +1702,76 @@
 
     キーバインドは別途定義している。
     もうちょっと真面目に定義したい
+
+** origami
+   :PROPERTIES:
+   :EXPORT_FILE_NAME: origami
+   :ID:       f309e8bd-8e1d-4a91-ae4d-9a960373969b
+   :END:
+*** 概要
+    [[https://github.com/elp-revive/origami.el][origami]] はコードの折り畳み機能を提供するやつ。
+    メジャーな言語は大体サポートしている感じ。
+    大きいファイルを見る時に便利。
+*** インストール
+    el-get 公式にはレシピがないので自前でレシピを用意している。
+
+    #+begin_src emacs-lisp :tangle recipes/origami.rcp
+      (:name origami
+             :website "https://github.com/elp-revive/origami.el"
+             :description "A text folding minor mode for Emacs."
+             :type github
+             :pkgname "elp-revive/origami.el"
+             :depends (s dash))
+    #+end_src
+
+    そしてそれを使ってインストール
+
+    #+begin_src emacs-lisp :tangle inits/50-origami.el
+    (el-get-bundle origami)
+    #+end_src
+*** キーバインド
+    origami-mode-map では以下のように動くように設定している。
+
+    | Key         | 効果                                                              |
+    | <backtab>   | 再帰的に折り畳んだり開いたりするやつ。org-mode の fold と似た感じ |
+    | M-<backtab> | そのノードだけ表示する                                            |
+
+    #+begin_src emacs-lisp :tangle inits/50-origami.el
+      (with-eval-after-load 'origami
+        (define-key origami-mode-map (kbd "<backtab>") 'origami-recursively-toggle-node)
+        (define-key origami-mode-map (kbd "M-<backtab>") 'origami-show-only-node))
+    #+end_src
+
+    ただこれだけだと多分足りないので Hydra で色々定義している。
+
+    #+begin_src emacs-lisp :tangle inits/50-origami.el
+      (with-eval-after-load 'pretty-hydra
+        (pretty-hydra-define origami-hydra
+          (:separator "-" :quit-key "q" :title "Origami")
+          ("Node"
+           (("o" origami-open-node "Open")
+            ("c" origami-close-node "Close")
+            ("s" origami-show-node "Show")
+            ("t" origami-toggle-node "Toggle")
+            ("S" origami-forward-toggle-node "Foward toggle")
+            ("r" origami-recursively-toggle-node "Recursive toggle"))
+
+           "All"
+           (("O" origami-open-all-nodes "Open")
+            ("C" origami-close-all-nodes "Close")
+            ("T" origami-toggle-all-nodes "Toggle"))
+
+           "Move"
+           (("n" origami-next-fold "Next")
+            ("p" origami-previous-fold "Previous"))
+
+           "Undo/Redo"
+           (("/" origami-undo "Undo")
+            ("?" origami-redo "Redo")
+            ("X" origami-reset "Reset")))))
+    #+end_src
+
+    この設定は [[id:befaa52b-d054-43bd-9445-fca7f5bd8be5][jk で起動する Hydra]] から呼び出せるようにしている
 
 ** smartparens
    :PROPERTIES:

--- a/init.org
+++ b/init.org
@@ -4303,11 +4303,12 @@
     - カッコの対応などもいい感じに動いて欲しいので smartparens-mode とその strict-mode を有効にしている
 
     #+begin_src emacs-lisp :tangle inits/40-emacs-lisp.el
-    (defun my/emacs-lisp-mode-hook ()
-      (display-line-numbers-mode 1)
-      (company-mode 1)
-      (smartparens-mode 1)
-      (turn-on-smartparens-strict-mode))
+      (defun my/emacs-lisp-mode-hook ()
+        (display-line-numbers-mode 1)
+        (origami-mode 1)
+        (company-mode 1)
+        (smartparens-mode 1)
+        (turn-on-smartparens-strict-mode))
     #+end_src
 
     そんで最後にその関数を hook に突っ込んでる。

--- a/init.org
+++ b/init.org
@@ -4990,6 +4990,7 @@
             (setq web-mode-markup-indent-offset 2)
             (setq web-mode-code-indent-offset 2)
             (setq web-mode-enable-auto-indentation nil)
+            (origami-mode 1)
             (company-mode 1)
             (turn-on-smartparens-mode)
             (display-line-numbers-mode t)

--- a/init.org
+++ b/init.org
@@ -5448,6 +5448,7 @@
 
      #+begin_src emacs-lisp :tangle inits/40-ts.el
        (defun my/ts-mode-hook ()
+         (origami-mode 1)
          (company-mode 1)
          (turn-on-smartparens-strict-mode)
          (display-line-numbers-mode t)

--- a/init.org
+++ b/init.org
@@ -5200,27 +5200,28 @@
      [[*major-mode-hydra][major-mode-hydra]] でキーを定義している
 
      #+begin_src emacs-lisp :tangle inits/40-ruby.el
-     (with-eval-after-load 'major-mode-hydra
-       (major-mode-hydra-define enh-ruby-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
-         ("Enh Ruby"
-          (("{" enh-ruby-toggle-block "Toggle block")
-           ("e" enh-ruby-insert-end "Insert end"))
+       (with-eval-after-load 'major-mode-hydra
+         (major-mode-hydra-define enh-ruby-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
+           ("Enh Ruby"
+            (("{" enh-ruby-toggle-block "Toggle block")
+             ("e" enh-ruby-insert-end "Insert end"))
 
-          "LSP"
-          (("i" lsp-ui-imenu "Imenu")
-           ("f" lsp-ui-flycheck-list "Flycheck list"))
+            "LSP"
+            (("i" lsp-ui-imenu "Imenu")
+             ("f" lsp-ui-flycheck-list "Flycheck list"))
 
-          "RSpec"
-          (("s" rspec-verify "Run associated spec")
-           ("m" rspec-verify-method "Run method spec")
-           ("r" rspec-rerun "Rerun")
-           ("l" rspec-run-last-failed "Run last failed"))
+            "RSpec"
+            (("s" rspec-verify "Run associated spec")
+             ("m" rspec-verify-method "Run method spec")
+             ("r" rspec-rerun "Rerun")
+             ("l" rspec-run-last-failed "Run last failed"))
 
-          "REPL"
-          (("I" inf-ruby "inf-ruby"))
+            "REPL"
+            (("I" inf-ruby "inf-ruby"))
 
-          "Other"
-          (("j" dumb-jump-go "Dumb Jump")))))
+            "Other"
+            (("j" dumb-jump-go "Dumb Jump")
+             ("o" origami-hydra/body "Origami")))))
      #+end_src
 
      | Key | 効果                                                                        |

--- a/init.org
+++ b/init.org
@@ -2824,6 +2824,7 @@
 
           "Edit"
           (("a" align-regexp "Align Regexp")
+           ("[" origami-hydra/body "Origami")
            (";" comment-dwim "Comment"))
 
           "Code"

--- a/init.org
+++ b/init.org
@@ -5304,24 +5304,25 @@
     scss を使う上で hook を使って色々有効化したりしている。
 
     #+begin_src emacs-lisp :tangle inits/40-scss.el
-    (defun my/scss-mode-hook ()
-      (flycheck-mode 1)
+      (defun my/scss-mode-hook ()
+        (flycheck-mode 1)
 
-      (setq-local lsp-prefer-flymake nil)
-      (lsp)
-      (lsp-ui-mode -1)
+        (setq-local lsp-prefer-flymake nil)
+        (lsp)
+        (lsp-ui-mode -1)
 
-      (smartparens-strict-mode 1)
+        (smartparens-strict-mode 1)
 
-      ;; lsp-ui とかより後に設定しないと上書きされるのでここに移動した
-      (setq-local flycheck-checker 'scss-stylelint)
-      (setq-local flycheck-check-syntax-automatically '(save new-line idle-change))
+        ;; lsp-ui とかより後に設定しないと上書きされるのでここに移動した
+        (setq-local flycheck-checker 'scss-stylelint)
+        (setq-local flycheck-check-syntax-automatically '(save new-line idle-change))
 
-      (company-mode 1)
-      (display-line-numbers-mode 1)
+        (origami-mode 1)
+        (company-mode 1)
+        (display-line-numbers-mode 1)
 
-      (rainbow-mode))
-    (add-hook 'scss-mode-hook 'my/scss-mode-hook)
+        (rainbow-mode))
+      (add-hook 'scss-mode-hook 'my/scss-mode-hook)
     #+end_src
 
     - flycheck-mode の有効化

--- a/init.org
+++ b/init.org
@@ -5158,6 +5158,7 @@
 
      #+begin_src emacs-lisp :tangle inits/40-ruby.el
        (defun my/enh-ruby-mode-hook ()
+         (origami-mode 1)
          (company-mode 1)
          (lsp)
          (lsp-ui-mode 1)

--- a/inits/40-emacs-lisp.el
+++ b/inits/40-emacs-lisp.el
@@ -1,5 +1,6 @@
 (defun my/emacs-lisp-mode-hook ()
   (display-line-numbers-mode 1)
+  (origami-mode 1)
   (company-mode 1)
   (smartparens-mode 1)
   (turn-on-smartparens-strict-mode))

--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -12,6 +12,7 @@
 
 (defun my/enh-ruby-mode-hook ()
   (company-mode 1)
+  (origami-mode 1)
   (lsp)
   (lsp-ui-mode 1)
   (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)

--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -43,4 +43,5 @@
      (("I" inf-ruby "inf-ruby"))
 
      "Other"
-     (("j" dumb-jump-go "Dumb Jump")))))
+     (("j" dumb-jump-go "Dumb Jump")
+      ("o" origami-hydra/body "Origami")))))

--- a/inits/40-scss.el
+++ b/inits/40-scss.el
@@ -30,6 +30,7 @@ See URL `http://stylelint.io/'."
   (setq-local flycheck-checker 'scss-stylelint)
   (setq-local flycheck-check-syntax-automatically '(save new-line idle-change))
 
+  (origami-mode 1)
   (company-mode 1)
   (display-line-numbers-mode 1)
 

--- a/inits/40-ts.el
+++ b/inits/40-ts.el
@@ -19,6 +19,7 @@
 
 (defun my/ts-mode-hook ()
   (company-mode 1)
+  (origami-mode 1)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode t)
   (lsp)

--- a/inits/41-react.el
+++ b/inits/41-react.el
@@ -18,6 +18,7 @@
       (setq web-mode-markup-indent-offset 2)
       (setq web-mode-code-indent-offset 2)
       (setq web-mode-enable-auto-indentation nil)
+      (origami-mode 1)
       (company-mode 1)
       (turn-on-smartparens-mode)
       (display-line-numbers-mode t)

--- a/inits/50-origami.el
+++ b/inits/50-origami.el
@@ -1,1 +1,30 @@
 (el-get-bundle origami)
+
+(with-eval-after-load 'origami
+  (define-key origami-mode-map (kbd "<backtab>") 'origami-recursively-toggle-node)
+  (define-key origami-mode-map (kbd "M-<backtab>") 'origami-show-only-node))
+
+(with-eval-after-load 'pretty-hydra
+  (pretty-hydra-define origami-hydra
+    (:separator "-" :quit-key "q" :title "Origami")
+    ("Node"
+     (("o" origami-open-node "Open")
+      ("c" origami-close-node "Close")
+      ("s" origami-show-node "Show")
+      ("t" origami-toggle-node "Toggle")
+      ("S" origami-forward-toggle-node "Foward toggle")
+      ("r" origami-recursively-toggle-node "Recursive toggle"))
+
+     "All"
+     (("O" origami-open-all-nodes "Open")
+      ("C" origami-close-all-nodes "Close")
+      ("T" origami-toggle-all-nodes "Toggle"))
+
+     "Move"
+     (("n" origami-next-fold "Next")
+      ("p" origami-previous-fold "Previous"))
+
+     "Undo/Redo"
+     (("/" origami-undo "Undo")
+      ("?" origami-redo "Redo")
+      ("X" origami-reset "Reset")))))

--- a/inits/50-origami.el
+++ b/inits/50-origami.el
@@ -1,0 +1,1 @@
+(el-get-bundle origami)

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -89,6 +89,7 @@
 
    "Edit"
    (("a" align-regexp "Align Regexp")
+    ("[" origami-hydra/body "Origami")
     (";" comment-dwim "Comment"))
 
    "Code"

--- a/recipes/origami.rcp
+++ b/recipes/origami.rcp
@@ -1,0 +1,6 @@
+(:name origami
+       :website "https://github.com/elp-revive/origami.el"
+       :description "A text folding minor mode for Emacs."
+       :type github
+       :pkgname "elp-revive/origami.el"
+       :depends (s dash))


### PR DESCRIPTION
# 概要

コードの折り畳みができるように [origami](https://github.com/elp-revive/origami.el) を導入した。

ひとまず Ruby, TS/TSX, SCSS の編集時に有効になるようにしている