### PR TITLE
feat: org clocktable scope includes yesterday's journal file

### DIFF
--- a/inits/61-org-journal.el
+++ b/inits/61-org-journal.el
@@ -2,6 +2,15 @@
 
 (require 'org-journal)
 
+(defun my/org-agenda-scope-with-yesterday-journal ()
+  (let* ((agenda-files (org-agenda-files t))
+         (24-hours-ago (* -60 60 24))
+         (yesterday (time-add (current-time) 24-hours-ago))
+         (yesterday-string (format-time-string "%Y%m%d" yesterday))
+         (yesterday-journal-file-path (concat org-journal-dir yesterday-string ".org"))
+         (files (append `(,yesterday-journal-file-path) agenda-files)))
+    (org-add-archive-files files)))
+
 (custom-set-variables
  '(org-journal-dir (concat org-directory "journal/"))
  '(org-journal-file-format "%Y%m%d.org")

--- a/snippets/org-mode/report
+++ b/snippets/org-mode/report
@@ -2,5 +2,5 @@
 # name: report
 # --
 ** Report
-#+BEGIN: clocktable :scope agenda-with-archives :maxlevel 10 :lang "ja" :block `(format-time-string "%Y-%m-%d")` :level 4 :fileskip0 t :link t
+#+BEGIN: clocktable :scope my/org-agenda-scope-with-yesterday-journal :maxlevel 10 :lang "ja" :block `(format-time-string "%Y-%m-%d")` :level 4 :fileskip0 t :link t
 #+END:


### PR DESCRIPTION
# 概要

前日分の journal ファイルも clocktable の検索対象に含めるように調整した。

翌日になってから前日分の clocktable を更新すると
前日の作業分が反映されなくて困っていたため。

# 気になること

もう少し単純に、その時に触ってるファイルを含めるようにした方が良かったのかも。
そうすると、2日後に更新する場合でも対応できるので……。

でも今から直すの面倒なので一旦このまま放り込む