### PR TITLE
fix: Use current date on org clocktable block

### DIFF
--- a/snippets/org-mode/report
+++ b/snippets/org-mode/report
@@ -2,5 +2,5 @@
 # name: report
 # --
 ** Report
-#+BEGIN: clocktable :scope agenda-with-archives :maxlevel 10 :lang "ja" :block 2023-11-01 :level 4 :fileskip0 t :link t
+#+BEGIN: clocktable :scope agenda-with-archives :maxlevel 10 :lang "ja" :block `(format-time-string "%Y-%m-%d")` :level 4 :fileskip0 t :link t
 #+END:


### PR DESCRIPTION
2023-11-01 を固定で指定してしまっていたので修正