### PR TITLE
Add magit.rcp

### DIFF
--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -1,0 +1,23 @@
+(:name magit
+       :website "https://github.com/magit/magit#readme"
+       :description "It's Magit! An Emacs mode for Git."
+       :type github
+       :pkgname "magit/magit"
+       :branch "main"
+       :minimum-emacs-version "25.1"
+       ;; Note: `git-commit' is shipped with `magit' code itself.
+       ;; Note: `magit-section' is shipped with `magit' code itself.
+       :depends (dash transient with-editor compat seq)
+       :info "docs"
+       :load-path "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.  Create an
+       ;; empty autoloads file because magit.el explicitly checks for
+       ;; a file of that name.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+                ("touch" "lisp/magit-autoloads.el"))
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+                              ("touch" "lisp/magit-autoloads.el"))
+       ;; assume windows lacks make and makeinfo
+       :build/windows-nt (with-temp-file "lisp/magit-autoloads.el" nil))


### PR DESCRIPTION
magit が
https://github.com/magit/magit/commit/84eaa203f3c70d55f29fbe6a8d6d9d5334cb6818
で seq-2.24 に依存するようになったが
Emacs 29.1 に builtin されている seq は 2.23 なので
別でインストールする必要がある

というわけで依存関係に含めたレシピを用意した