### PR TITLE
fix: Improve lsp-mode setting

### DIFF
--- a/hugo/content/programming/lsp-mode.md
+++ b/hugo/content/programming/lsp-mode.md
@@ -85,11 +85,12 @@ indent-region を使えずにいた
 <https://github.com/emacs-lsp/lsp-mode/issues/2915#issuecomment-855156802>
 
 を参考に
-lsp--formatting-indent-aliat に web-mode の設定を追加することで良い感じにインデントできるように調整している
+lsp--formatting-indent-aliat に web-mode と tsx-ts-mode の設定を追加することで良い感じにインデントできるように調整している
 
 ```emacs-lisp
 (with-eval-after-load 'lsp-mode
   (add-to-list 'lsp--formatting-indent-alist `(web-mode . web-mode-code-indent-offset))
+  (add-to-list 'lsp--formatting-indent-alist `(tsx-ts-mode . typescript-ts-mode-indent-offset))
   (add-to-list 'lsp-file-watch-ignored-directories "hello-friend-ng")
   (add-to-list 'lsp-file-watch-ignored-directories "ox-hugo"))
 ```

--- a/hugo/content/programming/lsp-mode.md
+++ b/hugo/content/programming/lsp-mode.md
@@ -91,6 +91,9 @@ lsp--formatting-indent-aliat に web-mode と tsx-ts-mode の設定を追加す�
 (with-eval-after-load 'lsp-mode
   (add-to-list 'lsp--formatting-indent-alist `(web-mode . web-mode-code-indent-offset))
   (add-to-list 'lsp--formatting-indent-alist `(tsx-ts-mode . typescript-ts-mode-indent-offset))
+  (add-to-list 'lsp-file-watch-ignored-directories "node_modules")
+  (add-to-list 'lsp-file-watch-ignored-directories "tmp")
+  (add-to-list 'lsp-file-watch-ignored-directories "vendor")
   (add-to-list 'lsp-file-watch-ignored-directories "hello-friend-ng")
   (add-to-list 'lsp-file-watch-ignored-directories "ox-hugo"))
 ```

--- a/init.org
+++ b/init.org
@@ -5292,12 +5292,13 @@ hook を色々突っ込んでる
     https://github.com/emacs-lsp/lsp-mode/issues/2915#issuecomment-855156802
 
     を参考に
-    lsp--formatting-indent-aliat に web-mode の設定を追加することで
+    lsp--formatting-indent-aliat に web-mode と tsx-ts-mode の設定を追加することで
     良い感じにインデントできるように調整している
 
     #+begin_src emacs-lisp :tangle inits/20-lsp.el
       (with-eval-after-load 'lsp-mode
         (add-to-list 'lsp--formatting-indent-alist `(web-mode . web-mode-code-indent-offset))
+        (add-to-list 'lsp--formatting-indent-alist `(tsx-ts-mode . typescript-ts-mode-indent-offset))
         (add-to-list 'lsp-file-watch-ignored-directories "hello-friend-ng")
         (add-to-list 'lsp-file-watch-ignored-directories "ox-hugo"))
     #+end_src

--- a/init.org
+++ b/init.org
@@ -5299,6 +5299,9 @@ hook を色々突っ込んでる
       (with-eval-after-load 'lsp-mode
         (add-to-list 'lsp--formatting-indent-alist `(web-mode . web-mode-code-indent-offset))
         (add-to-list 'lsp--formatting-indent-alist `(tsx-ts-mode . typescript-ts-mode-indent-offset))
+        (add-to-list 'lsp-file-watch-ignored-directories "node_modules")
+        (add-to-list 'lsp-file-watch-ignored-directories "tmp")
+        (add-to-list 'lsp-file-watch-ignored-directories "vendor")
         (add-to-list 'lsp-file-watch-ignored-directories "hello-friend-ng")
         (add-to-list 'lsp-file-watch-ignored-directories "ox-hugo"))
     #+end_src

--- a/inits/20-lsp.el
+++ b/inits/20-lsp.el
@@ -37,5 +37,8 @@
 (with-eval-after-load 'lsp-mode
   (add-to-list 'lsp--formatting-indent-alist `(web-mode . web-mode-code-indent-offset))
   (add-to-list 'lsp--formatting-indent-alist `(tsx-ts-mode . typescript-ts-mode-indent-offset))
+  (add-to-list 'lsp-file-watch-ignored-directories "node_modules")
+  (add-to-list 'lsp-file-watch-ignored-directories "tmp")
+  (add-to-list 'lsp-file-watch-ignored-directories "vendor")
   (add-to-list 'lsp-file-watch-ignored-directories "hello-friend-ng")
   (add-to-list 'lsp-file-watch-ignored-directories "ox-hugo"))

--- a/inits/20-lsp.el
+++ b/inits/20-lsp.el
@@ -36,5 +36,6 @@
 
 (with-eval-after-load 'lsp-mode
   (add-to-list 'lsp--formatting-indent-alist `(web-mode . web-mode-code-indent-offset))
+  (add-to-list 'lsp--formatting-indent-alist `(tsx-ts-mode . typescript-ts-mode-indent-offset))
   (add-to-list 'lsp-file-watch-ignored-directories "hello-friend-ng")
   (add-to-list 'lsp-file-watch-ignored-directories "ox-hugo"))


### PR DESCRIPTION
# 概要

いくつか不都合な点があったので設定を改善しました

## lsp--formatting-indent-alist の設定

tsx-ts-mode で indent-region(C-M-\) がうまく動いていなかったので修正。
indent offset を 2 としている

## lsp-file-watch-ignored-directories

tmp は自動生成される一時ファイルが入るだけなので見る必要なし
vendor, node_modules はパッケージファイルが入るのでそれもまた見る必要なし