### PR TITLE
chore: Bump Emacs version on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           - 27.2
           - 28.1
           - 28.2
+          - 29.1
 
     steps:
     - uses: purcell/setup-emacs@master


### PR DESCRIPTION
メインで利用している環境の Emacs のバージョンが上がったので
それに合わせて GitHub Actions で使うバージョンも上げておいた