### PR TITLE
feat: Improve org capture templates

### DIFF
--- a/hugo/content/org-mode/org-capture.md
+++ b/hugo/content/org-mode/org-capture.md
@@ -46,6 +46,9 @@ org-capture は org-mode 用にさくっとメモを取るための機能。
 | g   | GTD でとりあえず最初に放り込む Inbox に相当するファイルに登録 | Why?, Goal, How? 等の欄を設けることでそのタスクの諸々をハッキリさせようとしている                       |
 | m   | とりあえずメモっておきたいやつを放り込む | 最近使ってない。使いにくいのかも                                                                        |
 | p   | 資料を放り込むやつ                   | あとで読むリストになってる。読み終わっても、便利そうなのは DONE のまま置いている                        |
+| lr  | 読書メモ用                           |                                                                                                         |
+| lb  | ブログ記事感想とかに使う             |                                                                                                         |
+| lm  | 映画感想用                           |                                                                                                         |
 | i   | 割込みタスクの登録                   | [org-modeで割り込みにも対応した時間記録をとる方法](https://grugrut.hatenablog.jp/entry/2016/03/13/085417) のやつを流用している。たまに使う。 |
 | I   | 開発を進める上での障害をリストアップする用 | 最近使ってない。溜めても振り替えってないので溜める気すらなくなった                                      |
 | s   | SQL 用のメモに登録                   | さくっと書いた SQL を後からまた使えないかな〜と思って溜めてみている                                     |
@@ -75,6 +78,31 @@ org-capture は org-mode 用にさくっとメモを取るための機能。
         ("p" "Pointersにエントリー" entry
          (file+headline ,my/org-capture-pointers-file "Pointers")
          "** %?\n\t")
+        ("l" "鑑賞ログ")
+        ("lr" "読書メモ" entry
+         (id "a0e30a2f-d4ee-426d-9f19-a1bbab2b2563")
+         "** %?
+%t
+*** Reference
+
+*** 感想など
+")
+        ("lb" "ブログ記事メモ" entry
+         (id "e4eed87b-0852-4691-9cd6-4b1596f2b09b")
+         "** %?
+%t
+*** Reference
+
+*** 感想など
+")
+        ("lm" "映画" entry
+         (id "56af8238-c9e8-497c-9695-46849cc8e091")
+         "** %?
+%t
+*** Reference
+
+*** 感想など
+")
         ("i" "割り込みタスクにエントリー" entry ;; 参考: http://grugrut.hatenablog.jp/entry/2016/03/13/085417
          (file+headline ,my/org-capture-interrupted-file "Interrupted")
          "** %?\n\t" :clock-in t :clock-resume t)

--- a/hugo/content/org-mode/org-capture.md
+++ b/hugo/content/org-mode/org-capture.md
@@ -33,8 +33,6 @@ org-capture は org-mode 用にさくっとメモを取るための機能。
 (setq my/org-capture-impediments-file  (concat org-directory "work/scrum/impediments.org"))
 (setq my/org-capture-memo-file         (concat org-directory "memo.org"))
 (setq my/org-capture-sql-file          (concat org-directory "work/sql.org"))
-(setq my/org-capture-shopping-file     (concat my/org-tasks-directory "shopping.org"))
-(setq my/org-capture-2020-summary-file (concat org-directory "private/2020_summary.org"))
 (setq my/org-small-topic-file (concat org-directory "small-topic.org"))
 ```
 
@@ -50,9 +48,7 @@ org-capture は org-mode 用にさくっとメモを取るための機能。
 | p   | 資料を放り込むやつ                   | あとで読むリストになってる。読み終わっても、便利そうなのは DONE のまま置いている                        |
 | i   | 割込みタスクの登録                   | [org-modeで割り込みにも対応した時間記録をとる方法](https://grugrut.hatenablog.jp/entry/2016/03/13/085417) のやつを流用している。たまに使う。 |
 | I   | 開発を進める上での障害をリストアップする用 | 最近使ってない。溜めても振り替えってないので溜める気すらなくなった                                      |
-| R   | 2020年の振り返り用                   | もう2020年は過去の話なので不要でしょ                                                                    |
 | s   | SQL 用のメモに登録                   | さくっと書いた SQL を後からまた使えないかな〜と思って溜めてみている                                     |
-| S   | 買物リストに登録                     | Inbox から refile でもいい気がする                                                                      |
 | b   | Blogネタにエントリー                 | 最近使ってない……。ブログ止まってるしな。                                                              |
 | P   | Firefox からページの一部を資料として放り込む用 | <https://github.com/sprig/org-capture-extension> 関係。Win では設定できてない                           |
 | L   | Firefox からページURLを資料として放り込む用 | <https://github.com/sprig/org-capture-extension> 関係。Win では設定できてない                           |
@@ -85,18 +81,12 @@ org-capture は org-mode 用にさくっとメモを取るための機能。
         ("I" "障害リストにエントリー" entry
          (file+headline ,my/org-capture-impediments-file "Impediments")
          "** TODO %?\n\t")
-        ("R" "2020ふりかえりにエントリー" entry
-         (file+headline ,my/org-capture-2020-summary-file "Timeline")
-         "** %?\n\t")
         ("z" "一言・雑談ネタ" entry
          (file+headline ,my/org-small-topic-file "Topic")
          "** %?\n\t")
         ("s" "SQL にエントリー" entry
          (file+headline ,my/org-capture-sql-file "SQL")
          "** %?\n\t")
-        ("S" "買い物リストエントリー" entry
-         (file ,my/org-capture-shopping-file)
-         "* TODO %?\n\t")
         ("b" "Blogネタにエントリー" entry
          (file+headline ,my/org-capture-memo-file "Blogネタ")
          "** %?\n\t")

--- a/init.org
+++ b/init.org
@@ -8645,13 +8645,16 @@ https://qiita.com/takaxp/items/0b717ad1d0488b74429d を参考に設定したや�
 上記の変数を使って capture 用テンプレートを登録している。
 
 | Key | 効果                                                          | 備考                                                                                |
-| g   | GTD でとりあえず最初に放り込む Inbox に相当するファイルに登録 | Why?, Goal, How? 等の欄を設けることでそのタスクの諸々をハッキリさせようとしている    |
+| g   | GTD でとりあえず最初に放り込む Inbox に相当するファイルに登録 | Why?, Goal, How? 等の欄を設けることでそのタスクの諸々をハッキリさせようとしている   |
 | m   | とりあえずメモっておきたいやつを放り込む                      | 最近使ってない。使いにくいのかも                                                    |
 | p   | 資料を放り込むやつ                                            | あとで読むリストになってる。読み終わっても、便利そうなのは DONE のまま置いている    |
+| lr  | 読書メモ用                                                    |                                                                                     |
+| lb  | ブログ記事感想とかに使う                                      |                                                                                     |
+| lm  | 映画感想用                                                    |                                                                                     |
 | i   | 割込みタスクの登録                                            | [[https://grugrut.hatenablog.jp/entry/2016/03/13/085417][org-modeで割り込みにも対応した時間記録をとる方法]] のやつを流用している。たまに使う。 |
 | I   | 開発を進める上での障害をリストアップする用                    | 最近使ってない。溜めても振り替えってないので溜める気すらなくなった                  |
 | s   | SQL 用のメモに登録                                            | さくっと書いた SQL を後からまた使えないかな〜と思って溜めてみている                 |
-| b   | Blogネタにエントリー                                          | 最近使ってない……。ブログ止まってるしな。                                            |
+| b   | Blogネタにエントリー                                          | 最近使ってない……。ブログ止まってるしな。                                          |
 | P   | Firefox からページの一部を資料として放り込む用                | https://github.com/sprig/org-capture-extension 関係。Win では設定できてない         |
 | L   | Firefox からページURLを資料として放り込む用                   | https://github.com/sprig/org-capture-extension 関係。Win では設定できてない         |
 | c   | スケジュール管理用ファイルに登録                              | 使ってない。対象ファイルを変えて使ってみてもいいかも                                |
@@ -8677,6 +8680,31 @@ https://qiita.com/takaxp/items/0b717ad1d0488b74429d を参考に設定したや�
         ("p" "Pointersにエントリー" entry
          (file+headline ,my/org-capture-pointers-file "Pointers")
          "** %?\n\t")
+        ("l" "鑑賞ログ")
+        ("lr" "読書メモ" entry
+         (id "a0e30a2f-d4ee-426d-9f19-a1bbab2b2563")
+         "** %?
+%t
+,*** Reference
+
+,*** 感想など
+")
+        ("lb" "ブログ記事メモ" entry
+         (id "e4eed87b-0852-4691-9cd6-4b1596f2b09b")
+         "** %?
+%t
+,*** Reference
+
+,*** 感想など
+")
+        ("lm" "映画" entry
+         (id "56af8238-c9e8-497c-9695-46849cc8e091")
+         "** %?
+%t
+,*** Reference
+
+,*** 感想など
+")
         ("i" "割り込みタスクにエントリー" entry ;; 参考: http://grugrut.hatenablog.jp/entry/2016/03/13/085417
          (file+headline ,my/org-capture-interrupted-file "Interrupted")
          "** %?\n\t" :clock-in t :clock-resume t)

--- a/init.org
+++ b/init.org
@@ -8635,8 +8635,6 @@ https://qiita.com/takaxp/items/0b717ad1d0488b74429d を参考に設定したや�
 (setq my/org-capture-impediments-file  (concat org-directory "work/scrum/impediments.org"))
 (setq my/org-capture-memo-file         (concat org-directory "memo.org"))
 (setq my/org-capture-sql-file          (concat org-directory "work/sql.org"))
-(setq my/org-capture-shopping-file     (concat my/org-tasks-directory "shopping.org"))
-(setq my/org-capture-2020-summary-file (concat org-directory "private/2020_summary.org"))
 (setq my/org-small-topic-file (concat org-directory "small-topic.org"))
 #+end_src
 
@@ -8652,9 +8650,7 @@ https://qiita.com/takaxp/items/0b717ad1d0488b74429d を参考に設定したや�
 | p   | 資料を放り込むやつ                                            | あとで読むリストになってる。読み終わっても、便利そうなのは DONE のまま置いている    |
 | i   | 割込みタスクの登録                                            | [[https://grugrut.hatenablog.jp/entry/2016/03/13/085417][org-modeで割り込みにも対応した時間記録をとる方法]] のやつを流用している。たまに使う。 |
 | I   | 開発を進める上での障害をリストアップする用                    | 最近使ってない。溜めても振り替えってないので溜める気すらなくなった                  |
-| R   | 2020年の振り返り用                                            | もう2020年は過去の話なので不要でしょ                                                |
 | s   | SQL 用のメモに登録                                            | さくっと書いた SQL を後からまた使えないかな〜と思って溜めてみている                 |
-| S   | 買物リストに登録                                              | Inbox から refile でもいい気がする                                                  |
 | b   | Blogネタにエントリー                                          | 最近使ってない……。ブログ止まってるしな。                                            |
 | P   | Firefox からページの一部を資料として放り込む用                | https://github.com/sprig/org-capture-extension 関係。Win では設定できてない         |
 | L   | Firefox からページURLを資料として放り込む用                   | https://github.com/sprig/org-capture-extension 関係。Win では設定できてない         |
@@ -8687,18 +8683,12 @@ https://qiita.com/takaxp/items/0b717ad1d0488b74429d を参考に設定したや�
         ("I" "障害リストにエントリー" entry
          (file+headline ,my/org-capture-impediments-file "Impediments")
          "** TODO %?\n\t")
-        ("R" "2020ふりかえりにエントリー" entry
-         (file+headline ,my/org-capture-2020-summary-file "Timeline")
-         "** %?\n\t")
         ("z" "一言・雑談ネタ" entry
          (file+headline ,my/org-small-topic-file "Topic")
          "** %?\n\t")
         ("s" "SQL にエントリー" entry
          (file+headline ,my/org-capture-sql-file "SQL")
          "** %?\n\t")
-        ("S" "買い物リストエントリー" entry
-         (file ,my/org-capture-shopping-file)
-         "* TODO %?\n\t")
         ("b" "Blogネタにエントリー" entry
          (file+headline ,my/org-capture-memo-file "Blogネタ")
          "** %?\n\t")

--- a/inits/61-org-capture.el
+++ b/inits/61-org-capture.el
@@ -8,8 +8,6 @@
 (setq my/org-capture-impediments-file  (concat org-directory "work/scrum/impediments.org"))
 (setq my/org-capture-memo-file         (concat org-directory "memo.org"))
 (setq my/org-capture-sql-file          (concat org-directory "work/sql.org"))
-(setq my/org-capture-shopping-file     (concat my/org-tasks-directory "shopping.org"))
-(setq my/org-capture-2020-summary-file (concat org-directory "private/2020_summary.org"))
 (setq my/org-small-topic-file (concat org-directory "small-topic.org"))
 
 (setq org-capture-templates
@@ -38,18 +36,12 @@
         ("I" "障害リストにエントリー" entry
          (file+headline ,my/org-capture-impediments-file "Impediments")
          "** TODO %?\n\t")
-        ("R" "2020ふりかえりにエントリー" entry
-         (file+headline ,my/org-capture-2020-summary-file "Timeline")
-         "** %?\n\t")
         ("z" "一言・雑談ネタ" entry
          (file+headline ,my/org-small-topic-file "Topic")
          "** %?\n\t")
         ("s" "SQL にエントリー" entry
          (file+headline ,my/org-capture-sql-file "SQL")
          "** %?\n\t")
-        ("S" "買い物リストエントリー" entry
-         (file ,my/org-capture-shopping-file)
-         "* TODO %?\n\t")
         ("b" "Blogネタにエントリー" entry
          (file+headline ,my/org-capture-memo-file "Blogネタ")
          "** %?\n\t")

--- a/inits/61-org-capture.el
+++ b/inits/61-org-capture.el
@@ -30,6 +30,31 @@
         ("p" "Pointersにエントリー" entry
          (file+headline ,my/org-capture-pointers-file "Pointers")
          "** %?\n\t")
+        ("l" "鑑賞ログ")
+        ("lr" "読書メモ" entry
+         (id "a0e30a2f-d4ee-426d-9f19-a1bbab2b2563")
+         "** %?
+%t
+*** Reference
+
+*** 感想など
+")
+        ("lb" "ブログ記事メモ" entry
+         (id "e4eed87b-0852-4691-9cd6-4b1596f2b09b")
+         "** %?
+%t
+*** Reference
+
+*** 感想など
+")
+        ("lm" "映画" entry
+         (id "56af8238-c9e8-497c-9695-46849cc8e091")
+         "** %?
+%t
+*** Reference
+
+*** 感想など
+")
         ("i" "割り込みタスクにエントリー" entry ;; 参考: http://grugrut.hatenablog.jp/entry/2016/03/13/085417
          (file+headline ,my/org-capture-interrupted-file "Interrupted")
          "** %?\n\t" :clock-in t :clock-resume t)


### PR DESCRIPTION
# 概要

org-capture-templates を現在の状況に合わせて更新した

# 詳細

- 使ってないテンプレートを削除
  - それに伴い不要な変数も削除
- 新たに、読書メモなどのためのテンプレートを用意

一旦用意したテンプレートを使ってメモを取ったりすることにする