### PR TITLE
doc: Sync mocker.el.rcp

### DIFF
--- a/hugo/content/testing-tool/mocker-el.md
+++ b/hugo/content/testing-tool/mocker-el.md
@@ -16,8 +16,18 @@ weight = 2
 
 ## インストール {#インストール}
 
+レシピを自前で用意して
+
+```emacs-lisp
+(:name mocker.el
+       :type github
+       :description "Mocker.el is a mocking framework for Emacs lisp."
+       :pkgname "sigma/mocker.el"
+       :minimum-emacs-version (25 1))
+```
+
 el-get で GitHub から取得している。
 
 ```emacs-lisp
-(el-get-bundle sigma/mocker.el)
+(el-get-bundle mocker.el)
 ```

--- a/init.org
+++ b/init.org
@@ -8252,10 +8252,20 @@
     :ID:       a5c87aed-a0cb-430b-bda2-0bafc371640c
     :END:
 
+    レシピを自前で用意して
+
+    #+begin_src emacs-lisp :tangle recipes/mocker.el.rcp
+      (:name mocker.el
+             :type github
+             :description "Mocker.el is a mocking framework for Emacs lisp."
+             :pkgname "sigma/mocker.el"
+             :minimum-emacs-version (25 1))
+    #+end_src
+
     el-get で GitHub から取得している。
 
     #+begin_src emacs-lisp :tangle inits/99-mocker.el
-    (el-get-bundle sigma/mocker.el)
+    (el-get-bundle mocker.el)
     #+end_src
 
 * テストコード

--- a/inits/99-mocker.el
+++ b/inits/99-mocker.el
@@ -1,1 +1,1 @@
-(el-get-bundle sigma/mocker.el)
+(el-get-bundle mocker.el)

--- a/recipes/mocker.el.rcp
+++ b/recipes/mocker.el.rcp
@@ -1,6 +1,5 @@
 (:name mocker.el
-:type github
-:description "Mocker.el is a mocking framework for Emacs lisp."
-:pkgname "sigma/mocker.el"
-:minimum-emacs-version (25 1)
-)
+       :type github
+       :description "Mocker.el is a mocking framework for Emacs lisp."
+       :pkgname "sigma/mocker.el"
+       :minimum-emacs-version (25 1))


### PR DESCRIPTION
ついでに GitHub を直接指定していたところを
recipe 経由で取得するように直している