### PR TITLE
feat: Add my/org-reviews-execute to global-org hydra

### DIFF
--- a/inits/69-org-mode-hydra.el
+++ b/inits/69-org-mode-hydra.el
@@ -58,9 +58,10 @@
                 :title (concat (all-the-icons-fileicon "org") " Global Org commands")
                 :quit-key "q")
     ("Main"
-     (("a" org-agenda "Agenda")
-      ("c" counsel-org-capture "Capture")
-      ("l" org-store-link "Store link")
+     (("a" org-agenda                 "Agenda")
+      ("c" counsel-org-capture        "Capture")
+      ("l" org-store-link             "Store link")
+      ("r" my/org-reviews-execute     "Review")
       ("t" my/org-tags-view-only-todo "Tagged Todo"))
 
      "Calendar"


### PR DESCRIPTION
いつでも呼び出せる org-mode 用の hydra に
my/org-reviews-execute を追加。

毎日実行しているのでそろそろ昇格させた方がいいかなって