### PR TITLE
fix: Do not indent org-capture template

### DIFF
--- a/hugo/content/org-mode/org-capture.md
+++ b/hugo/content/org-mode/org-capture.md
@@ -63,8 +63,8 @@ org-capture は org-mode 用にさくっとメモを取るための機能。
       `(("g" "Inbox にエントリー" entry
          (file ,my/org-capture-inbox-file)
          "* TODO %? %^G\n** Ready の定義
-   - Why?, Goal, How? が埋められていること
-   - How がある程度具体的に書かれていること
+- Why?, Goal, How? が埋められていること
+- How がある程度具体的に書かれていること
 ** Why?
 ** Info
 ** Goal

--- a/init.org
+++ b/init.org
@@ -8385,8 +8385,8 @@ agenda ファイルに使われているタグは全部補完対象になって�
           `(("g" "Inbox にエントリー" entry
              (file ,my/org-capture-inbox-file)
              "* TODO %? %^G\n** Ready の定義
-       - Why?, Goal, How? が埋められていること
-       - How がある程度具体的に書かれていること
+    - Why?, Goal, How? が埋められていること
+    - How がある程度具体的に書かれていること
     ** Why?
     ** Info
     ** Goal

--- a/inits/61-org-capture.el
+++ b/inits/61-org-capture.el
@@ -16,8 +16,8 @@
       `(("g" "Inbox にエントリー" entry
          (file ,my/org-capture-inbox-file)
          "* TODO %? %^G\n** Ready の定義
-   - Why?, Goal, How? が埋められていること
-   - How がある程度具体的に書かれていること
+- Why?, Goal, How? が埋められていること
+- How がある程度具体的に書かれていること
 ** Why?
 ** Info
 ** Goal


### PR DESCRIPTION
インデントする必要がないのでテンプレートのインデントを解除した