### PR TITLE
ci: Use Emacs 29.1 on update packages

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 28.2
+        version: 29.1
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 28.2
+        version: 29.1
 
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
パッケージの更新関係の処理では Emacs 29.1 を使うようにした。
今メインで利用中の環境が Emacs 29.1 であり、
そしてそれによって el-get.lock に差分が生まれたりするため