### PR TITLE
fix: Remove counsel-osx-app from hydra

### DIFF
--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -85,8 +85,7 @@
     ("f" counsel-find-file     "Find File")
     ("d" counsel-find-dir      "Find Dir")
     ("r" counsel-recentf       "Recentf")
-    ("L" counsel-locate        "Locate")
-    ("A" counsel-osx-app       "macOS App"))
+    ("L" counsel-locate        "Locate"))
 
    "Edit"
    (("a" align-regexp "Align Regexp")


### PR DESCRIPTION
init.org では消してたけどそれを出力していなかった