### PR TITLE
fix: Remove hexmode--xml-rpc.rcp

### DIFF
--- a/recipes/hexmode--xml-rpc.rcp
+++ b/recipes/hexmode--xml-rpc.rcp
@@ -1,5 +1,0 @@
-(:name hexmode--xml-rpc
-       :description "An elisp implementation of clientside XML-RPC"
-       :type github
-       :features "xml-rpc"
-       :pkgname "hexmode/xml-rpc-el")


### PR DESCRIPTION
昔 seesaa blog に書いていたころの
自前の Emacs プラグインで利用していたがもう不要なのでさようなら