### PR TITLE
feat: Enable which-function-mode

### DIFF
--- a/hugo/content/programming/ruby.md
+++ b/hugo/content/programming/ruby.md
@@ -77,8 +77,8 @@ encoding 設定のマジックコメントが入らないようにしている�
 
 ```ruby
 hoge = {
-         foo: 1
-       }
+  foo: 1
+}
 ```
 
 みたいな深いインデントになるけど
@@ -109,6 +109,7 @@ hook 用の関数で補完などの機能を有効にしている
   (origami-mode 1)
   (company-mode 1)
   (subword-mode 1)
+  (which-function-mode 1)
   (lsp)
   (lsp-ui-mode 1)
   (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)
@@ -116,7 +117,10 @@ hook 用の関数で補完などの機能を有効にしている
   (display-line-numbers-mode 1))
 ```
 
+-   コード折り畳み用に origami を有効化
 -   補完用に company-mode を有効化
+-   CamelCase の単語区切りを有効にするため subword-mode を有効化
+-   今いる関数名が mode-line に出てると便利げなので which-function-mode を有効化
 -   [solargraph](https://github.com/castwide/solargraph) を使ってるので lsp-mode を有効にしている
     -   lsp-ui-mode も有効にして色々な情報を表示している
 -   また lsp-mode の自動フォーマットを保存時に実行するようにしている
@@ -142,8 +146,7 @@ Ruby を使ってる時にコメント部分はクォートの外以外では自
 
 ### キーバインド {#キーバインド}
 
-キーバインドは覚えられないので
-[major-mode-hydra]({{< relref "neotree#major-mode-hydra" >}}) でキーを定義している
+キーバインドは覚えられないので [major-mode-hydra]({{< relref "hydra#major-mode-hydra-のインストール" >}}) でキーを定義している
 
 ```emacs-lisp
 (with-eval-after-load 'major-mode-hydra

--- a/hugo/content/programming/scss.md
+++ b/hugo/content/programming/scss.md
@@ -87,6 +87,7 @@ scss を使う上で hook を使って色々有効化したりしている。
   (origami-mode 1)
   (company-mode 1)
   (subword-mode 1)
+  (which-function-mode 1)
   (display-line-numbers-mode 1)
 
   (rainbow-mode))
@@ -104,6 +105,7 @@ scss を使う上で hook を使って色々有効化したりしている。
     -   lsp-ui とかより後に設定しないと上書きされるので、それらより後に設定している
     -   設定の書き方の悪さのせいな気もする
 -   company-mode の有効化。これがないと補完できなくて厳しいよね
+-   which-function-mode が有効だと今編集している css が分かりやすくて便利
 -   display-line-numbers-mode の有効化。行数表示も欲しいよね。巨大ファイルだと邪魔だけど巨大にしなきゃいい
 -   [rainbow-mode](#rainbow-mode) の有効化
 

--- a/hugo/content/programming/typescript.md
+++ b/hugo/content/programming/typescript.md
@@ -70,6 +70,7 @@ hook を使って有効化している
   (origami-mode 1)
   (company-mode 1)
   (subword-mode 1)
+  (which-function-mode 1)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode t)
   (lsp)

