### PR TITLE
fix: Use lsp-eslint-fix-all for format

### DIFF
--- a/hugo/content/programming/react-js.md
+++ b/hugo/content/programming/react-js.md
@@ -67,7 +67,7 @@ jsx/tsx ファイルを開いた時には web-mode で動いてほしいので
 auto-mode-alist で関連付けをする
 
 ```emacs-lisp
-(add-to-list 'auto-mode-alist '("\\.[jt]sx" . web-mode))
+(add-to-list 'auto-mode-alist '("\\.tsx" . tsx-ts-mode))
 ```
 
 
@@ -76,7 +76,7 @@ auto-mode-alist で関連付けをする
 tsx の保存時に自動でフォーマットしてほしいのでそれ用に hook を追加
 
 ```emacs-lisp
-(defun my/web-mode-auto-fix-hook ()
+(defun my/tsx-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "tsx")
     (lsp-eslint-fix-all)))
 ```
@@ -107,7 +107,7 @@ indent は2桁スペースになるようにしているが自動インデント
 lsp-mode から eslint を使うことでやりたいことの対応ができるようなのでその設定は外した。
 
 ```emacs-lisp
-(defun my/web-mode-tsx-hook ()
+(defun my/tsx-hook ()
   (let ((ext (file-name-extension buffer-file-name)))
     (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
       (setq web-mode-markup-indent-offset 2)
@@ -122,5 +122,5 @@ lsp-mode から eslint を使うことでやりたいことの対応ができる
       (lsp-ui-mode 1)
       (add-hook 'before-save-hook 'my/web-mode-auto-fix-hook nil 'local))))
 
-(add-hook 'web-mode-hook 'my/web-mode-tsx-hook)
+(add-hook 'tsx-ts-mode-hook 'my/tsx-hook)
 ```

--- a/hugo/content/programming/react-js.md
+++ b/hugo/content/programming/react-js.md
@@ -78,7 +78,7 @@ tsx の保存時に自動でフォーマットしてほしいのでそれ用に 
 ```emacs-lisp
 (defun my/web-mode-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "tsx")
-    (lsp-format-buffer)))
+    (lsp-eslint-fix-all)))
 ```
 
 

--- a/hugo/content/programming/typescript.md
+++ b/hugo/content/programming/typescript.md
@@ -80,7 +80,7 @@ hook を使って有効化している
 この関数を
 
 ```emacs-lisp
-(add-hook 'typescript-mode-hook 'my/ts-mode-hook)
+(add-hook 'typescript-ts-mode-hook 'my/ts-mode-hook)
 ```
 
 として hook に追加している。
@@ -94,11 +94,11 @@ hook を使って有効化している
 auto-mode-alist に突っ込んでいる
 
 ```emacs-lisp
-(add-to-list 'auto-mode-alist '("\\.ts" . typescript-mode))
+(add-to-list 'auto-mode-alist '("\\.ts" . typescript-ts-mode))
 ```
 
 また skk もいい感じに動いてほしいので context-skk-programming-mode を有効にしている
 
 ```emacs-lisp
-(add-to-list 'context-skk-programming-mode 'typescript-mode)
+(add-to-list 'context-skk-programming-mode 'typescript-ts-mode)
 ```

--- a/hugo/content/programming/typescript.md
+++ b/hugo/content/programming/typescript.md
@@ -52,7 +52,7 @@ TypeScript ファイル(.ts) を使う上での設定を書いている。とり
 ```emacs-lisp
 (defun my/ts-mode-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "ts")
-    (lsp-format-buffer)))
+    (lsp-eslint-fix-all)))
 ```
 
 

--- a/init.org
+++ b/init.org
@@ -5553,7 +5553,7 @@ nerd-icons をインストールしていない場合は ~nerd-icons-install-fon
     #+begin_src emacs-lisp :tangle inits/41-react.el
       (defun my/web-mode-auto-fix-hook ()
         (when (string-equal (file-name-extension buffer-file-name) "tsx")
-          (lsp-format-buffer)))
+          (lsp-eslint-fix-all)))
     #+end_src
 *** lsp-mode などの有効化
     :PROPERTIES:
@@ -6133,7 +6133,7 @@ nerd-icons をインストールしていない場合は ~nerd-icons-install-fon
      #+begin_src emacs-lisp :tangle inits/40-ts.el
        (defun my/ts-mode-auto-fix-hook ()
          (when (string-equal (file-name-extension buffer-file-name) "ts")
-           (lsp-format-buffer)))
+           (lsp-eslint-fix-all)))
      #+end_src
 **** hook
      :PROPERTIES:

--- a/init.org
+++ b/init.org
@@ -5541,7 +5541,7 @@ nerd-icons をインストールしていない場合は ~nerd-icons-install-fon
     auto-mode-alist で関連付けをする
 
     #+begin_src emacs-lisp :tangle inits/41-react.el
-    (add-to-list 'auto-mode-alist '("\\.[jt]sx" . web-mode))
+    (add-to-list 'auto-mode-alist '("\\.tsx" . tsx-ts-mode))
     #+end_src
 
 *** 自動フォーマット hook の用意
@@ -5551,7 +5551,7 @@ nerd-icons をインストールしていない場合は ~nerd-icons-install-fon
     tsx の保存時に自動でフォーマットしてほしいのでそれ用に hook を追加
 
     #+begin_src emacs-lisp :tangle inits/41-react.el
