### PR TITLE
feat: Add frozen_string_literal snippet for enh-ruby-mode

### DIFF
--- a/snippets/enh-ruby-mode/frozen_string_literal
+++ b/snippets/enh-ruby-mode/frozen_string_literal
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: frozen_string_literal
+# key: frozen
+# --
+# frozen_string_literal: true


### PR DESCRIPTION
# 概要

frozen_string_literal のマジックコメントを簡単に挿入できるようにするため
snippet を追加した

# 課題

frozen_string_literal を rubocop で強制挿入することを検討していたけど
それをしようとすると unsafe での autocorrect になる。

unsafe の自動修正を強制するのは避けたいのでそれは断念し
その代わり、frozen_string_literal のマジックコメントを簡単に入れられるようにするため snippet を用意した

# 使い方

`frozen` をキーにしているので、それだけ入力してタブを叩けば OK
或いは `yas-insert-snippet` を実行したら ivy で選択もできるようになっている。