### PR TITLE
PR 作成の失敗時にも通知を飛ばすようにする

### DIFF
--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -59,7 +59,7 @@ jobs:
         title: ${{ env.PR_TITLE }}
         body: ${{ steps.get-pr-body.outputs.body }}
 
-    - if: env.found_update == 1
+    - if: always()
       name: Notify slack build result
       uses: lazy-actions/slatify@master
       with:


### PR DESCRIPTION
元々失敗時にはメンションを飛ばすように設定していたが
if の条件を間違えていて思ったように動いていなかった