-      (defun my/web-mode-auto-fix-hook ()
+      (defun my/tsx-auto-fix-hook ()
         (when (string-equal (file-name-extension buffer-file-name) "tsx")
           (lsp-eslint-fix-all)))
     #+end_src
@@ -5584,7 +5584,7 @@ nerd-icons をインストールしていない場合は ~nerd-icons-install-fon
     lsp-mode から eslint を使うことでやりたいことの対応ができるようなのでその設定は外した。
 
     #+begin_src emacs-lisp :tangle inits/41-react.el
-      (defun my/web-mode-tsx-hook ()
+      (defun my/tsx-hook ()
         (let ((ext (file-name-extension buffer-file-name)))
           (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
             (setq web-mode-markup-indent-offset 2)
@@ -5599,7 +5599,7 @@ nerd-icons をインストールしていない場合は ~nerd-icons-install-fon
             (lsp-ui-mode 1)
             (add-hook 'before-save-hook 'my/web-mode-auto-fix-hook nil 'local))))
 
-      (add-hook 'web-mode-hook 'my/web-mode-tsx-hook)
+      (add-hook 'tsx-ts-mode-hook 'my/tsx-hook)
     #+end_src
 
 ** rspec-mode

--- a/init.org
+++ b/init.org
@@ -6161,7 +6161,7 @@ nerd-icons をインストールしていない場合は ~nerd-icons-install-fon
      この関数を
 
      #+begin_src emacs-lisp :tangle inits/40-ts.el
-     (add-hook 'typescript-mode-hook 'my/ts-mode-hook)
+     (add-hook 'typescript-ts-mode-hook 'my/ts-mode-hook)
      #+end_src
 
      として hook に追加している。
@@ -6176,13 +6176,13 @@ nerd-icons をインストールしていない場合は ~nerd-icons-install-fon
      auto-mode-alist に突っ込んでいる
 
      #+begin_src emacs-lisp :tangle inits/40-ts.el
-     (add-to-list 'auto-mode-alist '("\\.ts" . typescript-mode))
+     (add-to-list 'auto-mode-alist '("\\.ts" . typescript-ts-mode))
      #+end_src
 
      また skk もいい感じに動いてほしいので context-skk-programming-mode を有効にしている
 
      #+begin_src emacs-lisp :tangle inits/40-ts.el
-       (add-to-list 'context-skk-programming-mode 'typescript-mode)
+       (add-to-list 'context-skk-programming-mode 'typescript-ts-mode)
      #+end_src
 ** Vue.js
    :PROPERTIES:

--- a/inits/40-ts.el
+++ b/inits/40-ts.el
@@ -25,8 +25,8 @@
   (lsp-ui-mode 1)
   (add-hook 'before-save-hook #'my/ts-mode-auto-fix-hook nil 'local))
 
-(add-hook 'typescript-mode-hook 'my/ts-mode-hook)
+(add-hook 'typescript-ts-mode-hook 'my/ts-mode-hook)
 
-(add-to-list 'auto-mode-alist '("\\.ts" . typescript-mode))
+(add-to-list 'auto-mode-alist '("\\.ts" . typescript-ts-mode))
 
-(add-to-list 'context-skk-programming-mode 'typescript-mode)
+(add-to-list 'context-skk-programming-mode 'typescript-ts-mode)

--- a/inits/40-ts.el
+++ b/inits/40-ts.el
@@ -13,7 +13,7 @@
 
 (defun my/ts-mode-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "ts")
-    (lsp-format-buffer)))
+    (lsp-eslint-fix-all)))
 
 (defun my/ts-mode-hook ()
   (origami-mode 1)

--- a/inits/41-react.el
+++ b/inits/41-react.el
@@ -6,7 +6,7 @@
 
 (defun my/web-mode-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "tsx")
-    (lsp-format-buffer)))
+    (lsp-eslint-fix-all)))
 
 (defun my/web-mode-tsx-hook ()
   (let ((ext (file-name-extension buffer-file-name)))

--- a/inits/41-react.el
+++ b/inits/41-react.el
@@ -2,13 +2,13 @@
 
 (el-get-bundle web-mode)
 
-(add-to-list 'auto-mode-alist '("\\.[jt]sx" . web-mode))
+(add-to-list 'auto-mode-alist '("\\.tsx" . tsx-ts-mode))
 
-(defun my/web-mode-auto-fix-hook ()
+(defun my/tsx-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "tsx")
     (lsp-eslint-fix-all)))
 
-(defun my/web-mode-tsx-hook ()
+(defun my/tsx-hook ()
   (let ((ext (file-name-extension buffer-file-name)))
     (when (or (string-equal "jsx" ext) (string-equal "tsx" ext))
       (setq web-mode-markup-indent-offset 2)
@@ -21,6 +21,6 @@
       (display-line-numbers-mode t)
       (lsp)
       (lsp-ui-mode 1)
-      (add-hook 'before-save-hook 'my/web-mode-auto-fix-hook nil 'local))))
+      (add-hook 'before-save-hook 'my/tsx-auto-fix-hook nil 'local))))
 
-(add-hook 'web-mode-hook 'my/web-mode-tsx-hook)
+(add-hook 'tsx-ts-mode-hook 'my/tsx-hook)


### PR DESCRIPTION
https://github.com/mugijiru/.emacs.d/pull/3679 で lsp-format-buffer を使うように変更したが
lsp-eslint-fix-all でうまく動くようなので戻した。

また treesit を導入することで諸々の設定が反映されなくなっていたので
それも合わせて修正しています