### PR TITLE
fix: copilot.el depend to jsonrpc

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -12,7 +12,6 @@
         (company-posframe :checksum "18d6641bba72cba3c00018cee737ea8b454f64a8")
         (nerd-icons :checksum "d53c5a1e0e8837735310d9ebff53d072a947872a")
         (copilot :checksum "1542d76909636bf8804dd9c770f28818a897cfdc")
-        (json-rpc :checksum "81a5a520072e20d18aeab2aac4d66c046b031e56")
         (editorconfig :checksum "9780a07648afe0c12c7f7cd8f1cdfe1be4fc8684")
         (emacs-sqlite3-api :checksum "a601c9965e4d0178705a64b7d4f88709ca9aea66")
         (org-roam :checksum "5c06471c3a11348342719fd9011486455adeb701")

--- a/hugo/content/editing/copilot.md
+++ b/hugo/content/editing/copilot.md
@@ -19,7 +19,7 @@ draft = false
        :type github
        :branch "main"
        :pkgname "zerolfx/copilot.el"
-       :depends (s dash editorconfig json-rpc))
+       :depends (s dash editorconfig jsonrpc))
 ```
 
 そして `el-get-bundle` でインストール

--- a/init.org
+++ b/init.org
@@ -1711,7 +1711,7 @@
        :type github
        :branch "main"
        :pkgname "zerolfx/copilot.el"
-       :depends (s dash editorconfig json-rpc))
+       :depends (s dash editorconfig jsonrpc))
 #+end_src
 
 そして ~el-get-bundle~ でインストール

--- a/recipes/copilot.rcp
+++ b/recipes/copilot.rcp
@@ -4,4 +4,4 @@
        :type github
        :branch "main"
        :pkgname "zerolfx/copilot.el"
-       :depends (s dash editorconfig json-rpc))
+       :depends (s dash editorconfig jsonrpc))


### PR DESCRIPTION
copilot.el が依存しているのは json-rpc ではなく jsonrpc だった。ややこし〜

元々うまく動いていたのは jsonrpc が bundle されていたから。