### PR TITLE
fix: Add .org extension to org-journal file

### DIFF
--- a/hugo/content/org-mode/org-journal.md
+++ b/hugo/content/org-mode/org-journal.md
@@ -37,5 +37,6 @@ draft = false
 ```emacs-lisp
 (custom-set-variables
  '(org-journal-dir (concat org-directory "journal/"))
+ '(org-journal-file-format "%Y%m%d.org")
  '(org-journal-date-format "%d日(%a)"))
 ```

--- a/init.org
+++ b/init.org
@@ -8219,9 +8219,10 @@
 *** 設定
 
 #+begin_src emacs-lisp :tangle inits/61-org-journal.el
-(custom-set-variables
- '(org-journal-dir (concat org-directory "journal/"))
- '(org-journal-date-format "%d日(%a)"))
+  (custom-set-variables
+   '(org-journal-dir (concat org-directory "journal/"))
+   '(org-journal-file-format "%Y%m%d.org")
+   '(org-journal-date-format "%d日(%a)"))
 #+end_src
 
 ** ox-hugo

--- a/inits/61-org-journal.el
+++ b/inits/61-org-journal.el
@@ -2,4 +2,5 @@
 
 (custom-set-variables
  '(org-journal-dir (concat org-directory "journal/"))
+ '(org-journal-file-format "%Y%m%d.org")
  '(org-journal-date-format "%d日(%a)"))


### PR DESCRIPTION
org-jounal-new-entry で生成されるファイル名に
`.org` の拡張子をつけるようにした

拡張子がないとまず単純に気持ち悪いし、
普通にファイルを開いた時に org-mode で開いてくれないので不便なのよね