### PR TITLE
fix: Refile today journal file

### DIFF
--- a/hugo/content/org-mode/org-journal.md
+++ b/hugo/content/org-mode/org-journal.md
@@ -31,6 +31,12 @@ draft = false
 (el-get-bundle org-journal)
 ```
 
+また [refile 先の候補設定]({{< relref "org-refile#refile-先の候補設定" >}}) で `org-journal--get-entry-path` という内部関数を使ってしまっていてそれが読み込まれていないと困るので、ここで require まで行っている
+
+```emacs-lisp
+(require 'org-journal)
+```
+
 
 ## 設定 {#設定}
 

--- a/hugo/content/org-mode/org-refile.md
+++ b/hugo/content/org-mode/org-refile.md
@@ -39,7 +39,8 @@ nil だと移動先候補PATHの最後の部分しか表示されないのでど
 いくつかの org ファイルを使っているのでターゲットを以下のように設定している。
 
 ```emacs-lisp
-(setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 1)
+(setq org-refile-targets `((,(org-journal--get-entry-path) :regexp . "Tasks")
+                           (,(concat org-directory "tasks/projects.org") :level . 1)
                            (,(concat org-directory "tasks/pointers.org") :level . 1)
                            (,(concat org-directory "work/scrum/impediments.org") :level . 3)
                            (,(concat org-directory "tasks/next-actions.org") :regexp . "today")
@@ -56,6 +57,6 @@ nil だと移動先候補PATHの最後の部分しか表示されないのでど
 | impediments.org    | スクラムの妨害リストでも作ってみようかと思って用意したやつ。放置中 |
 | next-actions today | その日やる作業を放り込むところ。projects や inbox から移動する時に使う。 |
 | next-actions C-    | いくつかの作業を各階層に分けて管理しようとしていたのでターゲット指定している。放置中。 |
-| 2020\_summary.org  | 2020 年の個人ふりかえり用。もう 2020 年は大昔なので当然もう使っていない |
+| 2020_summary.org   | 2020 年の個人ふりかえり用。もう 2020 年は大昔なので当然もう使っていない |
 | shopping.org       | 買物リスト。時々思い出した時に放り込んでるが主に使うのは beorg からなので refile では使ってない |
 | someday.org        | 遠い将来やるかもしれないリスト。放り込んで忘れるためにあるところ |

--- a/init.org
+++ b/init.org
@@ -8118,14 +8118,15 @@
      ターゲットを以下のように設定している。
 
      #+begin_src emacs-lisp :tangle inits/61-org-refile.el
-     (setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 1)
-                                (,(concat org-directory "tasks/pointers.org") :level . 1)
-                                (,(concat org-directory "work/scrum/impediments.org") :level . 3)
-                                (,(concat org-directory "tasks/next-actions.org") :regexp . "today")
-                                (,(concat org-directory "tasks/next-actions.org") :regexp . "C-")
-                                (,(concat org-directory "private/2020_summary.org") :level . 2)
-                                (,(concat org-directory "tasks/shopping.org") :level . 1)
-                                (,(concat org-directory "tasks/someday.org") :level . 1)))
+       (setq org-refile-targets `((,(org-journal--get-entry-path) :regexp . "Tasks")
+                                  (,(concat org-directory "tasks/projects.org") :level . 1)
+                                  (,(concat org-directory "tasks/pointers.org") :level . 1)
+                                  (,(concat org-directory "work/scrum/impediments.org") :level . 3)
+                                  (,(concat org-directory "tasks/next-actions.org") :regexp . "today")
+                                  (,(concat org-directory "tasks/next-actions.org") :regexp . "C-")
+                                  (,(concat org-directory "private/2020_summary.org") :level . 2)
+                                  (,(concat org-directory "tasks/shopping.org") :level . 1)
+                                  (,(concat org-directory "tasks/someday.org") :level . 1)))
      #+end_src
 
      | ターゲット         | 目的                                                                                                   |
@@ -8241,6 +8242,14 @@
 
 #+begin_src emacs-lisp :tangle inits/61-org-journal.el
 (el-get-bundle org-journal)
+#+end_src
+
+また [[id:5b4ca1a6-ade9-4768-9a06-0dbf57cffcba][refile 先の候補設定]] で ~org-journal--get-entry-path~ という内部関数を使ってしまっていて
+それが読み込まれていないと困るので、
+ここで require まで行っている
+
+#+begin_src emacs-lisp :tangle inits/61-org-journal.el
+(require 'org-journal)
 #+end_src
 
 *** 設定

--- a/inits/61-org-journal.el
+++ b/inits/61-org-journal.el
@@ -1,4 +1,5 @@
 (el-get-bundle org-journal)
+(require 'org-journal)
 
 (custom-set-variables
  '(org-journal-dir (concat org-directory "journal/"))

--- a/inits/61-org-journal.el
+++ b/inits/61-org-journal.el
@@ -1,4 +1,5 @@
 (el-get-bundle org-journal)
+
 (require 'org-journal)
 
 (custom-set-variables

--- a/inits/61-org-refile.el
+++ b/inits/61-org-refile.el
@@ -2,7 +2,8 @@
 
 (setq org-refile-use-outline-path 'file)
 
-(setq org-refile-targets `((,(concat org-directory "tasks/projects.org") :level . 1)
+(setq org-refile-targets `((,(org-journal--get-entry-path) :regexp . "Tasks")
+                           (,(concat org-directory "tasks/projects.org") :level . 1)
                            (,(concat org-directory "tasks/pointers.org") :level . 1)
                            (,(concat org-directory "work/scrum/impediments.org") :level . 3)
                            (,(concat org-directory "tasks/next-actions.org") :regexp . "today")


### PR DESCRIPTION
Emacs を開いた直後にもその日の journal ファイルに refile できるようにしました。

ただし refile 先が存在する前提で実装してるのでなかった場合はどうなるか知らない。
ま、それはそれで困った時にまた直せば良さそう