### PR TITLE
fix: company-quickhelp load after pos-tip

### DIFF
--- a/inits/30-company.el
+++ b/inits/30-company.el
@@ -7,10 +7,11 @@
 (custom-set-variables '(company-show-quick-access t))
 
 (el-get-bundle company-quickhelp)
-(company-quickhelp-mode t)
-
 (custom-set-variables
  '(company-quickhelp-color-background "#323445"))
+
+(with-eval-after-load 'pos-tip
+  (company-quickhelp-mode 1))
 
 (el-get-bundle company-posframe)
 (company-posframe-mode 1)


### PR DESCRIPTION
company-quickhelp は
pos-tip に依存しているので読み込みを遅らせるようにした