### PR TITLE
doc: Sync key-chord.rcp

### DIFF
--- a/hugo/content/keybinds/key-chord.md
+++ b/hugo/content/keybinds/key-chord.md
@@ -26,7 +26,7 @@ el-get のレシピは自前で用意している。なおインストールし�
 そして el-get でインストールしている。
 
 ```emacs-lisp
-(el-get-bundle zk-phi/key-chord)
+(el-get-bundle key-chord)
 ```
 
 

--- a/hugo/content/keybinds/key-chord.md
+++ b/hugo/content/keybinds/key-chord.md
@@ -14,7 +14,16 @@ draft = false
 
 ## インストール {#インストール}
 
-いつも通り el-get でインストールしている。本家の方じゃないので GitHub のリポジトリから突っ込んでいる。
+el-get のレシピは自前で用意している。なおインストールしているのは本家版ではない。
+
+```emacs-lisp
+(:name key-chord
+       :description "bind commands to combinations of key-strokes"
+       :type github
+       :pkgname "zk-phi/key-chord")
+```
+
+そして el-get でインストールしている。
 
 ```emacs-lisp
 (el-get-bundle zk-phi/key-chord)

--- a/init.org
+++ b/init.org
@@ -987,7 +987,7 @@
     そして el-get でインストールしている。
 
     #+begin_src emacs-lisp :tangle inits/70-key-chord.el
-    (el-get-bundle zk-phi/key-chord)
+    (el-get-bundle key-chord)
     #+end_src
 
 *** 設定

--- a/init.org
+++ b/init.org
@@ -974,8 +974,17 @@
     :ID:       5b08b398-607f-4a9a-b5ab-772220abc8b6
     :END:
 
-    いつも通り el-get でインストールしている。
-    本家の方じゃないので GitHub のリポジトリから突っ込んでいる。
+    el-get のレシピは自前で用意している。
+    なおインストールしているのは本家版ではない。
+
+    #+begin_src emacs-lisp :tangle recipes/key-chord.rcp
+      (:name key-chord
+             :description "bind commands to combinations of key-strokes"
+             :type github
+             :pkgname "zk-phi/key-chord")
+    #+end_src
+
+    そして el-get でインストールしている。
 
     #+begin_src emacs-lisp :tangle inits/70-key-chord.el
     (el-get-bundle zk-phi/key-chord)

--- a/inits/70-key-chord.el
+++ b/inits/70-key-chord.el
@@ -1,4 +1,4 @@
-(el-get-bundle zk-phi/key-chord)
+(el-get-bundle key-chord)
 
 (setq key-chord-two-keys-delay           0.25
       key-chord-safety-interval-backward 0.1


### PR DESCRIPTION
ついでに el-get-bundle の引数もレシピの方が使われるように調整している