### PR TITLE
fix: Install color-theme-molokai from recipe

### DIFF
--- a/hugo/content/ui/color-theme-molokai.md
+++ b/hugo/content/ui/color-theme-molokai.md
@@ -12,11 +12,19 @@ draft = false
 
 ## インストール {#インストール}
 
-いつも通り el-get で入れている。
-MELPA に登録されてないのかわからんけど直接 GitHub から入れている。
+el-get のレシピを自前で用意している
 
 ```emacs-lisp
-(el-get-bundle alloy-d/color-theme-molokai)
+(:name color-theme-molokai
+  :type github
+  :description "A pretty color theme."
+  :pkgname "alloy-d/color-theme-molokai")
+```
+
+そして el-get で入れている。
+
+```emacs-lisp
+(el-get-bundle color-theme-molokai)
 ```
 
 

--- a/init.org
+++ b/init.org
@@ -2323,11 +2323,20 @@
     :PROPERTIES:
     :ID:       f277aedd-c295-434e-b9ce-74c0d8348c3e
     :END:
-    いつも通り el-get で入れている。
-    MELPA に登録されてないのかわからんけど直接 GitHub から入れている。
+
+    el-get のレシピを自前で用意している
+
+    #+begin_src emacs-lisp :tangle recipes/color-theme-molokai.rcp
+      (:name color-theme-molokai
+        :type github
+        :description "A pretty color theme."
+        :pkgname "alloy-d/color-theme-molokai")
+    #+end_src
+
+    そして el-get で入れている。
 
     #+begin_src emacs-lisp :tangle inits/90-theme.el
-    (el-get-bundle alloy-d/color-theme-molokai)
+      (el-get-bundle color-theme-molokai)
     #+end_src
 *** テーマへの PATH を通す
     :PROPERTIES:

--- a/inits/90-theme.el
+++ b/inits/90-theme.el
@@ -1,4 +1,4 @@
-(el-get-bundle alloy-d/color-theme-molokai)
+(el-get-bundle color-theme-molokai)
 
 (add-to-list 'custom-theme-load-path (expand-file-name "~/.emacs.d/el-get/color-theme-molokai"))
 

--- a/recipes/color-theme-molokai.rcp
+++ b/recipes/color-theme-molokai.rcp
@@ -1,5 +1,4 @@
 (:name color-theme-molokai
-:type github
-:description "A pretty color theme."
-:pkgname "alloy-d/color-theme-molokai"
-)
+  :type github
+  :description "A pretty color theme."
+  :pkgname "alloy-d/color-theme-molokai")


### PR DESCRIPTION
color-theme-molokai を自前で用意したレシピを使って
インストールするコードに変更した

その際に init.org にレシピの追加も合わせて行っている