### PR TITLE
feat: Enable tree sitter

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((org-mode :checksum "17608670a4f4e8edb91efe04d86fe80ff9d01b69")
+      '((treesit-auto :checksum "07a8f924cd4f020a2eb32b45d8543af9556f355d")
+        (org-mode :checksum "17608670a4f4e8edb91efe04d86fe80ff9d01b69")
         (org-journal :checksum "7cf8922003ce33c20e7fa2827276679af77664a8")
         (company-terraform :checksum "8d5a16d1bbeeb18ca49a8fd57b5d8cd30c8b8dc7")
         (terraform-mode :checksum "e8b57df8c2a3d3171f3768f60eb84067f553289c")

--- a/inits/50-tree-sitter.el
+++ b/inits/50-tree-sitter.el
@@ -1,1 +1,8 @@
 (el-get-bundle treesit-auto)
+
+(custom-set-variables
+ '(treesit-auto-install 'prompt))
+
+(require 'treesit-auto)
+
+(global-treesit-auto-mode)

--- a/inits/50-tree-sitter.el
+++ b/inits/50-tree-sitter.el
@@ -1,0 +1,1 @@
+(el-get-bundle treesit-auto)

--- a/recipes/treesit-auto.rcp
+++ b/recipes/treesit-auto.rcp
@@ -1,0 +1,6 @@
+(:name treesit-auto
+       :website "https://github.com/renzmann/treesit-auto"
+       :description "Automatically install and use tree-sitter major modes in Emacs 29+."
+       :type github
+       :branch "main"
+       :pkgname "renzmann/treesit-auto")


### PR DESCRIPTION
# 概要

tree-sitter modes を使えるようにした。
そのために簡単に tree-sitter の grammar を取得できるように
treesit-auto を導入している