### PR TITLE
ci: Add label to dependency update PR

### DIFF
--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -62,6 +62,8 @@ jobs:
         commit-message: ${{ steps.get-pr-body.outputs.body }}
         title: ${{ env.PR_TITLE }}
         body: ${{ steps.get-pr-body.outputs.body }}
+        labels: |
+          dependency
 
     - if: always()
       name: Notify slack build result


### PR DESCRIPTION
依存関係の自動更新 PR には `dependency` ラベルをつけるようにした

明日の PR から反映されるはず