### PR TITLE
style: Use setopt instead of custom-set-variables on journal conf

### DIFF
--- a/hugo/content/org-mode/org-journal.md
+++ b/hugo/content/org-mode/org-journal.md
@@ -57,12 +57,11 @@ org-clock-report では前日分も target に入れてほしいのでそれの 
 ## 設定 {#設定}
 
 ```emacs-lisp
-(custom-set-variables
- '(org-journal-dir (concat org-directory "journal/"))
- '(org-journal-file-format "%Y%m%d.org")
- '(org-journal-date-format "%d日(%a)")
- '(org-journal-enable-agenda-integration nil)
- '(org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}"))
+(setopt org-journal-dir (concat org-directory "journal/"))
+(setopt org-journal-file-format "%Y%m%d.org")
+(setopt org-journal-date-format "%d日(%a)")
+(setopt org-journal-enable-agenda-integration nil)
+(setopt org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}")
 ```
 
 

--- a/init.org
+++ b/init.org
@@ -9214,12 +9214,11 @@ org-clock-report では前日分も target に入れてほしいので
 *** 設定
 
 #+begin_src emacs-lisp :tangle inits/61-org-journal.el
-(custom-set-variables
- '(org-journal-dir (concat org-directory "journal/"))
- '(org-journal-file-format "%Y%m%d.org")
- '(org-journal-date-format "%d日(%a)")
- '(org-journal-enable-agenda-integration nil)
- '(org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}"))
+(setopt org-journal-dir (concat org-directory "journal/"))
+(setopt org-journal-file-format "%Y%m%d.org")
+(setopt org-journal-date-format "%d日(%a)")
+(setopt org-journal-enable-agenda-integration nil)
+(setopt org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}")
 #+end_src
 
 *** hook

--- a/inits/61-org-journal.el
+++ b/inits/61-org-journal.el
@@ -11,12 +11,11 @@
          (files (append `(,yesterday-journal-file-path) agenda-files)))
     (org-add-archive-files files)))
 
-(custom-set-variables
- '(org-journal-dir (concat org-directory "journal/"))
- '(org-journal-file-format "%Y%m%d.org")
- '(org-journal-date-format "%d日(%a)")
- '(org-journal-enable-agenda-integration nil)
- '(org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}"))
+(setopt org-journal-dir (concat org-directory "journal/"))
+(setopt org-journal-file-format "%Y%m%d.org")
+(setopt org-journal-date-format "%d日(%a)")
+(setopt org-journal-enable-agenda-integration nil)
+(setopt org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}")
 
 (with-eval-after-load 'org-journal
   (add-to-list 'org-journal-after-header-create-hook 'my/reset-org-refile-targets))


### PR DESCRIPTION
# 概要

org-journal のカスタム変数を設定する際に
custom-set-variables ではなく setopt を使うようにした

# 変更の理由

複数の設定を custom-set-variables の中に囲むよりも
こっちを使っておく方が
編集して評価する際に1つの変数だけ変更できて便利だなって

# 補足

setopt は Emacs 29 で追加されたマクロ。
これにより setq と似た感覚で設定ができるようになる。