### PR TITLE
feat: Reset org-refile-targets after open new journal file

### DIFF
--- a/hugo/content/org-mode/org-journal.md
+++ b/hugo/content/org-mode/org-journal.md
@@ -48,3 +48,14 @@ draft = false
  '(org-journal-enable-agenda-integration t)
  '(org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}"))
 ```
+
+
+## hook {#hook}
+
+org-journal ファイルを新しく作る度にそのファイルを refile target で扱って欲しいので
+hook で org-refile-targets を設定し直すようにしている
+
+```emacs-lisp
+(with-eval-after-load 'org-journal
+  (add-to-list 'org-journal-after-header-create-hook 'my/reset-org-refile-targets))
+```

--- a/hugo/content/org-mode/org-refile.md
+++ b/hugo/content/org-mode/org-refile.md
@@ -38,11 +38,16 @@ nil だと移動先候補PATHの最後の部分しか表示されないのでど
 
 いくつかの org ファイルを使っているのでターゲットを以下のように設定している。
 
+なお関数化することで hook で呼び出せるようにしている
+
 ```emacs-lisp
-(setq org-refile-targets `((,(org-journal--get-entry-path) :regexp . "Tasks")
-                           (,(concat org-directory "tasks/projects.org") :level . 1)
-                           (,(concat org-directory "tasks/pointers.org") :level . 1)
-                           (,(concat org-directory "tasks/someday.org") :level . 1)))
+(defun my/reset-org-refile-targets ()
+  (setq org-refile-targets `((,(org-journal--get-entry-path) :regexp . "Tasks")
+                             (,(concat org-directory "tasks/projects.org") :level . 1)
+                             (,(concat org-directory "tasks/pointers.org") :level . 1)
+                             (,(concat org-directory "tasks/someday.org") :level . 1))))
+
+(my/reset-org-refile-targets)
 ```
 
 | ターゲット   | 目的                                                             |

--- a/init.org
+++ b/init.org
@@ -8728,6 +8728,16 @@ agenda ファイルに使われているタグは全部補完対象になって�
    '(org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}"))
 #+end_src
 
+*** hook
+
+org-journal ファイルを新しく作る度にそのファイルを refile target で扱って欲しいので
+hook で org-refile-targets を設定し直すようにしている
+
+#+begin_src emacs-lisp :tangle inits/61-org-journal.el
+  (with-eval-after-load 'org-journal
+    (add-to-list 'org-journal-after-header-create-hook 'my/reset-org-refile-targets))
+#+end_src
+
 ** ox-hugo
    :PROPERTIES:
    :EXPORT_HUGO_CUSTOM_FRONT_MATTER: :weight 12

--- a/init.org
+++ b/init.org
@@ -8587,11 +8587,16 @@ agenda ファイルに使われているタグは全部補完対象になって�
      いくつかの org ファイルを使っているので
      ターゲットを以下のように設定している。
 
+     なお関数化することで hook で呼び出せるようにしている
+
      #+begin_src emacs-lisp :tangle inits/61-org-refile.el
-       (setq org-refile-targets `((,(org-journal--get-entry-path) :regexp . "Tasks")
-                                  (,(concat org-directory "tasks/projects.org") :level . 1)
-                                  (,(concat org-directory "tasks/pointers.org") :level . 1)
-                                  (,(concat org-directory "tasks/someday.org") :level . 1)))
+       (defun my/reset-org-refile-targets ()
+         (setq org-refile-targets `((,(org-journal--get-entry-path) :regexp . "Tasks")
+                                    (,(concat org-directory "tasks/projects.org") :level . 1)
+                                    (,(concat org-directory "tasks/pointers.org") :level . 1)
+                                    (,(concat org-directory "tasks/someday.org") :level . 1))))
+
+       (my/reset-org-refile-targets)
      #+end_src
 
      | ターゲット         | 目的                                                                                                   |

--- a/inits/61-org-journal.el
+++ b/inits/61-org-journal.el
@@ -17,3 +17,6 @@
  '(org-journal-date-format "%d日(%a)")
  '(org-journal-enable-agenda-integration t)
  '(org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}"))
+
+(with-eval-after-load 'org-journal
+  (add-to-list 'org-journal-after-header-create-hook 'my/reset-org-refile-targets))

--- a/inits/61-org-refile.el
+++ b/inits/61-org-refile.el
@@ -2,7 +2,10 @@
 
 (setq org-refile-use-outline-path 'file)
 
-(setq org-refile-targets `((,(org-journal--get-entry-path) :regexp . "Tasks")
-                           (,(concat org-directory "tasks/projects.org") :level . 1)
-                           (,(concat org-directory "tasks/pointers.org") :level . 1)
-                           (,(concat org-directory "tasks/someday.org") :level . 1)))
+(defun my/reset-org-refile-targets ()
+  (setq org-refile-targets `((,(org-journal--get-entry-path) :regexp . "Tasks")
+                             (,(concat org-directory "tasks/projects.org") :level . 1)
+                             (,(concat org-directory "tasks/pointers.org") :level . 1)
+                             (,(concat org-directory "tasks/someday.org") :level . 1))))
+
+(my/reset-org-refile-targets)


### PR DESCRIPTION
新しく journal ファイルを開いた時に
org-refile-targets を更新するようにした

これで日付が変わって新しく journal ファイルを用意した時に自動で refile targets が切り替わってくれるようになるはずなので
毎朝の refile の準備がちょっと楽になる