--- a/hugo/content/ui/hydra.md
+++ b/hugo/content/ui/hydra.md
@@ -163,6 +163,7 @@ el-get の Hydra はここで定義してしまっている。その内 el-get �
    (("z" zoom-mode                 "zoom-mode"      :toggle zoom-mode)
     ("Z" toggle-frame-fullscreen   "Fullscreen"     :toggle (frame-parameter nil 'fullscreen))
     ("e" emojify-mode              "Emojify"        :toggle emojify-mode)
+    ("w" which-function-mode       "Which func"     :toggle which-func-mode)
     ("b" display-battery-mode      "Battery"        :toggle display-battery-mode)
     ("L" display-line-numbers-mode "Line Number"    :toggle display-line-numbers-mode)
     ("N" neotree-toggle            "Neotree"        :toggle (if (fboundp 'neo-global--window-exists-p) (neo-global--window-exists-p) nil)))
@@ -181,6 +182,8 @@ el-get の Hydra はここで定義してしまっている。その内 el-get �
 |-----|--------------------------------------------------------------------------------------|
 | z   | [zoom-mode]({{< relref "zoom" >}}) のON/OFF切替。狭いディスプレイの時は ON にするが、大きいディスプレイだと OFF にしている |
 | Z   | フルスクリーンの切替。狭いディスプレイの時は ON にするが、大きいディスプレイだと OFF にしている |
+| e   | 常に絵文字に変換されると厳しい時があるので toggle できるようにしている                 |
+| w   | 関数名の表示が邪魔になることもありそうなので toggle できるようにしている               |
 | b   | バッテリー表示モードの切替。OFF にしたことないな……                                   |
 | L   | 行番号表示の切替。邪魔になる時もあるので ON/OFF 切り替えている                         |
 | N   | [Neotree]({{< relref "neotree" >}}) の表示切替。普段は邪魔なので OFF にしている        |

--- a/init.org
+++ b/init.org
@@ -6197,6 +6197,7 @@ scss を使う上で hook を使って色々有効化したりしている。
   (origami-mode 1)
   (company-mode 1)
   (subword-mode 1)
+  (which-function-mode 1)
   (display-line-numbers-mode 1)
 
   (rainbow-mode))
@@ -6214,6 +6215,7 @@ scss を使う上で hook を使って色々有効化したりしている。
   - lsp-ui とかより後に設定しないと上書きされるので、それらより後に設定している
   - 設定の書き方の悪さのせいな気もする
 - company-mode の有効化。これがないと補完できなくて厳しいよね
+- which-function-mode が有効だと今編集している css が分かりやすくて便利
 - display-line-numbers-mode の有効化。行数表示も欲しいよね。巨大ファイルだと邪魔だけど巨大にしなきゃいい
 - [[*rainbow-mode][rainbow-mode]] の有効化
 *** カラーコード→ CSS Variable の置き換え

--- a/init.org
+++ b/init.org
@@ -3159,6 +3159,7 @@ el-get の Hydra はここで定義してしまっている。
    (("z" zoom-mode                 "zoom-mode"      :toggle zoom-mode)
     ("Z" toggle-frame-fullscreen   "Fullscreen"     :toggle (frame-parameter nil 'fullscreen))
     ("e" emojify-mode              "Emojify"        :toggle emojify-mode)
+    ("w" which-function-mode       "Which func"     :toggle which-func-mode)
     ("b" display-battery-mode      "Battery"        :toggle display-battery-mode)
     ("L" display-line-numbers-mode "Line Number"    :toggle display-line-numbers-mode)
     ("N" neotree-toggle            "Neotree"        :toggle (if (fboundp 'neo-global--window-exists-p) (neo-global--window-exists-p) nil)))
@@ -3176,7 +3177,9 @@ el-get の Hydra はここで定義してしまっている。
 | Key | 効果                                                                                              |
 | z   | [[*zoom][zoom-mode]] のON/OFF切替。狭いディスプレイの時は ON にするが、大きいディスプレイだと OFF にしている |
 | Z   | フルスクリーンの切替。狭いディスプレイの時は ON にするが、大きいディスプレイだと OFF にしている   |
-| b   | バッテリー表示モードの切替。OFF にしたことないな……                                                |
+| e   | 常に絵文字に変換されると厳しい時があるので toggle できるようにしている                            |
+| w   | 関数名の表示が邪魔になることもありそうなので toggle できるようにしている                          |
+| b   | バッテリー表示モードの切替。OFF にしたことないな……                                              |
 | L   | 行番号表示の切替。邪魔になる時もあるので ON/OFF 切り替えている                                    |
 | N   | [[*Neotree][Neotree]] の表示切替。普段は邪魔なので OFF にしている                                               |
 | S   | Slack 通知の切替。org-clock-in とかのタイミングで Slack に通知を飛ばしているが切る時もある        |
@@ -5918,6 +5921,7 @@ Docker と連携するように調整
 (custom-set-variables
  '(rspec-use-docker-when-possible t))
 #+end_src
+
 ** ruby
 :PROPERTIES:
 :EXPORT_FILE_NAME: ruby
@@ -6028,6 +6032,7 @@ hook 用の関数で補完などの機能を有効にしている
   (origami-mode 1)
   (company-mode 1)
   (subword-mode 1)
+  (which-function-mode 1)
   (lsp)
   (lsp-ui-mode 1)
   (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)
@@ -6035,18 +6040,21 @@ hook 用の関数で補完などの機能を有効にしている
   (display-line-numbers-mode 1))
 #+end_src
 
-  - 補完用に company-mode を有効化
-  - [[https://github.com/castwide/solargraph][solargraph]] を使ってるので lsp-mode を有効にしている
-    - lsp-ui-mode も有効にして色々な情報を表示している
-  - また lsp-mode の自動フォーマットを保存時に実行するようにしている
-  - 開きカッコと閉じカッコの組み合わせがズレないように smartparens-strict-mode を有効にしている
-  - 行番号も表示されている方が便利なので display-line-numbers-mode を有効にしている
+- コード折り畳み用に origami を有効化
+- 補完用に company-mode を有効化
+- CamelCase の単語区切りを有効にするため subword-mode を有効化
+- 今いる関数名が mode-line に出てると便利げなので which-function-mode を有効化
+- [[https://github.com/castwide/solargraph][solargraph]] を使ってるので lsp-mode を有効にしている
+  - lsp-ui-mode も有効にして色々な情報を表示している
+- また lsp-mode の自動フォーマットを保存時に実行するようにしている
+- 開きカッコと閉じカッコの組み合わせがズレないように smartparens-strict-mode を有効にしている
+- 行番号も表示されている方が便利なので display-line-numbers-mode を有効にしている
 
-    それらを設定する関数を enh-ruby-mode-hook に突っ込んでいる
+それらを設定する関数を enh-ruby-mode-hook に突っ込んでいる
 
-    #+begin_src emacs-lisp :tangle inits/40-ruby.el
+#+begin_src emacs-lisp :tangle inits/40-ruby.el
 (add-hook 'enh-ruby-mode-hook 'my/enh-ruby-mode-hook)
-    #+end_src
+#+end_src
 
 **** SKK の調整
 :PROPERTIES:
@@ -6059,13 +6067,11 @@ Ruby を使ってる時にコメント部分はクォートの外以外では
 #+begin_src emacs-lisp :tangle inits/40-ruby.el
 (add-to-list 'context-skk-programming-mode 'enh-ruby-mode)
 #+end_src
-
 **** キーバインド
 :PROPERTIES:
 :ID:       edd06a6f-6845-475a-83f5-df8d934fd241
 :END:
-キーバインドは覚えられないので
-[[*major-mode-hydra][major-mode-hydra]] でキーを定義している
+キーバインドは覚えられないので [[id:1daf2240-355e-4ecf-8a7d-875062872207][major-mode-hydra]] でキーを定義している
 
 #+begin_src emacs-lisp :tangle inits/40-ruby.el
 (with-eval-after-load 'major-mode-hydra
@@ -6103,7 +6109,6 @@ Ruby を使ってる時にコメント部分はクォートの外以外では
 | l   | 最後に失敗したテストの再実行                                                |
 | I   | REPL バッファで Ruby を実行する                                             |
 | j   | dumb-jump で関数定義にジャンプ。dumb-jump 用の hydra があるから要らなさそう |
-
 ** scss
 :PROPERTIES:
 :EXPORT_FILE_NAME: scss

--- a/init.org
+++ b/init.org
@@ -6425,9 +6425,9 @@ TypeScript ファイル(.ts) を使う上での設定を書いている。
 - Node.js の使用メモリも 2048 MB に増加。メモリ足らんってなる時があったので
 - 保存時の自動フォーマット
 
-  などを設定している。
+などを設定している。
 
-  #+begin_src emacs-lisp :tangle inits/40-ts.el
+#+begin_src emacs-lisp :tangle inits/40-ts.el
 (custom-set-variables
  '(typescript-indent-level 2)
  '(lsp-typescript-locale "ja")
@@ -6437,7 +6437,7 @@ TypeScript ファイル(.ts) を使う上での設定を書いている。
  '(lsp-clients-typescript-max-ts-server-memory 2048)
  '(lsp-disabled-clients '())
  '(lsp-eslint-auto-fix-on-save nil))
-  #+end_src
+#+end_src
 **** auto-fix の hook 関数
 :PROPERTIES:
 :ID:       26121357-e71c-4977-9046-a0d49c557069
@@ -6458,31 +6458,32 @@ TypeScript ファイル(.ts) を使う上での設定を書いている。
 - smartparens-strict-mode
 - lsp/lsp-ui
 
-  などのプログラミングで便利な各種のモードを
-  hook を使って有効化している
+などのプログラミングで便利な各種のモードを
+hook を使って有効化している
 
-  #+begin_src emacs-lisp :tangle inits/40-ts.el
+#+begin_src emacs-lisp :tangle inits/40-ts.el
 (defun my/ts-mode-hook ()
   (origami-mode 1)
   (company-mode 1)
   (subword-mode 1)
+  (which-function-mode 1)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode t)
   (lsp)
   (lsp-ui-mode 1)
   (add-hook 'before-save-hook #'my/ts-mode-auto-fix-hook nil 'local))
-  #+end_src
+#+end_src
 
-  この関数を
+この関数を
 
-  #+begin_src emacs-lisp :tangle inits/40-ts.el
+#+begin_src emacs-lisp :tangle inits/40-ts.el
 (add-hook 'typescript-ts-mode-hook 'my/ts-mode-hook)
-  #+end_src
+#+end_src
 
-  として hook に追加している。
+として hook に追加している。
 
-  直接 lambda で add-hook に書くという手もあるが
-  関数を分離しておくと修正の反映が用意なのでこのようにしている。
+直接 lambda で add-hook に書くという手もあるが
+関数を分離しておくと修正の反映が用意なのでこのようにしている。
 **** 拡張子による有効化
 :PROPERTIES:
 :ID:       99bddae1-3a76-4a7a-91e2-4ca7e1889600

--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -14,6 +14,7 @@
   (origami-mode 1)
   (company-mode 1)
   (subword-mode 1)
+  (which-function-mode 1)
   (lsp)
   (lsp-ui-mode 1)
   (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)

--- a/inits/40-scss.el
+++ b/inits/40-scss.el
@@ -33,6 +33,7 @@ See URL `http://stylelint.io/'."
   (origami-mode 1)
   (company-mode 1)
   (subword-mode 1)
+  (which-function-mode 1)
   (display-line-numbers-mode 1)
 
   (rainbow-mode))

--- a/inits/40-ts.el
+++ b/inits/40-ts.el
@@ -18,6 +18,7 @@
   (origami-mode 1)
   (company-mode 1)
   (subword-mode 1)
+  (which-function-mode 1)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode t)
   (lsp)

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -44,6 +44,7 @@
    (("z" zoom-mode                 "zoom-mode"      :toggle zoom-mode)
     ("Z" toggle-frame-fullscreen   "Fullscreen"     :toggle (frame-parameter nil 'fullscreen))
     ("e" emojify-mode              "Emojify"        :toggle emojify-mode)
+    ("w" which-function-mode       "Which func"     :toggle which-func-mode)
     ("b" display-battery-mode      "Battery"        :toggle display-battery-mode)
     ("L" display-line-numbers-mode "Line Number"    :toggle display-line-numbers-mode)
     ("N" neotree-toggle            "Neotree"        :toggle (if (fboundp 'neo-global--window-exists-p) (neo-global--window-exists-p) nil)))


### PR DESCRIPTION
# 概要

enh-ruby-mode, typescript-ts-mode, scss-mode で which-function-mode を有効にした。

また邪魔になった時のために toggle しやすいように
各 mode を toggle するための hydra にも追加してある