### PR TITLE
feat: Add which-key-show-top-level to Subtools hydra

### DIFF
--- a/hugo/content/ui/hydra.md
+++ b/hugo/content/ui/hydra.md
@@ -208,17 +208,19 @@ el-get の Hydra はここで定義してしまっている。その内 el-get �
     ("m" describe-minor-mode "Minor mode"))
    "Other"
    (("@" all-the-icons-hydra/body "List icons")
+    ("w" which-key-show-top-level "Which key")
     ("D" my/download-from-beorg))))
 ```
 
-| Key | 効果                             |
-|-----|--------------------------------|
-| b   | キーバインドを調べる             |
-| f   | Emacs Lisp の関数を調べる        |
-| v   | Emacs Lisp の変数を調べる        |
-| m   | minor-mode を調べる              |
-| @   | All the icons の Hydra を起動    |
-| D   | beorg 連携に使ってる WebDAV サーバからダウンロード |
+| Key | 効果                                                  |
+|-----|-----------------------------------------------------|
+| b   | キーバインドを調べる                                  |
+| f   | Emacs Lisp の関数を調べる                             |
+| v   | Emacs Lisp の変数を調べる                             |
+| m   | minor-mode を調べる                                   |
+| @   | All the icons の Hydra を起動                         |
+| w   | トップレベルのキーバインドを表示する                  |
+| D   | beorg 連携に使ってる WebDAV サーバからダウンロード(Dropbox に移行して不要になった) |
 
 
 ### Text Scale {#text-scale}

--- a/init.org
+++ b/init.org
@@ -2984,16 +2984,18 @@ http://home.hatanaka.info/article/474728666.html
            ("m" describe-minor-mode "Minor mode"))
           "Other"
           (("@" all-the-icons-hydra/body "List icons")
+           ("w" which-key-show-top-level "Which key")
            ("D" my/download-from-beorg))))
      #+end_src
 
-     | Key | 効果                                               |
-     | b   | キーバインドを調べる                               |
-     | f   | Emacs Lisp の関数を調べる                          |
-     | v   | Emacs Lisp の変数を調べる                          |
-     | m   | minor-mode を調べる                                |
-     | @   | All the icons の Hydra を起動                      |
-     | D   | beorg 連携に使ってる WebDAV サーバからダウンロード |
+     | Key | 効果                                                                               |
+     | b   | キーバインドを調べる                                                               |
+     | f   | Emacs Lisp の関数を調べる                                                          |
+     | v   | Emacs Lisp の変数を調べる                                                          |
+     | m   | minor-mode を調べる                                                                |
+     | @   | All the icons の Hydra を起動                                                      |
+     | w   | トップレベルのキーバインドを表示する                                               |
+     | D   | beorg 連携に使ってる WebDAV サーバからダウンロード(Dropbox に移行して不要になった) |
 
 **** Text Scale
      :PROPERTIES:

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -71,6 +71,7 @@
     ("m" describe-minor-mode "Minor mode"))
    "Other"
    (("@" all-the-icons-hydra/body "List icons")
+    ("w" which-key-show-top-level "Which key")
     ("D" my/download-from-beorg))))
 
 (pretty-hydra-define text-scale-hydra (:separator "-" :title (concat (all-the-icons-material "text_fields") " Text Scale") :exit nil :quit-key "q")


### PR DESCRIPTION
キーバインドがわからなくなることが多々あるため
すぐに Hydra から which-key-show-top-level を呼び出せるようにしておいた