### PR TITLE
feat: Define calibrated-search-mode hydras

### DIFF
--- a/hugo/content/external-tool/calibredb.md
+++ b/hugo/content/external-tool/calibredb.md
@@ -32,9 +32,90 @@ el-get 本体にはレシピがないので自前で用意。
 
 ## 設定 {#設定}
 
-今はとりあえず Calibre のライブラリのパスだけを指定している。
+とりあえず Calibre のライブラリのパスだけを指定している。
 
 ```emacs-lisp
 (custom-set-variables
  '(calibredb-root-dir "~/calibre-library"))
+```
+
+
+## キーバインド {#キーバインド}
+
+デフォルトで transient を用いたキーバインドが定義されているけど自分は Hydra が好きなので pretty-hydra/major-mode-hydra を使って少しだけ Hydra で calibredb のコマンドを叩けるようにしている
+
+```emacs-lisp
+(with-eval-after-load 'pretty-hydra
+  (pretty-hydra-define calibredb-filter-hydra (:separator "-" :exit t :quit-key "q" :title (concat (all-the-icons-material "filter_list") " calibredb filter"))
+    ("by"
+     (("t" calibredb-filter-by-tag           "Tag")
+      ("a" calibredb-filter-by-author-sort   "Author")
+      ("f" calibredb-filter-by-book-format   "Format")
+      ("d" calibredb-filter-by-last_modified "Updated at")
+      ("v" calibredb-virtual-library-list    "Virtual Library")
+      ("l" calibredb-library-list            "Library"))
+
+    "Other"
+    (("R" calibredb-search-clear-filter "Reset"))))
+
+  (pretty-hydra-define calibredb-sort-hydra (:separator "-" :exit t :quit-key "q" :title (concat (all-the-icons-material "book") " calibredb sort"))
+    ("by"
+     (("i" calibredb-sort-by-id       "Id")
+      ("t" calibredb-sort-by-title    "Title")
+      ("f" calibredb-sort-by-format   "Format")
+      ("a" calibredb-sort-by-author   "Author")
+      ("d" calibredb-sort-by-date     "Created at")
+      ("p" calibredb-sort-by-pubdate  "Published at")
+      ("T" calibredb-sort-by-tag      "Tag")
+      ("s" calibredb-sort-by-size     "Size")
+      ("l" calibredb-sort-by-language "Language")
+      ;; 関数を定義したりしたら恐らく以下でも検索可能
+      ;; author_sort, cover, isbn, last_modified, publisher, rating, series, seried_index, template, uuid)
+     )
+
+    "ASC/DESC"
+    (("z" calibredb-toggle-order "Toggle"))))
+
+  (pretty-hydra-define calibredb-metadata-hydra (:separator "-" :exit t :quit-key "q" :title (concat (all-the-icons-material "book") " calibredb metadata"))
+    ("Set"
+     (("t" calibredb-set-metadata--title       "Title")
+      ("g" calibredb-set-metadata--tags        "Tags")
+      ("a" calibredb-set-metadata--author_sort "Author sort")
+      ("A" calibredb-set-metadata--authors     "Authors")
+      ("c" calibredb-set-metadata--comments    "comments"))
+
+     "Fetch"
+     (("A" calibredb-fetch-and-set-metadata-by-author-and-title "Author/Title")
+      ("I" calibredb-fetch-and-set-metadata-by-isbn             "ISBN")
+      ("D" calibredb-fetch-and-set-metadata-by-id               "ID"))
+
+     "Other"
+     (("." calibredb-set-metadata-dispatch "Dispatch"))))
+
+  (major-mode-hydra-define calibredb-search-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-material "book") " calibredb-search"))
+    ("File/Dir"
+     (("a" calibredb-add     "Add")
+      ("A" calibredb-add-dir "Add dir")
+      ("c" calibredb-clone   "Clone")
+      ("r" calibre-remove    "Remove"))
+
+     "Nav"
+     (("RET" calibredb-view "Show")
+      ("o"   calibredb-open-file-with-default-tool "Open")
+      ;; This feature only support macOS
+      ;; ("SPC" calibredb-quick-look "Quick")
+      )
+
+     "Index"
+     (("f" calibredb-filter-hydra/body "Filter")
+      ("s" calibredb-sort-hydra/body "Sort")
+      ("/" calibredb-search-live-filter "Live"))
+
+     "Virtual Library"
+     (("l" calibredb-virtual-library-list     "List")
+      ("N" calibredb-virtual-library-next     "Next")
+      ("P" calibredb-virtual-library-previous "Prev"))
+
+     "Other"
+     (("M" calibredb-metadata-hydra/body "Metadata")))))
 ```

