### PR TITLE
feat: Enable lsp-mode, display-line-numbers-mode and flycheck on dockerfile-ts-mode

### DIFF
--- a/hugo/content/programming/docker.md
+++ b/hugo/content/programming/docker.md
@@ -46,6 +46,7 @@ dockerfile-mode-hook で lsp を起動させるようにしている。
 ```emacs-lisp
 (defun my/dockerfile-mode-hook ()
   (display-line-numbers-mode t)
+  (flycheck-mode 1)
   (lsp))
 
 (add-hook 'dockerfile-mode-hook 'my/dockerfile-mode-hook)

--- a/hugo/content/programming/docker.md
+++ b/hugo/content/programming/docker.md
@@ -49,4 +49,5 @@ dockerfile-mode-hook で lsp を起動させるようにしている。
   (lsp))
 
 (add-hook 'dockerfile-mode-hook 'my/dockerfile-mode-hook)
+(add-hook 'dockerfile-ts-mode-hook 'my/dockerfile-mode-hook)
 ```

--- a/init.org
+++ b/init.org
@@ -4835,6 +4835,7 @@ dockerfile-mode-hook で lsp を起動させるようにしている。
   (lsp))
 
 (add-hook 'dockerfile-mode-hook 'my/dockerfile-mode-hook)
+(add-hook 'dockerfile-ts-mode-hook 'my/dockerfile-mode-hook)
 #+end_src
 ** emacs-lisp
 :PROPERTIES:

--- a/init.org
+++ b/init.org
@@ -4832,6 +4832,7 @@ dockerfile-mode-hook で lsp を起動させるようにしている。
 #+begin_src emacs-lisp :tangle inits/40-dockerfile.el
 (defun my/dockerfile-mode-hook ()
   (display-line-numbers-mode t)
+  (flycheck-mode 1)
   (lsp))
 
 (add-hook 'dockerfile-mode-hook 'my/dockerfile-mode-hook)

--- a/init.org
+++ b/init.org
@@ -4821,7 +4821,7 @@ Dockerfile を書いたりするための設定。
 [[https://emacs-lsp.github.io/lsp-mode/page/lsp-dockerfile/][lsp-mode では Dockerfile もサポートしている]] ので
 
 #+begin_example
-     $ npm install -g dockerfile-language-server-nodejs
+$ npm install -g dockerfile-language-server-nodejs
 #+end_example
 
 で LSP サーバを入れた上で
@@ -4855,7 +4855,7 @@ Hook 用の関数を定義してその中に色々書いている。
 - 当然補完もしたいので company-mode を有効にしている
 - カッコの対応などもいい感じに動いて欲しいので smartparens-mode とその strict-mode を有効にしている
 
-  #+begin_src emacs-lisp :tangle inits/40-emacs-lisp.el
+#+begin_src emacs-lisp :tangle inits/40-emacs-lisp.el
 (defun my/emacs-lisp-mode-hook ()
   (display-line-numbers-mode 1)
   (origami-mode 1)
@@ -4868,7 +4868,7 @@ Hook 用の関数を定義してその中に色々書いている。
 
   #+begin_src emacs-lisp :tangle inits/40-emacs-lisp.el
 (add-hook 'emacs-lisp-mode-hook 'my/emacs-lisp-mode-hook)
-  #+end_src
+#+end_src
 *** アイコン挿入コマンドの用意
 :PROPERTIES:
 :ID:       cbcc5bb0-f684-4c40-a34c-c51dd46bf519

--- a/inits/40-dockerfile.el
+++ b/inits/40-dockerfile.el
@@ -5,6 +5,7 @@
 
 (defun my/dockerfile-mode-hook ()
   (display-line-numbers-mode t)
+  (flycheck-mode 1)
   (lsp))
 
 (add-hook 'dockerfile-mode-hook 'my/dockerfile-mode-hook)

--- a/inits/40-dockerfile.el
+++ b/inits/40-dockerfile.el
@@ -8,3 +8,4 @@
   (lsp))
 
 (add-hook 'dockerfile-mode-hook 'my/dockerfile-mode-hook)
+(add-hook 'dockerfile-ts-mode-hook 'my/dockerfile-mode-hook)


### PR DESCRIPTION
# 概要

Dockerfile を編集する時にメジャーモードが dockerfile-ts-mode になったので
その場合にも dockerfile-mode 用に定義した hook が動きように調整した。

そしてついでに flycheck-mode も有効になるようにした