### PR TITLE
ci: Use fixed version emacs for CI and package update

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 28.2
+        version: 29.1
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           - 27.2
           - 28.1
           - 28.2
+          - 29.1
 
     steps:
     - uses: purcell/setup-emacs@master
@@ -23,4 +24,8 @@ jobs:
 
     - name: Run tests
       run: |
-        emacs -Q --batch --eval "(setq user-emacs-directory \"$(pwd)/\")" -l inits/test/*-test.el -l inits/test/run-tests.el
+        emacs -Q --batch --eval "(setq user-emacs-directory \"$(pwd)/\")" \
+        --eval '(setq el-get-git-install-url "https://github.com/mugijiru/el-get.git")' \
+        --eval '(setq el-get-install-branch "fix-install-for-emacs29")' \
+        -l inits/test/*-test.el \
+        -l inits/test/run-tests.el

--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -20,13 +20,17 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 28.2
+        version: 29.1
 
     - uses: actions/checkout@v3
 
     - name: Update package
       run: |
-        emacs -Q --batch --eval "(setq user-emacs-directory \"$(pwd)/\")" -l ./init-el-get.el --eval="(my/el-get-auto-update \"$PACKAGE\")"
+        emacs -Q --batch --eval "(setq user-emacs-directory \"$(pwd)/\")" \
+          -l ./init-el-get.el \
+          --eval '(setq el-get-git-install-url "https://github.com/mugijiru/el-get.git")' \
+          --eval '(setq el-get-install-branch "fix-install-for-emacs29")' \
+          --eval "(my/el-get-auto-update \"$PACKAGE\")"
 
     - name: Detect el-get.lock diff
       run: |

--- a/count-emacs-obsolute-packages.sh
+++ b/count-emacs-obsolute-packages.sh
@@ -5,7 +5,11 @@ current=`date +%s`
 script_dir=$(cd $(dirname $0); pwd)
 
 if [ ! -e $file ] || [ $(($current-$(stat -c "%Y" $file))) -gt 3600 ]; then
-    emacs --batch -Q --eval "(setq user-emacs-directory \"${script_dir}/\")" -l ${script_dir}/el-get-lock-update-check.el --eval="(el-get-lock-update-check-print-obsolute-only)" > $file
+    emacs --batch -Q --eval "(setq user-emacs-directory \"${script_dir}/\")" \
+          -l ${script_dir}/el-get-lock-update-check.el \
+          --eval '(setq el-get-git-install-url "https://github.com/mugijiru/el-get.git")' \
+          --eval '(setq el-get-install-branch "fix-install-for-emacs29")' \
+          --eval "(el-get-lock-update-check-print-obsolute-only)" > $file
 fi
 
 wc -l $file | cut -d " " -f 1


### PR DESCRIPTION
# 概要

Emacs 29.1 で CI と package の update をチェックするようにした