--- a/init.org
+++ b/init.org
@@ -6830,11 +6830,91 @@ el-get 本体にはレシピがないので自前で用意。
 (el-get-bundle calibredb)
 #+end_src
 *** 設定
-今はとりあえず Calibre のライブラリのパスだけを指定している。
+とりあえず Calibre のライブラリのパスだけを指定している。
 
 #+begin_src emacs-lisp :tangle inits/50-calibredb.el
 (custom-set-variables
  '(calibredb-root-dir "~/calibre-library"))
+#+end_src
+*** キーバインド
+デフォルトで transient を用いたキーバインドが定義されているけど
+自分は Hydra が好きなので pretty-hydra/major-mode-hydra を使って
+少しだけ Hydra で calibredb のコマンドを叩けるようにしている
+
+#+begin_src emacs-lisp :tangle inits/50-calibredb.el
+(with-eval-after-load 'pretty-hydra
+  (pretty-hydra-define calibredb-filter-hydra (:separator "-" :exit t :quit-key "q" :title (concat (all-the-icons-material "filter_list") " calibredb filter"))
+    ("by"
+     (("t" calibredb-filter-by-tag           "Tag")
+      ("a" calibredb-filter-by-author-sort   "Author")
+      ("f" calibredb-filter-by-book-format   "Format")
+      ("d" calibredb-filter-by-last_modified "Updated at")
+      ("v" calibredb-virtual-library-list    "Virtual Library")
+      ("l" calibredb-library-list            "Library"))
+
+    "Other"
+    (("R" calibredb-search-clear-filter "Reset"))))
+
+  (pretty-hydra-define calibredb-sort-hydra (:separator "-" :exit t :quit-key "q" :title (concat (all-the-icons-material "book") " calibredb sort"))
+    ("by"
+     (("i" calibredb-sort-by-id       "Id")
+      ("t" calibredb-sort-by-title    "Title")
+      ("f" calibredb-sort-by-format   "Format")
+      ("a" calibredb-sort-by-author   "Author")
+      ("d" calibredb-sort-by-date     "Created at")
+      ("p" calibredb-sort-by-pubdate  "Published at")
+      ("T" calibredb-sort-by-tag      "Tag")
+      ("s" calibredb-sort-by-size     "Size")
+      ("l" calibredb-sort-by-language "Language")
+      ;; 関数を定義したりしたら恐らく以下でも検索可能
+      ;; author_sort, cover, isbn, last_modified, publisher, rating, series, seried_index, template, uuid)
+     )
+
+    "ASC/DESC"
+    (("z" calibredb-toggle-order "Toggle"))))
+
+  (pretty-hydra-define calibredb-metadata-hydra (:separator "-" :exit t :quit-key "q" :title (concat (all-the-icons-material "book") " calibredb metadata"))
+    ("Set"
+     (("t" calibredb-set-metadata--title       "Title")
+      ("g" calibredb-set-metadata--tags        "Tags")
+      ("a" calibredb-set-metadata--author_sort "Author sort")
+      ("A" calibredb-set-metadata--authors     "Authors")
+      ("c" calibredb-set-metadata--comments    "comments"))
+
+     "Fetch"
+     (("A" calibredb-fetch-and-set-metadata-by-author-and-title "Author/Title")
+      ("I" calibredb-fetch-and-set-metadata-by-isbn             "ISBN")
+      ("D" calibredb-fetch-and-set-metadata-by-id               "ID"))
+
+     "Other"
+     (("." calibredb-set-metadata-dispatch "Dispatch"))))
+
+  (major-mode-hydra-define calibredb-search-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-material "book") " calibredb-search"))
+    ("File/Dir"
+     (("a" calibredb-add     "Add")
+      ("A" calibredb-add-dir "Add dir")
+      ("c" calibredb-clone   "Clone")
+      ("r" calibre-remove    "Remove"))
+
+     "Nav"
+     (("RET" calibredb-view "Show")
+      ("o"   calibredb-open-file-with-default-tool "Open")
+      ;; This feature only support macOS
+      ;; ("SPC" calibredb-quick-look "Quick")
+      )
+
+     "Index"
+     (("f" calibredb-filter-hydra/body "Filter")
+      ("s" calibredb-sort-hydra/body "Sort")
+      ("/" calibredb-search-live-filter "Live"))
+
+     "Virtual Library"
+     (("l" calibredb-virtual-library-list     "List")
+      ("N" calibredb-virtual-library-next     "Next")
+      ("P" calibredb-virtual-library-previous "Prev"))
+
+     "Other"
+     (("M" calibredb-metadata-hydra/body "Metadata")))))
 #+end_src
 ** emacs-w3m
 :PROPERTIES:

