### PR TITLE
Revert "ci: Use Emacs 29.1 on update packages"

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 29.1
+        version: 28.2
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 29.1
+        version: 28.2
 
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
Reverts mugijiru/.emacs.d#2771

el-get 本体のインストールがうまくいかなくて update を確認できないので一旦 revert...