### PR TITLE
feat: Improve daily agendas

### DIFF
--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -186,6 +186,7 @@ nil にして表示しないようにしている。
                                            (:discard (:anything t))))))
     (tags-todo "Weekday-Finish|Daily"
                ((org-agenda-overriding-header "習慣")
+                (org-agenda-prefix-format "  ")
                 (org-habit-show-habits t)
                 (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
                 (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
@@ -209,7 +210,7 @@ nil にして表示しないようにしている。
                 (org-habit-show-habits nil)
                 (org-agenda-prefix-format "  %c: ")
                 (org-agenda-span 'day)
-                (org-agenda-files '("~/Documents/org/tasks/projects.org"))
+                (org-agenda-files '("~/Documents/org/tasks/projects.org" "~/Documents/org/tasks/inbox.org"))
                 (org-super-agenda-groups `((:name "〆切が過ぎてる作業" :and (:deadline past   :not (:property ("agenda-group" "1. Work"))))
                                            (:name "予定が過ぎてる作業" :and (:scheduled past  :not (:property ("agenda-group" "1. Work"))))
                                            (:name "今日〆切の作業"     :and (:deadline today  :not (:property ("agenda-group" "1. Work"))))
@@ -221,6 +222,7 @@ nil にして表示しないようにしている。
                                            (:discard (:anything t))))))
     (tags-todo "Holiday|Weekend|Daily"
                ((org-agenda-overriding-header "習慣")
+                (org-agenda-prefix-format "  ")
                 (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
                 (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                            (:name "今日予定の作業" :scheduled today)

--- a/init.org
+++ b/init.org
@@ -7661,6 +7661,7 @@ agenda ファイルに使われているタグは全部補完対象になって�
                                                   (:discard (:anything t))))))
            (tags-todo "Weekday-Finish|Daily"
                       ((org-agenda-overriding-header "習慣")
+                       (org-agenda-prefix-format "  ")
                        (org-habit-show-habits t)
                        (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
                        (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
@@ -7684,7 +7685,7 @@ agenda ファイルに使われているタグは全部補完対象になって�
                        (org-habit-show-habits nil)
                        (org-agenda-prefix-format "  %c: ")
                        (org-agenda-span 'day)
-                       (org-agenda-files '("~/Documents/org/tasks/projects.org"))
+                       (org-agenda-files '("~/Documents/org/tasks/projects.org" "~/Documents/org/tasks/inbox.org"))
                        (org-super-agenda-groups `((:name "〆切が過ぎてる作業" :and (:deadline past   :not (:property ("agenda-group" "1. Work"))))
                                                   (:name "予定が過ぎてる作業" :and (:scheduled past  :not (:property ("agenda-group" "1. Work"))))
                                                   (:name "今日〆切の作業"     :and (:deadline today  :not (:property ("agenda-group" "1. Work"))))
@@ -7696,6 +7697,7 @@ agenda ファイルに使われているタグは全部補完対象になって�
                                                   (:discard (:anything t))))))
            (tags-todo "Holiday|Weekend|Daily"
                       ((org-agenda-overriding-header "習慣")
+                       (org-agenda-prefix-format "  ")
                        (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
                        (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                                   (:name "今日予定の作業" :scheduled today)

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -98,7 +98,7 @@
                 (org-habit-show-habits nil)
                 (org-agenda-prefix-format "  %c: ")
                 (org-agenda-span 'day)
-                (org-agenda-files '("~/Documents/org/tasks/projects.org"))
+                (org-agenda-files '("~/Documents/org/tasks/projects.org" "~/Documents/org/tasks/inbox.org"))
                 (org-super-agenda-groups `((:name "〆切が過ぎてる作業" :and (:deadline past   :not (:property ("agenda-group" "1. Work"))))
                                            (:name "予定が過ぎてる作業" :and (:scheduled past  :not (:property ("agenda-group" "1. Work"))))
                                            (:name "今日〆切の作業"     :and (:deadline today  :not (:property ("agenda-group" "1. Work"))))

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -74,6 +74,7 @@
                                            (:discard (:anything t))))))
     (tags-todo "Weekday-Finish|Daily"
                ((org-agenda-overriding-header "習慣")
+                (org-agenda-prefix-format "  ")
                 (org-habit-show-habits t)
                 (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
                 (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
@@ -109,6 +110,7 @@
                                            (:discard (:anything t))))))
     (tags-todo "Holiday|Weekend|Daily"
                ((org-agenda-overriding-header "習慣")
+                (org-agenda-prefix-format "  ")
                 (org-agenda-files '("~/Documents/org/tasks/next-actions.org"))
                 (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                            (:name "今日予定の作業" :scheduled today)


### PR DESCRIPTION
- habits はそれだけでブロックを分けているので category を非表示にした
- 休日用 agenda では inbox.org も対象とした。そっちにあるタスクもチェックしたいため