### PR TITLE
fix: Disable org-journal to agenda integration

### DIFF
--- a/hugo/content/org-mode/org-journal.md
+++ b/hugo/content/org-mode/org-journal.md
@@ -61,7 +61,7 @@ org-clock-report では前日分も target に入れてほしいのでそれの 
  '(org-journal-dir (concat org-directory "journal/"))
  '(org-journal-file-format "%Y%m%d.org")
  '(org-journal-date-format "%d日(%a)")
- '(org-journal-enable-agenda-integration t)
+ '(org-journal-enable-agenda-integration nil)
  '(org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}"))
 ```
 

--- a/init.org
+++ b/init.org
@@ -9218,7 +9218,7 @@ org-clock-report では前日分も target に入れてほしいので
  '(org-journal-dir (concat org-directory "journal/"))
  '(org-journal-file-format "%Y%m%d.org")
  '(org-journal-date-format "%d日(%a)")
- '(org-journal-enable-agenda-integration t)
+ '(org-journal-enable-agenda-integration nil)
  '(org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}"))
 #+end_src
 

--- a/inits/61-org-journal.el
+++ b/inits/61-org-journal.el
@@ -15,7 +15,7 @@
  '(org-journal-dir (concat org-directory "journal/"))
  '(org-journal-file-format "%Y%m%d.org")
  '(org-journal-date-format "%d日(%a)")
- '(org-journal-enable-agenda-integration t)
+ '(org-journal-enable-agenda-integration nil)
  '(org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}"))
 
 (with-eval-after-load 'org-journal


### PR DESCRIPTION
# 概要

org-journal の保存時に
org-agenda-targets を自動で更新する機能を無効にした。

# 変更の理由

これを有効にしていると保存時に時間がかかるので、
一旦無効にして運用してみる。