### PR TITLE
fix: improve org-agenda-prefix-format on habit agendas

### DIFF
--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -131,22 +131,26 @@ nil にして表示しないようにしている。
 '(("h" . "Habits")
   ("hs" "Weekday Start"
    ((tags "Weekday&Start|Daily"
-          ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+          ((org-agenda-prefix-format "  ")
+           (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                       (:name "今日の作業" :scheduled today)
                                       (:discard (:anything t))))))))
   ("hf" "Weekday Finish"
    ((tags "Weekday&Finish"
-          ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+          ((org-agenda-prefix-format "  ")
+           (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                       (:name "今日の作業" :scheduled today)
                                       (:discard (:anything t))))))))
   ("hw" "Weekly"
    ((tags "Weekly"
-          ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+          ((org-agenda-prefix-format "  ")
+           (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                       (:name "今週の作業" :scheduled today)
                                       (:discard (:anything t))))))))
   ("hh" "Holiday"
    ((tags "Weekend|Holiday|Daily"
-          ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+          ((org-agenda-prefix-format "  ")
+           (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                       (:name "今日の作業" :scheduled today)
                                       (:discard (:anything t))))))))
   ("d" "Today"

--- a/init.org
+++ b/init.org
@@ -7665,22 +7665,26 @@ agenda ファイルに使われているタグは全部補完対象になって�
        '(("h" . "Habits")
          ("hs" "Weekday Start"
           ((tags "Weekday&Start|Daily"
-                 ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                 ((org-agenda-prefix-format "  ")
+                  (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                              (:name "今日の作業" :scheduled today)
                                              (:discard (:anything t))))))))
          ("hf" "Weekday Finish"
           ((tags "Weekday&Finish"
-                 ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                 ((org-agenda-prefix-format "  ")
+                  (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                              (:name "今日の作業" :scheduled today)
                                              (:discard (:anything t))))))))
          ("hw" "Weekly"
           ((tags "Weekly"
-                 ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                 ((org-agenda-prefix-format "  ")
+                  (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                              (:name "今週の作業" :scheduled today)
                                              (:discard (:anything t))))))))
          ("hh" "Holiday"
           ((tags "Weekend|Holiday|Daily"
-                 ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                 ((org-agenda-prefix-format "  ")
+                  (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                              (:name "今日の作業" :scheduled today)
                                              (:discard (:anything t))))))))
          ("d" "Today"

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -19,22 +19,26 @@
 '(("h" . "Habits")
   ("hs" "Weekday Start"
    ((tags "Weekday&Start|Daily"
-          ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+          ((org-agenda-prefix-format "  ")
+           (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                       (:name "今日の作業" :scheduled today)
                                       (:discard (:anything t))))))))
   ("hf" "Weekday Finish"
    ((tags "Weekday&Finish"
-          ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+          ((org-agenda-prefix-format "  ")
+           (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                       (:name "今日の作業" :scheduled today)
                                       (:discard (:anything t))))))))
   ("hw" "Weekly"
    ((tags "Weekly"
-          ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+          ((org-agenda-prefix-format "  ")
+           (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                       (:name "今週の作業" :scheduled today)
                                       (:discard (:anything t))))))))
   ("hh" "Holiday"
    ((tags "Weekend|Holiday|Daily"
-          ((org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+          ((org-agenda-prefix-format "  ")
+           (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                       (:name "今日の作業" :scheduled today)
                                       (:discard (:anything t))))))))
   ("d" "Today"


### PR DESCRIPTION
habits だけを出力する custom agenda view において
category を出力する必要はないので
org-agenda-prefix-format を空白文字だけにした