### PR TITLE
fix: Remove ruby-end.rcp

### DIFF
--- a/recipes/ruby-end.rcp
+++ b/recipes/ruby-end.rcp
@@ -1,4 +1,0 @@
-(:name ruby-end
-       :description "Emacs minor mode for automatic insertion of end blocks for Ruby"
-       :type github
-       :pkgname "rejeep/ruby-end.el")


### PR DESCRIPTION
https://github.com/mugijiru/.emacs.d/pull/250
https://github.com/mugijiru/.emacs.d/pull/455

あたりで使わなくなっているのにまだ残っていたので削除