### PR TITLE
feat: Use flycheck on terraform-mode

### DIFF
--- a/hugo/content/programming/terraform.md
+++ b/hugo/content/programming/terraform.md
@@ -53,11 +53,16 @@ origami
 company
 : コード補完
 
+flyccheck
+: コードの変な部分の指摘
+
 smartparens-strict-mode
 : カッコの対応を強力にしてくれるやつ
 
 display-line-numbers-mode
 : 行数表示
+
+flycheck に関しては [terraform-tflint が tflint 0.47 に対応してない](https://github.com/flycheck/flycheck/issues/2024)のでそいつだけ無効にしている
 
 :ID:       dc0abe68-1440-4519-9b27-01856ebca176
 
@@ -65,6 +70,9 @@ display-line-numbers-mode
 (defun my/terraform-mode-hook ()
   (origami-mode 1)
   (company-mode 1)
+  (setq-local flycheck-checker 'terraform)
+  (setq-local flycheck-disabled-checkers '(terraform-tflint))
+  (flycheck-mode 1)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode 1))
 

--- a/init.org
+++ b/init.org
@@ -5728,8 +5728,12 @@
 
      - origami :: コードの折り畳み
      - company :: コード補完
+     - flyccheck :: コードの変な部分の指摘
      - smartparens-strict-mode :: カッコの対応を強力にしてくれるやつ
      - display-line-numbers-mode :: 行数表示
+
+     flycheck に関しては [[https://github.com/flycheck/flycheck/issues/2024][terraform-tflint が tflint 0.47 に対応してない]]ので
+     そいつだけ無効にしている
 
      :PROPERTIES:
      :ID:       dc0abe68-1440-4519-9b27-01856ebca176
@@ -5738,6 +5742,9 @@
        (defun my/terraform-mode-hook ()
          (origami-mode 1)
          (company-mode 1)
+         (setq-local flycheck-checker 'terraform)
+         (setq-local flycheck-disabled-checkers '(terraform-tflint))
+         (flycheck-mode 1)
          (turn-on-smartparens-strict-mode)
          (display-line-numbers-mode 1))
 

--- a/inits/40-terraform.el
+++ b/inits/40-terraform.el
@@ -6,6 +6,9 @@
 (defun my/terraform-mode-hook ()
   (origami-mode 1)
   (company-mode 1)
+  (setq-local flycheck-checker 'terraform)
+  (setq-local flycheck-disabled-checkers '(terraform-tflint))
+  (flycheck-mode 1)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode 1))
 


### PR DESCRIPTION
terraform-mode で flycheck を使うようにした
ただし terraform-tflint は tflint 0.47 以降に対応してないので
そちらは無効にしている