### PR TITLE
ci: Change slack webhook for hugo build notification

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -51,7 +51,6 @@ jobs:
           mention: 'here'
           username: 'GitHub Actions'
           mention_if: 'failure'
-          channel: '#develop'
-          url: ${{ secrets.SLACK_WEBHOOK }}
+          url: ${{ secrets.HUGO_BUILD_TO_SLACK }}
           commit: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hugo の build 通知の送信先を変更した。
App 版の Incoming webhook に切り替えたついでに
投稿するチャンネルも変更している