### PR TITLE
feat: Hide priority C items from holiday agenda

### DIFF
--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -233,10 +233,16 @@ nil にして表示しないようにしている。
                                            (:discard (:anything t))))))
     (tags-todo "Emacs&LEVEL=2"
                ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                (org-agenda-overriding-header "Emacs")))
+                (org-agenda-overriding-header "Emacs")
+                (org-super-agenda-groups '((:priority>= "B")
+                                           (:name "no priority" :not (:priority>= "C"))
+                                           (:discard (:anything t))))))
     (tags-todo "Env&LEVEL=2"
                ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                (org-agenda-overriding-header "Env")))))
+                (org-agenda-overriding-header "Env")
+                (org-super-agenda-groups '((:priority>= "B")
+                                           (:name "no priority" :not (:priority>= "C"))
+                                           (:discard (:anything t))))))))
 
   ("p" . "Projects")
   ("pA" "Projects Priority A"

--- a/init.org
+++ b/init.org
@@ -7918,10 +7918,16 @@ agenda ファイルに使われているタグは全部補完対象になって�
                                                   (:discard (:anything t))))))
            (tags-todo "Emacs&LEVEL=2"
                       ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                       (org-agenda-overriding-header "Emacs")))
+                       (org-agenda-overriding-header "Emacs")
+                       (org-super-agenda-groups '((:priority>= "B")
+                                                  (:name "no priority" :not (:priority>= "C"))
+                                                  (:discard (:anything t))))))
            (tags-todo "Env&LEVEL=2"
                       ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                       (org-agenda-overriding-header "Env")))))
+                       (org-agenda-overriding-header "Env")
+                       (org-super-agenda-groups '((:priority>= "B")
+                                                  (:name "no priority" :not (:priority>= "C"))
+                                                  (:discard (:anything t))))))))
 
          ("p" . "Projects")
          ("pA" "Projects Priority A"

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -121,10 +121,16 @@
                                            (:discard (:anything t))))))
     (tags-todo "Emacs&LEVEL=2"
                ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                (org-agenda-overriding-header "Emacs")))
+                (org-agenda-overriding-header "Emacs")
+                (org-super-agenda-groups '((:priority>= "B")
+                                           (:name "no priority" :not (:priority>= "C"))
+                                           (:discard (:anything t))))))
     (tags-todo "Env&LEVEL=2"
                ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                (org-agenda-overriding-header "Env")))))
+                (org-agenda-overriding-header "Env")
+                (org-super-agenda-groups '((:priority>= "B")
+                                           (:name "no priority" :not (:priority>= "C"))
+                                           (:discard (:anything t))))))))
 
   ("p" . "Projects")
   ("pA" "Projects Priority A"


### PR DESCRIPTION
休日用 agenda から priority C の項目を省いた。

C のやつはやる可能性が低い優先度の低いやつなので
常に見えている必要はなさそうなため