### PR TITLE
fix: Improve lsp-file-watch-ignored-directories

### DIFF
--- a/hugo/content/programming/lsp-mode.md
+++ b/hugo/content/programming/lsp-mode.md
@@ -91,9 +91,8 @@ lsp--formatting-indent-aliat に web-mode と tsx-ts-mode の設定を追加す�
 (with-eval-after-load 'lsp-mode
   (add-to-list 'lsp--formatting-indent-alist `(web-mode . web-mode-code-indent-offset))
   (add-to-list 'lsp--formatting-indent-alist `(tsx-ts-mode . typescript-ts-mode-indent-offset))
-  (add-to-list 'lsp-file-watch-ignored-directories "node_modules")
   (add-to-list 'lsp-file-watch-ignored-directories "tmp")
-  (add-to-list 'lsp-file-watch-ignored-directories "vendor")
+  (add-to-list 'lsp-file-watch-ignored-directories "[/\\\\]vendor\\'")
   (add-to-list 'lsp-file-watch-ignored-directories "hello-friend-ng")
   (add-to-list 'lsp-file-watch-ignored-directories "ox-hugo"))
 ```

--- a/init.org
+++ b/init.org
@@ -5416,9 +5416,8 @@ lsp--formatting-indent-aliat に web-mode と tsx-ts-mode の設定を追加す�
 (with-eval-after-load 'lsp-mode
   (add-to-list 'lsp--formatting-indent-alist `(web-mode . web-mode-code-indent-offset))
   (add-to-list 'lsp--formatting-indent-alist `(tsx-ts-mode . typescript-ts-mode-indent-offset))
-  (add-to-list 'lsp-file-watch-ignored-directories "node_modules")
   (add-to-list 'lsp-file-watch-ignored-directories "tmp")
-  (add-to-list 'lsp-file-watch-ignored-directories "vendor")
+  (add-to-list 'lsp-file-watch-ignored-directories "[/\\\\]vendor\\'")
   (add-to-list 'lsp-file-watch-ignored-directories "hello-friend-ng")
   (add-to-list 'lsp-file-watch-ignored-directories "ox-hugo"))
 #+end_src

--- a/inits/20-lsp.el
+++ b/inits/20-lsp.el
@@ -37,8 +37,7 @@
 (with-eval-after-load 'lsp-mode
   (add-to-list 'lsp--formatting-indent-alist `(web-mode . web-mode-code-indent-offset))
   (add-to-list 'lsp--formatting-indent-alist `(tsx-ts-mode . typescript-ts-mode-indent-offset))
-  (add-to-list 'lsp-file-watch-ignored-directories "node_modules")
   (add-to-list 'lsp-file-watch-ignored-directories "tmp")
-  (add-to-list 'lsp-file-watch-ignored-directories "vendor")
+  (add-to-list 'lsp-file-watch-ignored-directories "[/\\\\]vendor\\'")
   (add-to-list 'lsp-file-watch-ignored-directories "hello-friend-ng")
   (add-to-list 'lsp-file-watch-ignored-directories "ox-hugo"))


### PR DESCRIPTION
- node_modueles はデフォルトで無視対象だったので追加をやめた
- vendor ディレクトリを厳密に除外するように正規表現を利用する