### PR TITLE
Use ivy--regexp-plus for counsel-describe-*

### DIFF
--- a/hugo/content/ui/ivy.md
+++ b/hugo/content/ui/ivy.md
@@ -293,6 +293,8 @@ completing-read や ivy-completing-read を指定してもうまくいかない�
 ```emacs-lisp
 (setq ivy-re-builders-alist '((t . ivy-migemo-regex-plus)
                               (counsel-M-x . ivy--regex-plus)
+                              (counsel-describe-function . ivy--regex-plus)
+                              (counsel-describe-variable . ivy--regex-plus)
                               (swiper . ivy-migemo-regex-plus)
                               (counsel-find-file . ivy-migemo-regex-plus)))
 ```

--- a/init.org
+++ b/init.org
@@ -3224,6 +3224,8 @@
       #+begin_src emacs-lisp :tangle inits/82-ivy.el
         (setq ivy-re-builders-alist '((t . ivy-migemo-regex-plus)
                                       (counsel-M-x . ivy--regex-plus)
+                                      (counsel-describe-function . ivy--regex-plus)
+                                      (counsel-describe-variable . ivy--regex-plus)
                                       (swiper . ivy-migemo-regex-plus)
                                       (counsel-find-file . ivy-migemo-regex-plus)))
       #+end_src

--- a/inits/82-ivy.el
+++ b/inits/82-ivy.el
@@ -103,5 +103,7 @@
 
 (setq ivy-re-builders-alist '((t . ivy-migemo-regex-plus)
                               (counsel-M-x . ivy--regex-plus)
+                              (counsel-describe-function . ivy--regex-plus)
+                              (counsel-describe-variable . ivy--regex-plus)
                               (swiper . ivy-migemo-regex-plus)
                               (counsel-find-file . ivy-migemo-regex-plus)))


### PR DESCRIPTION
counsel-describe-function 及び counsel-describe-variable では
ivy--regex-plus を使うように指定した

行頭の ^ とかを使いたいため