### PR TITLE
feat: agenda tasks indent by level

### DIFF
--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -162,7 +162,7 @@ nil にして表示しないようにしている。
                 (org-agenda-overriding-header "今日の作業")
                 (org-habit-show-habits nil)
                 (org-agenda-span 'day)
-                (org-agenda-prefix-format "  %c: ")
+                (org-agenda-prefix-format "%l%c: ")
                 (org-agenda-files '("~/Documents/org/tasks/habits.org"
                                     "~/Documents/org/journal/"
                                     "~/Documents/org/tasks/reviews.org"))

--- a/init.org
+++ b/init.org
@@ -7847,7 +7847,7 @@ agenda ファイルに使われているタグは全部補完対象になって�
                        (org-agenda-overriding-header "今日の作業")
                        (org-habit-show-habits nil)
                        (org-agenda-span 'day)
-                       (org-agenda-prefix-format "  %c: ")
+                       (org-agenda-prefix-format "%l%c: ")
                        (org-agenda-files '("~/Documents/org/tasks/habits.org"
                                            "~/Documents/org/journal/"
                                            "~/Documents/org/tasks/reviews.org"))

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -50,7 +50,7 @@
                 (org-agenda-overriding-header "今日の作業")
                 (org-habit-show-habits nil)
                 (org-agenda-span 'day)
-                (org-agenda-prefix-format "  %c: ")
+                (org-agenda-prefix-format "%l%c: ")
                 (org-agenda-files '("~/Documents/org/tasks/habits.org"
                                     "~/Documents/org/journal/"
                                     "~/Documents/org/tasks/reviews.org"))


### PR DESCRIPTION
子タスクもフラットに表示されると困るので

auto-parent を使う手もあったけど表示がイマイチだと思ったので一旦こちらに