### PR TITLE
fix: Improve ember-mode recipe

### DIFF
--- a/hugo/content/programming/ember-js.md
+++ b/hugo/content/programming/ember-js.md
@@ -28,10 +28,11 @@ projectile なんかがやってるようにフォルダ構成から判定させ
 el-get.lock を用いたバージョン更新確認スクリプトのためレシピを追加している
 
 ```emacs-lisp
-(:name madnificent/ember-mode
+(:name ember-mode
        :website "https://github.com/madnificent/ember-mode"
        :description "Ember-mode speeds up navigation in EmberJS projects."
        :type github
+       :branch "master"
        :pkgname "madnificent/ember-mode")
 ```
 

--- a/init.org
+++ b/init.org
@@ -4953,10 +4953,11 @@ el-get.lock を用いたバージョン更新確認スクリプトのため
 レシピを追加している
 
 #+begin_src emacs-lisp :tangle recipes/ember-mode.rcp
-(:name madnificent/ember-mode
+(:name ember-mode
        :website "https://github.com/madnificent/ember-mode"
        :description "Ember-mode speeds up navigation in EmberJS projects."
        :type github
+       :branch "master"
        :pkgname "madnificent/ember-mode")
 #+end_src
 

--- a/recipes/ember-mode.rcp
+++ b/recipes/ember-mode.rcp
@@ -2,4 +2,5 @@
        :website "https://github.com/madnificent/ember-mode"
        :description "Ember-mode speeds up navigation in EmberJS projects."
        :type github
+       :branch "master"
        :pkgname "madnificent/ember-mode")

--- a/recipes/ember-mode.rcp
+++ b/recipes/ember-mode.rcp
@@ -1,4 +1,4 @@
-(:name madnificent/ember-mode
+(:name ember-mode
        :website "https://github.com/madnificent/ember-mode"
        :description "Ember-mode speeds up navigation in EmberJS projects."
        :type github


### PR DESCRIPTION
# 概要

ember-mode のレシピの記述を修正しました。

# 課題

連日 ember-mode の更新処理が失敗しています。
ref: https://github.com/mugijiru/.emacs.d/actions/runs/8178184731/job/22361610522

```
Error: error ("Package madnificent/ember-mode is nowhere to be found in el-get status file.")
```

とか言われているので、恐らく原因は recipe で記述している名前の問題かな〜と。

# 対応内容

というわけでレシピ名を修正し、ファイル名と揃えています。
そもそもリポジトリ名まで入れてたのは、多分単純なミスだし。

# その他

ついでに branch も指定しています。
これは master なのであまり必要ないけど。