### PR TITLE
fix: Improve react setting

### DIFF
--- a/hugo/content/programming/react-js.md
+++ b/hugo/content/programming/react-js.md
@@ -116,7 +116,7 @@ lsp-mode から eslint を使うことでやりたいことの対応ができる
       (origami-mode 1)
       (company-mode 1)
       (subword-mode 1)
-      (turn-on-smartparens-mode)
+      (turn-on-smartparens-strict-mode)
       (display-line-numbers-mode t)
       (lsp)
       (lsp-ui-mode 1)

--- a/hugo/content/programming/react-js.md
+++ b/hugo/content/programming/react-js.md
@@ -78,7 +78,7 @@ tsx の保存時に自動でフォーマットしてほしいのでそれ用に 
 ```emacs-lisp
 (defun my/tsx-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "tsx")
-    (lsp-eslint-fix-all)))
+    (lsp-eslint-apply-all-fixes)))
 ```
 
 

--- a/hugo/content/programming/typescript.md
+++ b/hugo/content/programming/typescript.md
@@ -52,7 +52,7 @@ TypeScript ファイル(.ts) を使う上での設定を書いている。とり
 ```emacs-lisp
 (defun my/ts-mode-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "ts")
-    (lsp-eslint-fix-all)))
+    (lsp-eslint-apply-all-fixes)))
 ```
 
 

--- a/init.org
+++ b/init.org
@@ -5636,7 +5636,7 @@ mocha としてテストを実行するコマンドを用意している。
     #+begin_src emacs-lisp :tangle inits/41-react.el
       (defun my/tsx-auto-fix-hook ()
         (when (string-equal (file-name-extension buffer-file-name) "tsx")
-          (lsp-eslint-fix-all)))
+          (lsp-eslint-apply-all-fixes)))
     #+end_src
 *** lsp-mode などの有効化
     :PROPERTIES:
@@ -6217,7 +6217,7 @@ mocha としてテストを実行するコマンドを用意している。
      #+begin_src emacs-lisp :tangle inits/40-ts.el
        (defun my/ts-mode-auto-fix-hook ()
          (when (string-equal (file-name-extension buffer-file-name) "ts")
-           (lsp-eslint-fix-all)))
+           (lsp-eslint-apply-all-fixes)))
      #+end_src
 **** hook
      :PROPERTIES:

--- a/init.org
+++ b/init.org
@@ -5676,7 +5676,7 @@ mocha としてテストを実行するコマンドを用意している。
             (origami-mode 1)
             (company-mode 1)
             (subword-mode 1)
-            (turn-on-smartparens-mode)
+            (turn-on-smartparens-strict-mode)
             (display-line-numbers-mode t)
             (lsp)
             (lsp-ui-mode 1)

--- a/inits/40-ts.el
+++ b/inits/40-ts.el
@@ -13,7 +13,7 @@
 
 (defun my/ts-mode-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "ts")
-    (lsp-eslint-fix-all)))
+    (lsp-eslint-apply-all-fixes)))
 
 (defun my/ts-mode-hook ()
   (origami-mode 1)

--- a/inits/41-react.el
+++ b/inits/41-react.el
@@ -6,7 +6,7 @@
 
 (defun my/tsx-auto-fix-hook ()
   (when (string-equal (file-name-extension buffer-file-name) "tsx")
-    (lsp-eslint-fix-all)))
+    (lsp-eslint-apply-all-fixes)))
 
 (defun my/tsx-hook ()
   (let ((ext (file-name-extension buffer-file-name)))

--- a/inits/41-react.el
+++ b/inits/41-react.el
@@ -17,7 +17,7 @@
       (origami-mode 1)
       (company-mode 1)
       (subword-mode 1)
-      (turn-on-smartparens-mode)
+      (turn-on-smartparens-strict-mode)
       (display-line-numbers-mode t)
       (lsp)
       (lsp-ui-mode 1)


### PR DESCRIPTION
# 概要

ちょっと使いにくいところがあったので React 向けの設定を変更した

## lsp-eslint-apply-all-fix を保存時に使うようにした

https://github.com/mugijiru/.emacs.d/pull/3679 で lsp-format-buffer を使ったり
https://github.com/mugijiru/.emacs.d/pull/3689 で lsp-eslint-fix-all に戻したりしたけど
lsp-eslint-fix-all は時々 source.fixAll.eslint が available じゃないって状態になるので使うのをやめた
その代わり lsp-eslint-apply-all-fix がいい感じに動くっぽいのでそちらを採用した

## tsx で smartparens-strict-mode を使うようにした

カッコの中だけいい感じに消してほしいので strict な mode に切り替えた

https://github.com/mugijiru/.emacs.d/pull/377#issue-999968642 によると arrow function と相性が悪いらしいので
これも様子見かな。