### PR TITLE
feat: Add GoogleCalendar file to org-agenda-files

### DIFF
--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -5,7 +5,7 @@
 (setq org-agenda-span 'day)
 
 (custom-set-variables
- '(org-agenda-files '("~/Documents/org/tasks/")))
+ '(org-agenda-files '("~/Documents/org/gcals/mugijiru.org" "~/Documents/org/tasks/")))
 
 (setq org-agenda-use-time-grid nil)
 


### PR DESCRIPTION
clocktable で表示されてほしかったので
org-agenda-files に突っ込んだ