### PR TITLE
feat: Add hydra keybind for org-agenda-{schedule|deadline}

### DIFF
--- a/hugo/content/org-mode/org-mode-keybinds.md
+++ b/hugo/content/org-mode/org-mode-keybinds.md
@@ -72,7 +72,9 @@ major-mode-hydra で、org-mode のファイルを開いている時によく使
      (("a" org-agenda-archive  "Archive")
       ("r" org-agenda-refile   "Refile")
       ("t" org-agenda-todo     "TODO")
-      ("Q" org-agenda-set-tags "Tag"))
+      ("Q" org-agenda-set-tags "Tag")
+      ("s" org-agenda-schedule "Schedule")
+      ("d" org-agenda-deadline "Deadline"))
 
      "Filter"
      (("C" org-agenda-filter-by-category     "Category")

--- a/init.org
+++ b/init.org
@@ -10068,7 +10068,9 @@ major-mode-hydra で、org-mode のファイルを開いている時によく使
      (("a" org-agenda-archive  "Archive")
       ("r" org-agenda-refile   "Refile")
       ("t" org-agenda-todo     "TODO")
-      ("Q" org-agenda-set-tags "Tag"))
+      ("Q" org-agenda-set-tags "Tag")
+      ("s" org-agenda-schedule "Schedule")
+      ("d" org-agenda-deadline "Deadline"))
 
      "Filter"
      (("C" org-agenda-filter-by-category     "Category")

--- a/inits/69-org-mode-hydra.el
+++ b/inits/69-org-mode-hydra.el
@@ -54,7 +54,9 @@
      (("a" org-agenda-archive  "Archive")
       ("r" org-agenda-refile   "Refile")
       ("t" org-agenda-todo     "TODO")
-      ("Q" org-agenda-set-tags "Tag"))
+      ("Q" org-agenda-set-tags "Tag")
+      ("s" org-agenda-schedule "Schedule")
+      ("d" org-agenda-deadline "Deadline"))
 
      "Filter"
      (("C" org-agenda-filter-by-category     "Category")


### PR DESCRIPTION
org-agenda-schedule と org-agenda-deadline を呼び出すための
Hydra のキーバインドを
org-agenda-mode 用の major-mode-hydra で定義した