### PR TITLE
feat: Add and congiure moccur-edit and color-moccur

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,7 @@
 (setq el-get-lock-package-versions
-      '((esxml :checksum "225693096a587492d76bf696d1f0c25c61f7d531")
+      '((moccur-edit :checksum "026f5dd4159bd1b68c430ab385757157ba01a361")
+        (color-moccur :checksum "4f1c59ffd1ccc2ab1a171cd6b721e8cb9e002fb7")
+        (esxml :checksum "225693096a587492d76bf696d1f0c25c61f7d531")
         (kv :checksum "721148475bce38a70e0b678ba8aa923652e8900e")
         (calibredb :checksum "124c916f203511c64d03fac28d303dfb102a6ead")
         (git-modes :checksum "3cc94974c09c43462dfbfbe20396a414352dbb92")

--- a/hugo/content/editing/_index.md
+++ b/hugo/content/editing/_index.md
@@ -26,6 +26,9 @@ disableToc = true
 [flyspell]({{< relref "flyspell" >}})
 : スペルチェックをしてくれるパッケージ
 
+[moccur-edit]({{< relref "moccur-edit" >}})
+: color-moccur でディレクトリごと検索した後にそのバッファでそのまま編集できるようにするやつ
+
 [multiple-cursors]({{< relref "multiple-cursors" >}})
 : カーソルを増やして複数箇所を同時に編集できるようになるやつ
 

--- a/hugo/content/editing/moccur-edit.md
+++ b/hugo/content/editing/moccur-edit.md
@@ -1,0 +1,34 @@
++++
+title = "moccur-edit"
+draft = false
++++
+
+## 概要 {#概要}
+
+[moccur-edit](https://github.com/myuhe/moccur-edit.el) は [color-moccur](https://github.com/myuhe/color-moccur.el) で検索した結果を編集するためのツール。
+
+
+## インストール {#インストール}
+
+el-get 本体にレシピがあるのでそちらからインストールしている。
+
+```emacs-lisp
+(el-get-bundle moccur-edit)
+```
+
+なお EmacsWiki に moccur-edit も color-moccur もあるのだけど
+color-moccur の方がソースコードが古めなので
+GitHub から入れるのを推奨する。
+
+el-get のレシピは GitHub を見ているので安心
+
+
+## 設定 {#設定}
+
+とりあえず color-moccur で migemo が使えると検索する時に便利なのでその機能を有効にしている。また、編集したところがわかりやすい方がいいかなと思ったので、そこをハイライトする設定も入れておいた
+
+```emacs-lisp
+(custom-set-variables
+ '(moccur-use-migemo t)
+ '(moccur-edit-highlight-edited-text t))
+```

--- a/init.org
+++ b/init.org
@@ -1515,6 +1515,7 @@
    - [[id:549f0212-8e33-4ab8-bc84-418dd45bf92d][copilot]] :: GitHub Copilot を使えるようにするパッケージ
    - [[*emojify][emojify]] :: Slack や GitHub みたいに ~:smile:~ とか入れると笑顔の絵文字を表示する、みたいなやつ
    - [[id:3140f1e1-c1ee-4098-adc5-ddc695d5ea9d][flyspell]] :: スペルチェックをしてくれるパッケージ
+   - [[id:1e135071-8d60-4435-8819-3572c031f787][moccur-edit]] :: color-moccur でディレクトリごと検索した後にそのバッファでそのまま編集できるようにするやつ
    - [[*multiple-cursors][multiple-cursors]] :: カーソルを増やして複数箇所を同時に編集できるようになるやつ
    - [[id:f309e8bd-8e1d-4a91-ae4d-9a960373969b][origami]] :: コードの折り畳みができるようになるやつ
    - [[*smartparens][smartparens]] :: カッコや引用符などのペアになるやつの入力補助をしてくれるやつ
@@ -1868,6 +1869,34 @@ http://home.hatanaka.info/article/474728666.html
 *** その他
 ~flyspell-prog-mode~ を使うと、文字列やコメントにのみ有効にできるようですが
 そのあたりはまだ試していません。
+** moccur-edit
+:PROPERTIES:
+:EXPORT_FILE_NAME: moccur-edit
+:ID:       1e135071-8d60-4435-8819-3572c031f787
+:END:
+*** 概要
+[[https://github.com/myuhe/moccur-edit.el][moccur-edit]] は [[https://github.com/myuhe/color-moccur.el][color-moccur]] で検索した結果を編集するためのツール。
+*** インストール
+el-get 本体にレシピがあるのでそちらからインストールしている。
+
+#+begin_src emacs-lisp :tangle inits/40-moccur.el
+(el-get-bundle moccur-edit)
+#+end_src
+
+なお EmacsWiki に moccur-edit も color-moccur もあるのだけど
+color-moccur の方がソースコードが古めなので
+GitHub から入れるのを推奨する。
+
+el-get のレシピは GitHub を見ているので安心
+*** 設定
+とりあえず color-moccur で migemo が使えると検索する時に便利なのでその機能を有効にしている。
+また、編集したところがわかりやすい方がいいかなと思ったので、そこをハイライトする設定も入れておいた
+
+#+begin_src emacs-lisp :tangle inits/40-moccur.el
+(custom-set-variables
+ '(moccur-use-migemo t)
+ '(moccur-edit-highlight-edited-text t))
+#+end_src
 ** multiple-cursors
    :PROPERTIES:
    :EXPORT_FILE_NAME: multiple-cursors

--- a/inits/40-moccur.el
+++ b/inits/40-moccur.el
@@ -1,0 +1,5 @@
+(el-get-bundle moccur-edit)
+
+(custom-set-variables
+ '(moccur-use-migemo t)
+ '(moccur-edit-highlight-edited-text t))


### PR DESCRIPTION
# 概要

ディレクトリ以下とかをまるっと検索するための color-moccur と
その検索結果を直接編集できる moccur-edit を導入した

color-moccur は migemo も使えるので便利そう