--- a/inits/50-calibredb.el
+++ b/inits/50-calibredb.el
@@ -2,3 +2,18 @@
 
 (custom-set-variables
  '(calibredb-root-dir "~/calibre-library"))
+
+(with-eval-after-load 'pretty-hydra
+  (pretty-hydra-define calibredb-filter-hydra (:separator "-" :exit t :quit-key "q" :title (concat (all-the-icons-material "filter_list") " calibredb filter"))
+    ("by"
+     (("t" calibredb-filter-by-tag           "Tag")
+      ("a" calibredb-filter-by-author-sort   "Author")
+      ("f" calibredb-filter-by-book-format   "Format")
+      ("d" calibredb-filter-by-last_modified "Updated at")
+      ("v" calibredb-virtual-library-list    "Virtual Library")
+      ("l" calibredb-library-list            "Library"))
+
+    "Other"
+    (("R" calibredb-search-clear-filter "Reset"))))
+
+  )

--- a/inits/50-calibredb.el
+++ b/inits/50-calibredb.el
@@ -16,4 +16,22 @@
     "Other"
     (("R" calibredb-search-clear-filter "Reset"))))
 
+  (pretty-hydra-define calibredb-sort-hydra (:separator "-" :exit t :quit-key "q" :title (concat (all-the-icons-material "book") " calibredb sort"))
+    ("by"
+     (("i" calibredb-sort-by-id       "Id")
+      ("t" calibredb-sort-by-title    "Title")
+      ("f" calibredb-sort-by-format   "Format")
+      ("a" calibredb-sort-by-author   "Author")
+      ("d" calibredb-sort-by-date     "Created at")
+      ("p" calibredb-sort-by-pubdate  "Published at")
+      ("T" calibredb-sort-by-tag      "Tag")
+      ("s" calibredb-sort-by-size     "Size")
+      ("l" calibredb-sort-by-language "Language")
+      ;; 関数を定義したりしたら恐らく以下でも検索可能
+      ;; author_sort, cover, isbn, last_modified, publisher, rating, series, seried_index, template, uuid)
+     )
+
+    "ASC/DESC"
+    (("z" calibredb-toggle-order "Toggle"))))
+
   )

--- a/inits/50-calibredb.el
+++ b/inits/50-calibredb.el
@@ -34,4 +34,20 @@
     "ASC/DESC"
     (("z" calibredb-toggle-order "Toggle"))))
 
+  (pretty-hydra-define calibredb-metadata-hydra (:separator "-" :exit t :quit-key "q" :title (concat (all-the-icons-material "book") " calibredb metadata"))
+    ("Set"
+     (("t" calibredb-set-metadata--title       "Title")
+      ("g" calibredb-set-metadata--tags        "Tags")
+      ("a" calibredb-set-metadata--author_sort "Author sort")
+      ("A" calibredb-set-metadata--authors     "Authors")
+      ("c" calibredb-set-metadata--comments    "comments"))
+
+     "Fetch"
+     (("A" calibredb-fetch-and-set-metadata-by-author-and-title "Author/Title")
+      ("I" calibredb-fetch-and-set-metadata-by-isbn             "ISBN")
+      ("D" calibredb-fetch-and-set-metadata-by-id               "ID"))
+
+     "Other"
+     (("." calibredb-set-metadata-dispatch "Dispatch"))))
+
   )

--- a/inits/50-calibredb.el
+++ b/inits/50-calibredb.el
@@ -50,4 +50,29 @@
      "Other"
      (("." calibredb-set-metadata-dispatch "Dispatch"))))
 
-  )
+  (major-mode-hydra-define calibredb-search-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-material "book") " calibredb-search"))
+    ("File/Dir"
+     (("a" calibredb-add     "Add")
+      ("A" calibredb-add-dir "Add dir")
+      ("c" calibredb-clone   "Clone")
+      ("r" calibre-remove    "Remove"))
+
+     "Nav"
+     (("RET" calibredb-view "Show")
+      ("o"   calibredb-open-file-with-default-tool "Open")
+      ;; This feature only support macOS
+      ;; ("SPC" calibredb-quick-look "Quick")
+      )
+
+     "Index"
+     (("f" calibredb-filter-hydra/body "Filter")
+      ("s" calibredb-sort-hydra/body "Sort")
+      ("/" calibredb-search-live-filter "Live"))
+
+     "Virtual Library"
+     (("l" calibredb-virtual-library-list     "List")
+      ("N" calibredb-virtual-library-next     "Next")
+      ("P" calibredb-virtual-library-previous "Prev"))
+
+     "Other"
+     (("M" calibredb-metadata-hydra/body "Metadata")))))


### PR DESCRIPTION
# 概要

calibredb-search-mode 用に Hydra をいくつか定義した

# 追加した理由

- 自分が Hydra を使うのが好きだから
- 既存のキーバインドには手を入れずに自分好みのキーバインドを用意したかったから