### PR TITLE
feat: Retry org-roam

### DIFF
--- a/inits/65-org-roam.el
+++ b/inits/65-org-roam.el
@@ -1,9 +1,9 @@
 (el-get-bundle org-roam)
 
 (custom-set-variables
- '(org-roam-directory (file-truename org-directory)))
+ '(org-roam-directory (file-truename (concat org-directory "roam/"))))
 
-;; (org-roam-db-autosync-mode 1)
+(org-roam-db-autosync-mode 1)
 
 (with-eval-after-load 'pretty-hydra
   (pretty-hydra-define org-roam-hydra (:separator "-"

--- a/inits/65-org-roam.el
+++ b/inits/65-org-roam.el
@@ -6,10 +6,17 @@
 (org-roam-db-autosync-mode 1)
 
 (with-eval-after-load 'pretty-hydra
-  (pretty-hydra-define org-roam-hydra (:separator "-"
-                                                  :color teal
-                                                  :foreign-key warn
-                                                  :title (concat (all-the-icons-material "graphic_eq") " Roam")
-                                                  :quit-key "q")
-    ("commands"
-     (("i" org-roam-node-insert "Insert")))))
+  (pretty-hydra-define
+    org-roam-hydra
+    (:separator "-"
+                :color teal
+                :foreign-key warn
+                :title (concat (all-the-icons-material "graphic_eq") " Roam")
+                :quit-key "q")
+    ("Node"
+     (("f" org-roam-node-find "Find")
+      ("r" org-roam-node-random "Random"))
+
+     "DB"
+     (("S" org-roam-db-sync "Sync")
+      ("C" org-roam-db-clear-all "Clear")))))

--- a/inits/69-org-mode-hydra.el
+++ b/inits/69-org-mode-hydra.el
@@ -37,9 +37,6 @@
      (("e" org-babel-confirm-evaluate "Eval")
       ("x" org-babel-tangle "Export SRC"))
 
-     "Roam"
-     ((";" org-roam-hydra/body "Menu"))
-
      "Trello"
      (("K" org-trello-mode "On/Off" :toggle org-trello-mode)
       ("k" (if org-trello-mode
@@ -78,8 +75,10 @@
       ("j" org-clock-goto     "Goto"))
 
      "Search"
-     (("H" org-search-view "Heading")
-      ("f" org-roam-find-file "Roam"))
+     (("H" org-search-view "Heading"))
+
+     "Roam"
+     ((";" org-roam-hydra/body "Menu"))
 
      "Pomodoro"
      (("p" org-pomodoro "Pomodoro")))))


### PR DESCRIPTION
以前の導入時は DB 構築で時間がかかりまくるので断念したが
とりあえず今回は roam フォルダ以下に限定することで DB 構築に時間がかからないようにして使い始めた

その際に簡単に Hydra も用意している。

本当は major-mode-hydra にも入れたいが
org-roam が有効でない時に実行してもしょうがないので一旦諦めている。