### PR TITLE
feat: Turn off tempbuf-mode on today journal file

### DIFF
--- a/hugo/content/buffer-management/tempbuf.md
+++ b/hugo/content/buffer-management/tempbuf.md
@@ -37,11 +37,18 @@ kill されると org-clock が狂って面倒なことになるのでそれら�
 find-file した時に上でリストアップしたファイルだった場合は kill されないように
 tempbuf-mode が自動的に無効になるような hook を用意している。
 
+あとその日の journal ファイルも勝手に kill されると org-clock 的に困るので
+tempbuf-mode をオフにしている
+
 ```emacs-lisp
 (defun my/find-file-tempbuf-hook ()
-  (let ((ignore-file-names (mapcar 'expand-file-name my/tempbuf-ignore-files)))
-    (unless (member (buffer-file-name) ignore-file-names)
-      (turn-on-tempbuf-mode))))
+  (cond
+   ((string= (org-journal--get-entry-path) (buffer-file-name))
+    (turn-off-tempbuf-mode))
+   (t
+    (let ((ignore-file-names (mapcar 'expand-file-name my/tempbuf-ignore-files)))
+      (unless (member (buffer-file-name) ignore-file-names)
+        (turn-on-tempbuf-mode))))))
 ```
 
 

--- a/init.org
+++ b/init.org
@@ -921,11 +921,18 @@
     上でリストアップしたファイルだった場合は kill されないように
     tempbuf-mode が自動的に無効になるような hook を用意している。
 
+    あとその日の journal ファイルも勝手に kill されると org-clock 的に困るので
+    tempbuf-mode をオフにしている
+
     #+begin_src emacs-lisp :tangle inits/70-tempbuf.el
-    (defun my/find-file-tempbuf-hook ()
-      (let ((ignore-file-names (mapcar 'expand-file-name my/tempbuf-ignore-files)))
-        (unless (member (buffer-file-name) ignore-file-names)
-          (turn-on-tempbuf-mode))))
+      (defun my/find-file-tempbuf-hook ()
+        (cond
+         ((string= (org-journal--get-entry-path) (buffer-file-name))
+          (turn-off-tempbuf-mode))
+         (t
+          (let ((ignore-file-names (mapcar 'expand-file-name my/tempbuf-ignore-files)))
+            (unless (member (buffer-file-name) ignore-file-names)
+              (turn-on-tempbuf-mode))))))
     #+end_src
 *** hook の設定
     :PROPERTIES:

--- a/inits/70-tempbuf.el
+++ b/inits/70-tempbuf.el
@@ -6,9 +6,13 @@
                                 ))
 
 (defun my/find-file-tempbuf-hook ()
-  (let ((ignore-file-names (mapcar 'expand-file-name my/tempbuf-ignore-files)))
-    (unless (member (buffer-file-name) ignore-file-names)
-      (turn-on-tempbuf-mode))))
+  (cond
+   ((string= (org-journal--get-entry-path) (buffer-file-name))
+    (turn-off-tempbuf-mode))
+   (t
+    (let ((ignore-file-names (mapcar 'expand-file-name my/tempbuf-ignore-files)))
+      (unless (member (buffer-file-name) ignore-file-names)
+        (turn-on-tempbuf-mode))))))
 
 (add-hook 'find-file-hook 'my/find-file-tempbuf-hook)
 


### PR DESCRIPTION
# 概要

その日の journal ファイルを開いた時に tempbuf-mode をオフにするようにした

# 課題

その日の journal ファイルにはその日のタスクも積んでいて
それに対して org-clock を実行している。

しかしそのバッファが勝手に kill されると org-clock が狂ってしまう

# 対応内容

org-clock が狂ってしまわないようにするため
その日の journal ファイルも勝手に kill されないように調整した。

# その他

org-clock が動いているバッファを検知して kill を中断させる機構があれば
この hook は不要になりそうだけど
とりあえずそのあたりを調べるのが面倒なので一旦これでお茶を濁す