### PR TITLE
fix: Remove unnecessary variable org-overriding-columns-format

### DIFF
--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -159,7 +159,6 @@ nil にして表示しないようにしている。
                 (org-habit-show-habits nil)
                 (org-agenda-span 'day)
                 (org-agenda-todo-keyword-format "-")
-                (org-overriding-columns-format "%25ITEM %TODO")
                 (org-agenda-files '("~/Documents/org/tasks/next-actions.org"
                                     "~/Documents/org/journal/"
                                     "~/Documents/org/tasks/reviews.org"))
@@ -173,7 +172,6 @@ nil にして表示しないようにしている。
                 (org-habit-show-habits nil)
                 (org-agenda-span 'day)
                 (org-agenda-todo-keyword-format "-")
-                (org-overriding-columns-format "%25ITEM %TODO")
                 (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                 (org-super-agenda-groups `((:name "〆切が過ぎてる作業" :and (:deadline past :not (:category "Private")))
                                            (:name "予定が過ぎてる作業" :and (:scheduled past :not (:category "Private")))
@@ -198,7 +196,6 @@ nil にして表示しないようにしている。
                 (org-habit-show-habits nil)
                 (org-agenda-span 'day)
                 (org-agenda-todo-keyword-format "-")
-                (org-overriding-columns-format "%25ITEM %TODO")
                 (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                 (org-super-agenda-groups '((:name "仕掛かり中" :and (:todo "DOING" :not (:category "レビュー") :not (:category "開発")))
                                            (:name "TODO" :and (:todo "TODO" :not (:category "レビュー") :not (:category "開発")))
@@ -210,7 +207,6 @@ nil にして表示しないようにしている。
                 (org-habit-show-habits nil)
                 (org-agenda-span 'day)
                 (org-agenda-todo-keyword-format "-")
-                (org-overriding-columns-format "%25ITEM %TODO")
                 (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                 (org-super-agenda-groups `((:name "〆切が過ぎてる作業" :and (:deadline past :category "Private"))
                                            (:name "予定が過ぎてる作業" :and (:scheduled past :category "Private"))
@@ -243,7 +239,6 @@ nil にして表示しないようにしている。
                           (org-habit-show-habits nil)
                           (org-agenda-span 'day)
                           (org-agenda-todo-keyword-format "-")
-                          (org-overriding-columns-format "%25ITEM %TODO")
                           (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                           (org-super-agenda-groups (append
                                                     (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
@@ -254,7 +249,6 @@ nil にして表示しないようにしている。
                           (org-habit-show-habits nil)
                           (org-agenda-span 'day)
                           (org-agenda-todo-keyword-format "-")
-                          (org-overriding-columns-format "%25ITEM %TODO")
                           (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                           (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
                                                      (:name "予定が過ぎてる作業" :scheduled past)
@@ -272,7 +266,6 @@ nil にして表示しないようにしている。
                  (org-habit-show-habits nil)
                  (org-agenda-span 'day)
                  (org-agenda-todo-keyword-format "-")
-                 (org-overriding-columns-format "%25ITEM %TODO")
                  (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                  (org-super-agenda-groups (append
                                            (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
@@ -283,7 +276,6 @@ nil にして表示しないようにしている。
                  (org-habit-show-habits nil)
                  (org-agenda-span 'day)
                  (org-agenda-todo-keyword-format "-")
-                 (org-overriding-columns-format "%25ITEM %TODO")
                  (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                  (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
                                             (:name "予定が過ぎてる作業" :scheduled past)
@@ -321,7 +313,6 @@ nil にして表示しないようにしている。
                   (org-habit-show-habits nil)
                   (org-agenda-span 'day)
                   (org-agenda-todo-keyword-format "-")
-                  ;; (org-overriding-columns-format "%25ITEM %TODO %CATEGORY")
                   (org-columns-default-format-for-agenda "%25ITEM %TODO %3PRIORITY")
                   (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                   (org-super-agenda-groups (append
@@ -332,7 +323,6 @@ nil にして表示しないようにしている。
                  (org-habit-show-habits nil)
                  (org-agenda-span 'day)
                  (org-agenda-todo-keyword-format "-")
-                 (org-overriding-columns-format "%25ITEM %TODO")
                  (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                  (org-super-agenda-groups (append
                                            (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))

--- a/init.org
+++ b/init.org
@@ -7632,7 +7632,6 @@ agenda ファイルに使われているタグは全部補完対象になって�
                        (org-habit-show-habits nil)
                        (org-agenda-span 'day)
                        (org-agenda-todo-keyword-format "-")
-                       (org-overriding-columns-format "%25ITEM %TODO")
                        (org-agenda-files '("~/Documents/org/tasks/next-actions.org"
                                            "~/Documents/org/journal/"
                                            "~/Documents/org/tasks/reviews.org"))
@@ -7646,7 +7645,6 @@ agenda ファイルに使われているタグは全部補完対象になって�
                        (org-habit-show-habits nil)
                        (org-agenda-span 'day)
                        (org-agenda-todo-keyword-format "-")
-                       (org-overriding-columns-format "%25ITEM %TODO")
                        (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                        (org-super-agenda-groups `((:name "〆切が過ぎてる作業" :and (:deadline past :not (:category "Private")))
                                                   (:name "予定が過ぎてる作業" :and (:scheduled past :not (:category "Private")))
@@ -7671,7 +7669,6 @@ agenda ファイルに使われているタグは全部補完対象になって�
                        (org-habit-show-habits nil)
                        (org-agenda-span 'day)
                        (org-agenda-todo-keyword-format "-")
-                       (org-overriding-columns-format "%25ITEM %TODO")
                        (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                        (org-super-agenda-groups '((:name "仕掛かり中" :and (:todo "DOING" :not (:category "レビュー") :not (:category "開発")))
                                                   (:name "TODO" :and (:todo "TODO" :not (:category "レビュー") :not (:category "開発")))
@@ -7683,7 +7680,6 @@ agenda ファイルに使われているタグは全部補完対象になって�
                        (org-habit-show-habits nil)
                        (org-agenda-span 'day)
                        (org-agenda-todo-keyword-format "-")
-                       (org-overriding-columns-format "%25ITEM %TODO")
                        (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                        (org-super-agenda-groups `((:name "〆切が過ぎてる作業" :and (:deadline past :category "Private"))
                                                   (:name "予定が過ぎてる作業" :and (:scheduled past :category "Private"))
@@ -7716,7 +7712,6 @@ agenda ファイルに使われているタグは全部補完対象になって�
                                  (org-habit-show-habits nil)
                                  (org-agenda-span 'day)
                                  (org-agenda-todo-keyword-format "-")
-                                 (org-overriding-columns-format "%25ITEM %TODO")
                                  (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                                  (org-super-agenda-groups (append
                                                            (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
@@ -7727,7 +7722,6 @@ agenda ファイルに使われているタグは全部補完対象になって�
                                  (org-habit-show-habits nil)
                                  (org-agenda-span 'day)
                                  (org-agenda-todo-keyword-format "-")
-                                 (org-overriding-columns-format "%25ITEM %TODO")
                                  (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                                  (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
                                                             (:name "予定が過ぎてる作業" :scheduled past)
@@ -7745,7 +7739,6 @@ agenda ファイルに使われているタグは全部補完対象になって�
                         (org-habit-show-habits nil)
                         (org-agenda-span 'day)
                         (org-agenda-todo-keyword-format "-")
-                        (org-overriding-columns-format "%25ITEM %TODO")
                         (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                         (org-super-agenda-groups (append
                                                   (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
@@ -7756,7 +7749,6 @@ agenda ファイルに使われているタグは全部補完対象になって�
                         (org-habit-show-habits nil)
                         (org-agenda-span 'day)
                         (org-agenda-todo-keyword-format "-")
-                        (org-overriding-columns-format "%25ITEM %TODO")
                         (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                         (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
                                                    (:name "予定が過ぎてる作業" :scheduled past)
@@ -7794,7 +7786,6 @@ agenda ファイルに使われているタグは全部補完対象になって�
                          (org-habit-show-habits nil)
                          (org-agenda-span 'day)
                          (org-agenda-todo-keyword-format "-")
-                         ;; (org-overriding-columns-format "%25ITEM %TODO %CATEGORY")
                          (org-columns-default-format-for-agenda "%25ITEM %TODO %3PRIORITY")
                          (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                          (org-super-agenda-groups (append
@@ -7805,7 +7796,6 @@ agenda ファイルに使われているタグは全部補完対象になって�
                         (org-habit-show-habits nil)
                         (org-agenda-span 'day)
                         (org-agenda-todo-keyword-format "-")
-                        (org-overriding-columns-format "%25ITEM %TODO")
                         (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                         (org-super-agenda-groups (append
                                                   (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -47,7 +47,6 @@
                 (org-habit-show-habits nil)
                 (org-agenda-span 'day)
                 (org-agenda-todo-keyword-format "-")
-                (org-overriding-columns-format "%25ITEM %TODO")
                 (org-agenda-files '("~/Documents/org/tasks/next-actions.org"
                                     "~/Documents/org/journal/"
                                     "~/Documents/org/tasks/reviews.org"))
@@ -61,7 +60,6 @@
                 (org-habit-show-habits nil)
                 (org-agenda-span 'day)
                 (org-agenda-todo-keyword-format "-")
-                (org-overriding-columns-format "%25ITEM %TODO")
                 (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                 (org-super-agenda-groups `((:name "〆切が過ぎてる作業" :and (:deadline past :not (:category "Private")))
                                            (:name "予定が過ぎてる作業" :and (:scheduled past :not (:category "Private")))
@@ -86,7 +84,6 @@
                 (org-habit-show-habits nil)
                 (org-agenda-span 'day)
                 (org-agenda-todo-keyword-format "-")
-                (org-overriding-columns-format "%25ITEM %TODO")
                 (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                 (org-super-agenda-groups '((:name "仕掛かり中" :and (:todo "DOING" :not (:category "レビュー") :not (:category "開発")))
                                            (:name "TODO" :and (:todo "TODO" :not (:category "レビュー") :not (:category "開発")))
@@ -98,7 +95,6 @@
                 (org-habit-show-habits nil)
                 (org-agenda-span 'day)
                 (org-agenda-todo-keyword-format "-")
-                (org-overriding-columns-format "%25ITEM %TODO")
                 (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                 (org-super-agenda-groups `((:name "〆切が過ぎてる作業" :and (:deadline past :category "Private"))
                                            (:name "予定が過ぎてる作業" :and (:scheduled past :category "Private"))
@@ -131,7 +127,6 @@
                           (org-habit-show-habits nil)
                           (org-agenda-span 'day)
                           (org-agenda-todo-keyword-format "-")
-                          (org-overriding-columns-format "%25ITEM %TODO")
                           (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                           (org-super-agenda-groups (append
                                                     (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
@@ -142,7 +137,6 @@
                           (org-habit-show-habits nil)
                           (org-agenda-span 'day)
                           (org-agenda-todo-keyword-format "-")
-                          (org-overriding-columns-format "%25ITEM %TODO")
                           (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                           (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
                                                      (:name "予定が過ぎてる作業" :scheduled past)
@@ -160,7 +154,6 @@
                  (org-habit-show-habits nil)
                  (org-agenda-span 'day)
                  (org-agenda-todo-keyword-format "-")
-                 (org-overriding-columns-format "%25ITEM %TODO")
                  (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                  (org-super-agenda-groups (append
                                            (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))
@@ -171,7 +164,6 @@
                  (org-habit-show-habits nil)
                  (org-agenda-span 'day)
                  (org-agenda-todo-keyword-format "-")
-                 (org-overriding-columns-format "%25ITEM %TODO")
                  (org-agenda-files '("~/Documents/org/tasks/projects.org"))
                  (org-super-agenda-groups '((:name "〆切が過ぎてる作業" :deadline past)
                                             (:name "予定が過ぎてる作業" :scheduled past)
@@ -209,7 +201,6 @@
                   (org-habit-show-habits nil)
                   (org-agenda-span 'day)
                   (org-agenda-todo-keyword-format "-")
-                  ;; (org-overriding-columns-format "%25ITEM %TODO %CATEGORY")
                   (org-columns-default-format-for-agenda "%25ITEM %TODO %3PRIORITY")
                   (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                   (org-super-agenda-groups (append
@@ -220,7 +211,6 @@
                  (org-habit-show-habits nil)
                  (org-agenda-span 'day)
                  (org-agenda-todo-keyword-format "-")
-                 (org-overriding-columns-format "%25ITEM %TODO")
                  (org-agenda-files '("~/Documents/org/tasks/next-actions.org" "~/Documents/org/journal/"))
                  (org-super-agenda-groups (append
                                            (mapcar (lambda (key) `(:name ,key :and (:category ,key :todo ("DOING" "WAIT")))) (if (boundp 'my/nippou-categories) my/nippou-categories nil))


### PR DESCRIPTION
# 概要

alltodo とか todo とかでは何も意味をなさない指定だったので削除した。
有効なのは agenda とかの time-grid 表示の時だけっぽい