### PR TITLE
ci: Use hugo v0.116.1

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.104.2'
+          hugo-version: '0.117.0'
+          extended: true
 
       - name: Build
         run: |


### PR DESCRIPTION
現在手元の環境で動いているのと同じバージョンを使うようにした

latest 指定もできるんだけど
以前別のリポジトリでやった時はうまく動かなかった……

https://github.com/mugijiru/mugijiru.github.com/pull/56/commits/6a5784450d25f547bc6d4e36dd373f0bce8a2e9f