### PR TITLE
chore: Use org-mode v9.6.6

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((org-journal :checksum "a306f76ee2b0292946a20530bd9114aefc85a263")
+      '((org-mode :checksum "17608670a4f4e8edb91efe04d86fe80ff9d01b69")
+        (org-journal :checksum "a306f76ee2b0292946a20530bd9114aefc85a263")
         (company-terraform :checksum "8d5a16d1bbeeb18ca49a8fd57b5d8cd30c8b8dc7")
         (terraform-mode :checksum "25a22a66f81e35c75f2fdaaab89aad7f9940fe06")
         (hcl-mode :checksum "ec27736c4c16fbf7f1ecab0210ec3c71ac2406fa")
@@ -165,7 +166,6 @@
         (page-break-lines :checksum "5e9ed86bb56fd076b12ae7adaf40eeaa09aed4c5")
         (org-trello :checksum "fc63ed580101e6160edfb6f43215fb3200ce1ea7")
         (undo-fu :checksum "0e74116fd5c7797811a91ba4eadef50d67523eb6")
-        (emacs-todoist :checksum "e1d1b602430f7a5bb84f9b52d96fe552def9ed3d")
-        (org-mode :checksum "abedf386b3f13af2769728755d00c4698ac5d3b0")))
+        (emacs-todoist :checksum "e1d1b602430f7a5bb84f9b52d96fe552def9ed3d")))
 (setq el-get-lock-locked-packages 'nil)
 (setq el-get-lock-unlocked-packages 'nil)

--- a/hugo/content/org-mode/base.md
+++ b/hugo/content/org-mode/base.md
@@ -11,17 +11,36 @@ weight = 1
 
 ## org-mode のインストール {#org-mode-のインストール}
 
-Emacs に標準で入っている org-mode は大体古過ぎるのでとりあえずデフォルトで入ってるやつは削除しちゃって
-el-get でインストールしている。
+Emacs に標準で入っている org-mode は古かったりするのでとりあえずデフォルトで入ってるやつは削除しちゃって el-get でインストールしている。
 
 ```emacs-lisp
 (el-get-bundle org-mode)
 ```
 
-なんか入れてるパッケージの問題か、依存関係が解決できなかったので
-Git から入れた上でバージョンを固定している。
+とりあえず今は Emacs 29.1 に標準で bundle されているバージョンを入れておいている。バージョンを固定するために el-get についているレシピをコピーして書き換えて使っている。
 
-バージョンぐらいはそのうち上げたいね
+```emacs-lisp
+(:name org-mode
+       :website "http://orgmode.org/"
+       :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
+       :type git
+       :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
+       :checkout "release_9.6.6"
+       :info "doc"
+       :build/berkeley-unix `,(mapcar
+                               (lambda (target)
+                                 (list "gmake" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
+                               '("oldorg"))
+       :build `,(mapcar
+                 (lambda (target)
+                   (list "make" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
+                 '("oldorg"))
+       :load-path ("." "lisp")
+       :load ("lisp/org-loaddefs.el"))
+```
+
+その内もっと新しいのにするけど
+<span class="timestamp-wrapper"><span class="timestamp">[2023-10-30 月] </span></span> に main ブランチのものを入れたら agenda が動かなくなって焦ったのでまた落ち着いた時にトライする
 
 
 ## org 用ディレクトリの指定 {#org-用ディレクトリの指定}

--- a/init.org
+++ b/init.org
@@ -6918,18 +6918,39 @@
     :PROPERTIES:
     :ID:       dd3c3e63-3019-4db0-a796-a45c73666374
     :END:
-    Emacs に標準で入っている org-mode は大体古過ぎるので
-    とりあえずデフォルトで入ってるやつは削除しちゃって
-    el-get でインストールしている。
+    Emacs に標準で入っている org-mode は古かったりするので
+    とりあえずデフォルトで入ってるやつは削除しちゃって el-get でインストールしている。
 
     #+begin_src emacs-lisp :tangle inits/60-org.el
     (el-get-bundle org-mode)
     #+end_src
 
-    なんか入れてるパッケージの問題か、依存関係が解決できなかったので
-    Git から入れた上でバージョンを固定している。
+    とりあえず今は Emacs 29.1 に標準で bundle されているバージョンを入れておいている。
+    バージョンを固定するために el-get についているレシピをコピーして書き換えて使っている。
 
-    バージョンぐらいはそのうち上げたいね
+    #+begin_src emacs-lisp :tangle recipes/org-mode.rcp
+      (:name org-mode
+             :website "http://orgmode.org/"
+             :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
+             :type git
+             :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
+             :checkout "release_9.6.6"
+             :info "doc"
+             :build/berkeley-unix `,(mapcar
+                                     (lambda (target)
+                                       (list "gmake" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
+                                     '("oldorg"))
+             :build `,(mapcar
+                       (lambda (target)
+                         (list "make" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
+                       '("oldorg"))
+             :load-path ("." "lisp")
+             :load ("lisp/org-loaddefs.el"))
+    #+end_src
+
+    その内もっと新しいのにするけど
+    [2023-10-30 月] に main ブランチのものを入れたら agenda が動かなくなって焦ったので
+    また落ち着いた時にトライする
 
 *** org 用ディレクトリの指定
     :PROPERTIES:

--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -13,5 +13,5 @@
                  (lambda (target)
                    (list "make" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
                  '("oldorg"))
-       :load-path ("." "contrib/lisp" "lisp")
+       :load-path ("." "lisp")
        :load ("lisp/org-loaddefs.el"))

--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -3,7 +3,7 @@
        :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
        :type git
        :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
-       :checkout "release_9.4.4"
+       :checkout "release_9.6.6"
        :info "doc"
        :build/berkeley-unix `,(mapcar
                                (lambda (target)


### PR DESCRIPTION
https://github.com/mugijiru/.emacs.d/pull/3196 で org-mode の最新開発版にしたら
org-agenda を開こうとすると CPU 使用率 100% になってしまったり
https://github.com/mugijiru/.emacs.d/pull/3200 で元々使ってたバージョンに戻そうとしたら
なんか build できなくて戻せなくなったりしたので
とりあえず Emacs 29.1 に標準でバンドルされている版を使うようにした

最新リリース版は 9.6.8 なのでどこかでそれに上げたい