### PR TITLE
feat: Use subword-mode

### DIFF
--- a/hugo/content/programming/react-js.md
+++ b/hugo/content/programming/react-js.md
@@ -96,6 +96,7 @@ lsp-mode から eslint を使うことでやりたいことの対応ができる
       (setq web-mode-enable-auto-indentation nil)
       (origami-mode 1)
       (company-mode 1)
+      (subword-mode 1)
       (turn-on-smartparens-mode)
       (display-line-numbers-mode t)
       (lsp)

--- a/hugo/content/programming/ruby.md
+++ b/hugo/content/programming/ruby.md
@@ -108,6 +108,7 @@ hook 用の関数で補完などの機能を有効にしている
 (defun my/enh-ruby-mode-hook ()
   (origami-mode 1)
   (company-mode 1)
+  (subword-mode 1)
   (lsp)
   (lsp-ui-mode 1)
   (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)

--- a/hugo/content/programming/scss.md
+++ b/hugo/content/programming/scss.md
@@ -86,6 +86,7 @@ scss を使う上で hook を使って色々有効化したりしている。
 
   (origami-mode 1)
   (company-mode 1)
+  (subword-mode 1)
   (display-line-numbers-mode 1)
 
   (rainbow-mode))

--- a/hugo/content/programming/typescript.md
+++ b/hugo/content/programming/typescript.md
@@ -79,6 +79,7 @@ hook を使って有効化している
 (defun my/ts-mode-hook ()
   (origami-mode 1)
   (company-mode 1)
+  (subword-mode 1)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode t)
   (lsp)

--- a/hugo/content/ui/hydra.md
+++ b/hugo/content/ui/hydra.md
@@ -154,6 +154,7 @@ el-get の Hydra はここで定義してしまっている。その内 el-get �
     ("v" my/toggle-view-mode       "Readonly"       :toggle view-mode)
     ("f" flycheck-mode             "Flycheck"       :toggle flycheck-mode)
     ("A" auto-fix-mode             "Auto fix"       :toggle auto-fix-mode)
+    ("^" subword-mode              "Subword"        :toggle subword-mode)
     ("E" toggle-debug-on-error     "Debug on error" :toggle debug-on-error))))
 ```
 

--- a/init.org
+++ b/init.org
@@ -2738,6 +2738,7 @@
            ("v" my/toggle-view-mode       "Readonly"       :toggle view-mode)
            ("f" flycheck-mode             "Flycheck"       :toggle flycheck-mode)
            ("A" auto-fix-mode             "Auto fix"       :toggle auto-fix-mode)
+           ("^" subword-mode              "Subword"        :toggle subword-mode)
            ("E" toggle-debug-on-error     "Debug on error" :toggle debug-on-error))))
      #+end_src
 

--- a/init.org
+++ b/init.org
@@ -4994,6 +4994,7 @@
             (setq web-mode-enable-auto-indentation nil)
             (origami-mode 1)
             (company-mode 1)
+            (subword-mode 1)
             (turn-on-smartparens-mode)
             (display-line-numbers-mode t)
             (lsp)
@@ -5162,6 +5163,7 @@
        (defun my/enh-ruby-mode-hook ()
          (origami-mode 1)
          (company-mode 1)
+         (subword-mode 1)
          (lsp)
          (lsp-ui-mode 1)
          (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)
@@ -5322,6 +5324,7 @@
 
         (origami-mode 1)
         (company-mode 1)
+        (subword-mode 1)
         (display-line-numbers-mode 1)
 
         (rainbow-mode))
@@ -5453,6 +5456,7 @@
        (defun my/ts-mode-hook ()
          (origami-mode 1)
          (company-mode 1)
+         (subword-mode 1)
          (turn-on-smartparens-strict-mode)
          (display-line-numbers-mode t)
          (lsp)

--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -13,6 +13,7 @@
 (defun my/enh-ruby-mode-hook ()
   (company-mode 1)
   (origami-mode 1)
+  (subword-mode 1)
   (lsp)
   (lsp-ui-mode 1)
   (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)

--- a/inits/40-scss.el
+++ b/inits/40-scss.el
@@ -32,6 +32,7 @@ See URL `http://stylelint.io/'."
 
   (origami-mode 1)
   (company-mode 1)
+  (subword-mode 1)
   (display-line-numbers-mode 1)
 
   (rainbow-mode))

--- a/inits/40-ts.el
+++ b/inits/40-ts.el
@@ -20,6 +20,7 @@
 (defun my/ts-mode-hook ()
   (company-mode 1)
   (origami-mode 1)
+  (subword-mode 1)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode t)
   (lsp)

--- a/inits/41-react.el
+++ b/inits/41-react.el
@@ -20,6 +20,7 @@
       (setq web-mode-enable-auto-indentation nil)
       (origami-mode 1)
       (company-mode 1)
+      (subword-mode 1)
       (turn-on-smartparens-mode)
       (display-line-numbers-mode t)
       (lsp)

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -51,6 +51,7 @@
     ("v" my/toggle-view-mode       "Readonly"       :toggle view-mode)
     ("f" flycheck-mode             "Flycheck"       :toggle flycheck-mode)
     ("A" auto-fix-mode             "Auto fix"       :toggle auto-fix-mode)
+    ("^" subword-mode              "Subword"        :toggle subword-mode)
     ("(" smartparens-strict-mode   "strict parens"  :toggle smartparens-strict-mode)
     ("E" toggle-debug-on-error     "Debug on error" :toggle debug-on-error))))
 


### PR DESCRIPTION
- ruby
- scss
- typescript
- tsx

ファイルを開く時の hook で subword-mode を有効にすることで
camelCase, PascalCase の単語区切りに簡単に移動できるようにしました。

合わせて toggle-hydra にも subword-mode の切り替え用のコマンドを追加したので
ON/OFF も簡単に行えるようにしています