### PR TITLE
feat: Improve org-journal settings

### DIFF
--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -4,9 +4,8 @@
 
 (setq org-agenda-span 'day)
 
-(setq org-agenda-files
-      '("~/Documents/org/journal/"
-        "~/Documents/org/tasks/"))
+(custom-set-variables
+ '(org-agenda-files '("~/Documents/org/tasks/")))
 
 (setq org-agenda-use-time-grid nil)
 

--- a/inits/61-org-journal.el
+++ b/inits/61-org-journal.el
@@ -3,4 +3,6 @@
 (custom-set-variables
  '(org-journal-dir (concat org-directory "journal/"))
  '(org-journal-file-format "%Y%m%d.org")
- '(org-journal-date-format "%d日(%a)"))
+ '(org-journal-date-format "%d日(%a)")
+ '(org-journal-enable-agenda-integration t)
+ '(org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}"))


### PR DESCRIPTION
- org-journal-enable-agenda-integration で
  journal ファイルを自動的に org-agenda-files に入れさせるように
- org-journal-carryover-items を変更し
  作業中のタスクも翌日の journal ファイルに移動されるようにした