### PR TITLE
chore: Replace key-chord to original

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((minimap :checksum "8bc9a65825925a7c58b83ad389f07a93f22d60f3")
+      '((key-chord :checksum "dbf91fefdad58b1c2f07c92e658ce81490837c60")
+        (minimap :checksum "8bc9a65825925a7c58b83ad389f07a93f22d60f3")
         (org-protocol-capture-html :checksum "08a2aed1bbeb935ef62b2ebc06037202fd8ddcb1")
         (blamer :checksum "ab7d19c2ee54424d3ffc853982fe875ad47b6e7f")
         (rg :checksum "4885473a6d248a6ee508b7b7ef3705762af631d9")
@@ -137,7 +138,6 @@
         (japanese-holidays :checksum "324b6bf2f55ec050bef49e001caedaabaf4fa35d")
         (js2-mode :checksum "9b90d31ed968e5c51bd3e279d4003248ea896807")
         (jump :checksum "55caa66a7cc6e0b1a76143fd40eff38416928941")
-        (key-chord :checksum "e222bafe89c4ce33c77e5aed4f0f0b37828656e6")
         (lsp-mode :checksum "f2b9ab5e2b64a996ca093206a2adf54c578febc2")
         (lsp-ui :checksum "a59fb5d02eaa97908a06cfc07156de73458c8ae8")
         (major-mode-hydra.el :checksum "d0a5dadee97c3752fcdef113cf2ba1923972a480")

--- a/hugo/content/keybinds/global-keybinds.md
+++ b/hugo/content/keybinds/global-keybinds.md
@@ -15,8 +15,8 @@ Emacs では様々なグローバルマイナーモードが存在したりし�
 ```emacs-lisp
 (if (eq window-system 'ns)
     (progn
-          (setq ns-alternate-modifier (quote super)) ;; option  => super
-          (setq ns-command-modifier (quote meta))))  ;; command => meta
+      (setq ns-alternate-modifier (quote super)) ;; option  => super
+      (setq ns-command-modifier (quote meta))))  ;; command => meta
 ```
 
 
@@ -132,20 +132,6 @@ Mac だとデフォルト状態だと \\ を入れると円マークになるの
 Ladicle さんの <https://ladicle.com/post/config/#multiple-cursor> の設定が便利そうだなって思って気になってるけどまだ試してない。
 
 
-## Helm {#helm}
-
-最近はほぼ Ivy に乗り換えてるのでほとんど出番はないのだけど
-helm-find-file が便利でそこだけ乗り換えできてないのでそれだけ定義がコメントアウトされずに残っている。
-
-```emacs-lisp
-;; (global-set-key (kbd "M-y") 'helm-show-kill-ring)
-(global-set-key (kbd "C-;") 'helm-for-files)
-;; (global-set-key (kbd "M-x") 'helm-M-x)
-;; (global-set-key (kbd "C-x b") 'helm-mini)
-;; (global-set-key (kbd "C-x C-f") 'helm-find-files)
-```
-
-
 ## Ivy {#ivy}
 
 Helm から乗り換えて今はこちらをメインで使っている。基本的には既存のキーバインドの持っていた機能が強化されるようなコマンドを代わりに割り当てている。デフォルトより良い感じで良い。
@@ -165,7 +151,7 @@ Helm から乗り換えて今はこちらをメインで使っている。基本
 | C-x C-f | find-file の置き換え。ido より便利な感じの絞り込み選択ができる。 |
 
 
-## zoom-window {#zoom-window}
+## zoom-window <span class="tag"><span class="unused">unused</span></span> {#zoom-window}
 
 [zoom-window](https://github.com/emacsorphanage/zoom-window) は tmux の zoom 機能のように選択している window だけを表示したり戻したりができるパッケージ。
 
@@ -176,9 +162,9 @@ Helm から乗り換えて今はこちらをメインで使っている。基本
 実は戻すことがあんまりないので、このキーバインドは戻してもいいかもしれないなと思っていたりする。
 
 
-## neotree {#neotree}
+## neotree <span class="tag"><span class="unused">unused</span></span> {#neotree}
 
-[Neotree](https://github.com/jaypei/emacs-neotree) は IDE みたいにファイルツリーを表示を表示するパッケージ。有効にしているとちょっぴりモダンな雰囲気になるぞい。
+Neotree]] は IDE みたいにファイルツリーを表示を表示するパッケージ。有効にしているとちょっぴりモダンな雰囲気になるぞい。
 
 ```emacs-lisp
 (global-set-key [f8] 'neotree-toggle)
@@ -188,7 +174,7 @@ f8 にバインドしているけど
 Helm でも起動できるようにしているので、こっちの設定は外してもいいかもなとか思っている。
 
 
-## org-mode {#org-mode}
+## org-mode <span class="tag"><span class="unused">unused</span></span> {#org-mode}
 
 みんな大好き org-mode 用にもキーバインドを設定している。
 
@@ -204,7 +190,7 @@ Helm でも起動できるようにしているので、こっちの設定は外
 
 ## keychord {#keychord}
 
-keycohrd は2つのキーを同時押しというキーバインドを実現するパッケージ。麦汁は <https://github.com/zk-phi/key-chord/> のバージョンを利用している。
+keycohrd は2つのキーを同時押しというキーバインドを実現するパッケージ。
 
 とりあえず jk を入力するとグローバルに使いたいコマンドを載せた Hydra が起動するようにしている。めっちゃ使ってる。便利。
 

--- a/hugo/content/keybinds/key-chord.md
+++ b/hugo/content/keybinds/key-chord.md
@@ -7,23 +7,12 @@ draft = false
 
 [key-chord](https://github.com/emacsorphanage/key-chord) はキーを同時に押した時にコマンドを発動させるということができるようにしてくれるパッケージ。
 
-なのですが[本家の方だと誤爆が多い](https://qiita.com/zk_phi/items/e70bc4c69b5a4755edd6)ということなのでそれを改善した [zk-phi/key-chord](https://github.com/zk-phi/key-chord/) の方を利用している。
-
-まあほとんど使えてないので改良版の恩恵をまだ受けてないけど……。
-
 
 ## インストール {#インストール}
 
-el-get のレシピは自前で用意している。なおインストールしているのは本家版ではない。
+el-get 本体にレシピが用意あれているのでそれを使っている
 
-```emacs-lisp
-(:name key-chord
-       :description "bind commands to combinations of key-strokes"
-       :type github
-       :pkgname "zk-phi/key-chord")
-```
-
-そして el-get でインストールしている。
+そして `el-get-bundle` でインストールしている。
 
 ```emacs-lisp
 (el-get-bundle key-chord)
@@ -35,14 +24,10 @@ el-get のレシピは自前で用意している。なおインストールし�
 同時押し時の許容時間、その前後で別のキーが押されていたら発動しない判断をする、みたいな設定を入れている。
 
 ```emacs-lisp
-(setq key-chord-two-keys-delay           0.25
-      key-chord-safety-interval-backward 0.1
-      key-chord-safety-interval-forward  0.15)
+(setopt key-chord-two-keys-delay 0.25)
 ```
 
-キーの同時押し判定は 0.15 秒で、それらのキーが押される直前の 0.1 秒以内、または直後の 0.15 秒に押されていたら発動しない、という設定にしている。
-
-改良版の作者の記事だと、直後判定は 0.25 秒で設定されていたが自分は Hydra の起動に使っている上に Hydra で叩けるやつでよく使うやつは覚えているので表示を待たずに次のキーを押すので 0.25 秒も待っていられないという事情があった。
+キーの同時押し判定は 0.25 秒という設定にしている。
 
 
 ## 有効化 {#有効化}

--- a/init.org
+++ b/init.org
@@ -1262,16 +1262,15 @@
     |-----+-----------------------------------------------------------------------|
 
 ** グローバルキーバインド
-   :PROPERTIES:
-   :EXPORT_FILE_NAME: global-keybinds
-   :END:
+:PROPERTIES:
+:EXPORT_FILE_NAME: global-keybinds
+:END:
 *** 概要
-    Emacs では様々なグローバルマイナーモードが存在したりしていて
-    いつでも使えるようなコマンドが多数存在するので
-    ここでまとめて定義している。
+Emacs では様々なグローバルマイナーモードが存在したりしていて
+いつでも使えるようなコマンドが多数存在するので
+ここでまとめて定義している。
 
-    が、Hydra 関係もここに書くと項目が大きくなりすぎるので、それはまた別途定義している。
-
+が、Hydra 関係もここに書くと項目が大きくなりすぎるので、それはまた別途定義している。
 *** Mac での修飾キー変更
 :PROPERTIES:
 :ID:       c7b6e782-af93-4875-ae2a-9dac865793f4
@@ -1283,219 +1282,209 @@
       (setq ns-command-modifier (quote meta))))  ;; command => meta
 #+end_src
 *** C-h を backspace に変更
-    :PROPERTIES:
-    :ID:       e9b47644-3c73-4816-8ed8-608d224c23d7
-    :END:
-    C-h で文字を消せないと不便なのでずっと昔からこの設定は入れている。
+:PROPERTIES:
+:ID:       e9b47644-3c73-4816-8ed8-608d224c23d7
+:END:
+C-h で文字を消せないと不便なのでずっと昔からこの設定は入れている。
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (keyboard-translate ?\C-h ?\C-?)
 (global-set-key "\C-h" nil)
-    #+end_src
+#+end_src
 *** M-g rをstring-replaceに割り当て
-    :PROPERTIES:
-    :ID:       b8267487-fb05-4d11-a1ab-9192b84ee8fe
-    :END:
-    string-replace はよく使うのでそれなりに使いやすいキーにアサインしている
+:PROPERTIES:
+:ID:       b8267487-fb05-4d11-a1ab-9192b84ee8fe
+:END:
+string-replace はよく使うのでそれなりに使いやすいキーにアサインしている
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (global-set-key (kbd "M-g r") 'replace-string)
-    #+end_src
+#+end_src
 
-    replace-regexp もまあまあ使うけどそれはキーを当ててないので
-    どこかでなんとかしたい。
-    Hydra 使う?
+replace-regexp もまあまあ使うけどそれはキーを当ててないので
+どこかでなんとかしたい。
+Hydra 使う?
 *** C-\ で SKK が有効になるようにする
-    :PROPERTIES:
-    :ID:       77bc3c39-ad62-48cd-ac3a-320495ffed11
-    :END:
-    C-\ で skk-mode を起動できるようにしている。
-    C-x C-j の方も設定は生きているが使ってない。っていうか忘れてた。
+:PROPERTIES:
+:ID:       77bc3c39-ad62-48cd-ac3a-320495ffed11
+:END:
+C-\ で skk-mode を起動できるようにしている。
+C-x C-j の方も設定は生きているが使ってない。っていうか忘れてた。
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (global-set-key (kbd "C-\\") 'skk-mode)
-    #+end_src
+#+end_src
 
-    余談だけど org-mode とか commit message 書く時とかは
-    自動で有効になるようにしたい気はする。
+余談だけど org-mode とか commit message 書く時とかは
+自動で有効になるようにしたい気はする。
 *** C-s を swiper に置き換え
-    :PROPERTIES:
-    :ID:       cb8be291-0c4b-41f8-9779-17d91b071b75
-    :END:
-    デフォルトだと C-s でインクリメンタルサーチが起動するが
-    swiper の方が絞り込みができて便利だしカッチョいいのでそっちを使うようにしている
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+:PROPERTIES:
+:ID:       cb8be291-0c4b-41f8-9779-17d91b071b75
+:END:
+デフォルトだと C-s でインクリメンタルサーチが起動するが
+swiper の方が絞り込みができて便利だしカッチョいいのでそっちを使うようにしている
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (global-set-key (kbd "C-s") 'swiper)
-    #+end_src
+#+end_src
 *** window 間の移動
 **** C-x o を ace-window に置き換え
-     :PROPERTIES:
-     :ID:       6e4557f8-4c27-4014-b1d6-7cc16fc855ac
-     :END:
-     C-x o はデフォルトだと順番に window を移動するコマンドだが
-     ace-window を使えばたくさん画面分割している時の移動が楽だし
-     2分割の時は元の挙動と同様に2つの window を行き来する感じになので
-     完全に置き換えても大丈夫と判断して、置き換えている。
+:PROPERTIES:
+:ID:       6e4557f8-4c27-4014-b1d6-7cc16fc855ac
+:END:
+C-x o はデフォルトだと順番に window を移動するコマンドだが
+ace-window を使えばたくさん画面分割している時の移動が楽だし
+2分割の時は元の挙動と同様に2つの window を行き来する感じになので
+完全に置き換えても大丈夫と判断して、置き換えている。
 
-     #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (global-set-key (kbd "C-x o") 'ace-window)
-     #+end_src
+#+end_src
 
-     ace-window は他にもコマンドがあって
-     Hydra の方で ace-swap-window は使えるようにしている
+ace-window は他にもコマンドがあって
+Hydra の方で ace-swap-window は使えるようにしている
 **** Shift+カーソルキーで window 移動
-     :PROPERTIES:
-     :ID:       3b921278-f3c1-441f-9aee-bba382d6a4b6
-     :END:
-     シフトキーを押しながらカーソルキーを押すことでも
-     window を移動できるようにしている
+:PROPERTIES:
+:ID:       3b921278-f3c1-441f-9aee-bba382d6a4b6
+:END:
+シフトキーを押しながらカーソルキーを押すことでも
+window を移動できるようにしている
 
-     #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (windmove-default-keybindings)
-     #+end_src
+#+end_src
 
-     ただし org-mode のキーバインドとぶつかるので実はあまり使ってないし
-     そろそろ無効にしてもいいんじゃないかなという気もしている
-
+ただし org-mode のキーバインドとぶつかるので実はあまり使ってないし
+そろそろ無効にしてもいいんじゃないかなという気もしている
 *** undo/redo
-    :PROPERTIES:
-    :ID:       6238d423-1a21-4351-9121-ecca45e1e71c
-    :END:
-    undo  と redo には undo-fu を使っている
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+:PROPERTIES:
+:ID:       6238d423-1a21-4351-9121-ecca45e1e71c
+:END:
+undo  と redo には undo-fu を使っている
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (global-set-key (kbd "C-/") 'undo-fu-only-undo)
 (global-set-key (kbd "C-M-/") 'undo-fu-only-redo)
-    #+end_src
-
+#+end_src
 *** \ を入力した時に円マークにならないようにする設定
-    :PROPERTIES:
-    :ID:       9eebf56d-4cbe-461c-9366-0df004199b95
-    :END:
-    Mac だとデフォルト状態だと \ を入れると円マークになるのだが
-    プログラムを書く上ではバックスラッシュであってほしいので
-    円マークが入力された時はバックスラッシュが入力されたように扱われるようにしている。
+:PROPERTIES:
+:ID:       9eebf56d-4cbe-461c-9366-0df004199b95
+:END:
+Mac だとデフォルト状態だと \ を入れると円マークになるのだが
+プログラムを書く上ではバックスラッシュであってほしいので
+円マークが入力された時はバックスラッシュが入力されたように扱われるようにしている。
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (define-key global-map [?¥] [?\\])
 (define-key global-map [?\C-¥] [?\C-\\])
 (define-key global-map [?\M-¥] [?\M-\\])
 (define-key global-map [?\C-\M-¥] [?\C-\M-\\])
-    #+end_src
+#+end_src
 
-    ただ、たまに円マークを出したくなる時があるので
-    その時はどうすべきかという課題がある。
-
+ただ、たまに円マークを出したくなる時があるので
+その時はどうすべきかという課題がある。
 *** multiple-cursors
-    :PROPERTIES:
-    :ID:       fbe31c14-b4cc-42f1-9754-6fbe93ab73c0
-    :END:
-    カーソルを複数表示できる [[https://github.com/magnars/multiple-cursors.el][multiple-cursors]] 用のキーバインド。
-    基本的には公式 README に従って設定している。
+:PROPERTIES:
+:ID:       fbe31c14-b4cc-42f1-9754-6fbe93ab73c0
+:END:
+カーソルを複数表示できる [[https://github.com/magnars/multiple-cursors.el][multiple-cursors]] 用のキーバインド。
+基本的には公式 README に従って設定している。
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 ;; multiple-cursors
 (global-set-key (kbd "C-:") 'mc/edit-lines)
 (global-set-key (kbd "C->") 'mc/mark-next-like-this)
 (global-set-key (kbd "C-<") 'mc/mark-previous-like-this)
 (global-set-key (kbd "C-c C-<") 'mc/mark-all-like-this)
-    #+end_src
+#+end_src
 
-    Ladicle さんの https://ladicle.com/post/config/#multiple-cursor の設定が便利そうだなって思って気になってるけどまだ試してない。
-
+Ladicle さんの https://ladicle.com/post/config/#multiple-cursor の設定が便利そうだなって思って気になってるけどまだ試してない。
 *** Ivy
-    :PROPERTIES:
-    :ID:       56e06084-5464-4aa9-be75-279787f9e0d0
-    :END:
-    Helm から乗り換えて今はこちらをメインで使っている。
-    基本的には既存のキーバインドの持っていた機能が強化されるようなコマンドを代わりに割り当てている。
-    デフォルトより良い感じで良い。
+:PROPERTIES:
+:ID:       56e06084-5464-4aa9-be75-279787f9e0d0
+:END:
+Helm から乗り換えて今はこちらをメインで使っている。
+基本的には既存のキーバインドの持っていた機能が強化されるようなコマンドを代わりに割り当てている。
+デフォルトより良い感じで良い。
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (global-set-key (kbd "M-x") 'counsel-M-x)
 (global-set-key (kbd "M-y") 'counsel-yank-pop)
 (global-set-key (kbd "C-x b") 'counsel-switch-buffer)
 (global-set-key (kbd "C-x C-f") 'counsel-find-file)
-    #+end_src
+#+end_src
 
-    | Key     | 効果                                                                                                    |
-    | M-x     | コマンド実行。絞り込みができるのでコマンド名がうろ覚えでも実行できて便利                                |
-    | M-y     | kill-ring の候補表示。適当に複数 kill-ring に入れておいてこれを起動して絞り込んで貼り付けとかできて便利 |
-    | C-x b   | バッファ切替。これも適当にバッファを絞り込めて便利                                                      |
-    | C-x C-f | find-file の置き換え。ido より便利な感じの絞り込み選択ができる。                                        |
-
+| Key     | 効果                                                                                                    |
+| M-x     | コマンド実行。絞り込みができるのでコマンド名がうろ覚えでも実行できて便利                                |
+| M-y     | kill-ring の候補表示。適当に複数 kill-ring に入れておいてこれを起動して絞り込んで貼り付けとかできて便利 |
+| C-x b   | バッファ切替。これも適当にバッファを絞り込めて便利                                                      |
+| C-x C-f | find-file の置き換え。ido より便利な感じの絞り込み選択ができる。                                        |
 *** zoom-window                                                      :unused:
-    :PROPERTIES:
-    :ID:       8e81ab68-cdca-4376-8fa4-e5bb08fd8dd7
-    :END:
-    [[https://github.com/emacsorphanage/zoom-window][zoom-window]] は tmux の zoom 機能のように
-    選択している window だけを表示したり戻したりができるパッケージ。
+:PROPERTIES:
+:ID:       8e81ab68-cdca-4376-8fa4-e5bb08fd8dd7
+:END:
+[[https://github.com/emacsorphanage/zoom-window][zoom-window]] は tmux の zoom 機能のように
+選択している window だけを表示したり戻したりができるパッケージ。
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (global-set-key (kbd "C-x 1") 'zoom-window-zoom)
-    #+end_src
+#+end_src
 
-    実は戻すことがあんまりないので、
-    このキーバインドは戻してもいいかもしれないなと思っていたりする。
-
+実は戻すことがあんまりないので、
+このキーバインドは戻してもいいかもしれないなと思っていたりする。
 *** neotree                                                          :unused:
-    :PROPERTIES:
-    :ID:       6e2189a7-8dad-4d50-b609-d6a1c29c2d10
-    :END:
-    [[https://github.com/jaypei/emacs-neotree][Neotree]] は IDE みたいにファイルツリーを表示を表示するパッケージ。
-    有効にしているとちょっぴりモダンな雰囲気になるぞい。
+:PROPERTIES:
+:ID:       6e2189a7-8dad-4d50-b609-d6a1c29c2d10
+:END:
+Neotree]] は IDE みたいにファイルツリーを表示を表示するパッケージ。
+有効にしているとちょっぴりモダンな雰囲気になるぞい。
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (global-set-key [f8] 'neotree-toggle)
-    #+end_src
+#+end_src
 
-    f8 にバインドしているけど
-    Helm でも起動できるようにしているので、こっちの設定は外してもいいかもなとか思っている。
-
+f8 にバインドしているけど
+Helm でも起動できるようにしているので、こっちの設定は外してもいいかもなとか思っている。
 *** org-mode                                                         :unused:
-    :PROPERTIES:
-    :ID:       b01cfab2-09ed-48c0-80c6-303e8bca0458
-    :END:
-    みんな大好き org-mode 用にもキーバインドを設定している。
+:PROPERTIES:
+:ID:       b01cfab2-09ed-48c0-80c6-303e8bca0458
+:END:
+みんな大好き org-mode 用にもキーバインドを設定している。
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (setq my/org-mode-prefix-key "C-c o ")
 (global-set-key (kbd (concat my/org-mode-prefix-key "a")) 'org-agenda)
 (global-set-key (kbd (concat my/org-mode-prefix-key "c")) 'org-capture)
 (global-set-key (kbd (concat my/org-mode-prefix-key "l")) 'org-store-link)
-    #+end_src
+#+end_src
 
-    けど org-mode 用の Hydra も用意しているので
-    これもそろそろ削除かな……
-
+けど org-mode 用の Hydra も用意しているので
+これもそろそろ削除かな……
 *** keychord
-    :PROPERTIES:
-    :ID:       1ec019db-13a3-46bc-a029-0cd6002ed209
-    :END:
-    keycohrd は2つのキーを同時押しというキーバインドを実現するパッケージ。
-    麦汁は https://github.com/zk-phi/key-chord/ のバージョンを利用している。
+:PROPERTIES:
+:ID:       1ec019db-13a3-46bc-a029-0cd6002ed209
+:END:
+keycohrd は2つのキーを同時押しというキーバインドを実現するパッケージ。
 
-    とりあえず jk を入力すると
-    グローバルに使いたいコマンドを載せた Hydra が起動するようにしている。
-    めっちゃ使ってる。便利。
+とりあえず jk を入力すると
+グローバルに使いたいコマンドを載せた Hydra が起動するようにしている。
+めっちゃ使ってる。便利。
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 (key-chord-define-global "jk" 'pretty-hydra-usefull-commands/body)
-    #+end_src
-
+#+end_src
 *** yes or no ではなく y or n で質問する
-    :PROPERTIES:
-    :ID:       32fa9132-5975-42d5-b36f-5429e384081b
-    :END:
-    何か質問された時に yes とか入力するのがだるいので
-    y だけで済ませられるようにしている。
+:PROPERTIES:
+:ID:       32fa9132-5975-42d5-b36f-5429e384081b
+:END:
+何か質問された時に yes とか入力するのがだるいので
+y だけで済ませられるようにしている。
 
-    #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
+#+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
 ;; Don't ask yes or no.
 (defalias 'yes-or-no-p 'y-or-n-p)
-    #+end_src
+#+end_src
 
-    一応 Emacs 的には重要なのは yes/no で回答するようになっていたはずなので
-    より安全に使いたい人はこの設定は入れない方が良いはず。
+一応 Emacs 的には重要なのは yes/no で回答するようになっていたはずなので
+より安全に使いたい人はこの設定は入れない方が良いはず。
 
 * ファイル編集/入力補助
   :PROPERTIES:

--- a/init.org
+++ b/init.org
@@ -973,115 +973,86 @@
    - [[*グローバルキーバインド][グローバルキーバインド]] :: いつでもどこでも使えるキーバインド周りの設定をここにまとめている
 
 ** key-chord
-   :PROPERTIES:
-   :EXPORT_FILE_NAME: key-chord
-   :END:
-
+:PROPERTIES:
+:EXPORT_FILE_NAME: key-chord
+:END:
 *** 概要
-
-    [[https://github.com/emacsorphanage/key-chord][key-chord]] はキーを同時に押した時にコマンドを発動させるということができるようにしてくれるパッケージ。
-
-    なのですが[[https://qiita.com/zk_phi/items/e70bc4c69b5a4755edd6][本家の方だと誤爆が多い]]ということなので
-    それを改善した [[https://github.com/zk-phi/key-chord/][zk-phi/key-chord]] の方を利用している。
-
-    まあほとんど使えてないので改良版の恩恵をまだ受けてないけど……。
+[[https://github.com/emacsorphanage/key-chord][key-chord]] はキーを同時に押した時にコマンドを発動させるということができるようにしてくれるパッケージ。
 
 *** インストール
-    :PROPERTIES:
-    :ID:       5b08b398-607f-4a9a-b5ab-772220abc8b6
-    :END:
+:PROPERTIES:
+:ID:       5b08b398-607f-4a9a-b5ab-772220abc8b6
+:END:
 
-    el-get のレシピは自前で用意している。
-    なおインストールしているのは本家版ではない。
+el-get 本体にレシピが用意あれているのでそれを使っている
 
-    #+begin_src emacs-lisp :tangle recipes/key-chord.rcp
-(:name key-chord
-       :description "bind commands to combinations of key-strokes"
-       :type github
-       :pkgname "zk-phi/key-chord")
-    #+end_src
+そして ~el-get-bundle~ でインストールしている。
 
-    そして el-get でインストールしている。
-
-    #+begin_src emacs-lisp :tangle inits/70-key-chord.el
+#+begin_src emacs-lisp :tangle inits/70-key-chord.el
 (el-get-bundle key-chord)
-    #+end_src
-
+#+end_src
 *** 設定
-    :PROPERTIES:
-    :ID:       74eb2ce4-03c8-444e-828f-882319d8fdc3
-    :END:
+:PROPERTIES:
+:ID:       74eb2ce4-03c8-444e-828f-882319d8fdc3
+:END:
 
-    同時押し時の許容時間、その前後で別のキーが押されていたら発動しない判断をする、みたいな設定を入れている。
+同時押し時の許容時間、その前後で別のキーが押されていたら発動しない判断をする、みたいな設定を入れている。
 
-    #+begin_src emacs-lisp :tangle inits/70-key-chord.el
-(setq key-chord-two-keys-delay           0.25
-      key-chord-safety-interval-backward 0.1
-      key-chord-safety-interval-forward  0.15)
-    #+end_src
+#+begin_src emacs-lisp :tangle inits/70-key-chord.el
+(setopt key-chord-two-keys-delay 0.25)
+#+end_src
 
-    キーの同時押し判定は 0.15 秒で、
-    それらのキーが押される直前の 0.1 秒以内、または直後の 0.15 秒に押されていたら発動しない、
-    という設定にしている。
-
-    改良版の作者の記事だと、直後判定は 0.25 秒で設定されていたが
-    自分は Hydra の起動に使っている上に Hydra で叩けるやつでよく使うやつは覚えているので
-    表示を待たずに次のキーを押すので 0.25 秒も待っていられないという事情があった。
-
+キーの同時押し判定は 0.25 秒という設定にしている。
 *** 有効化
-    :PROPERTIES:
-    :ID:       31beae4a-3927-457d-8fd7-fe026aa1195a
-    :END:
+:PROPERTIES:
+:ID:       31beae4a-3927-457d-8fd7-fe026aa1195a
+:END:
 
-    設定を入れた後は有効にするだけである。
+設定を入れた後は有効にするだけである。
 
-    #+begin_src emacs-lisp :tangle inits/70-key-chord.el
+#+begin_src emacs-lisp :tangle inits/70-key-chord.el
 (key-chord-mode 1)
-    #+end_src
+#+end_src
 
-    実際のキーバインド設定は各モードだったり
-    グローバルキーバインドを設定しているファイルだったりで書く感じ。
+実際のキーバインド設定は各モードだったり
+グローバルキーバインドを設定しているファイルだったりで書く感じ。
 
-    といいつつ現状では Hydra 起動のやつしか使ってないので、
-    グローバルキーバインド設定でしか書いてない。
-
+といいつつ現状では Hydra 起動のやつしか使ってないので、
+グローバルキーバインド設定でしか書いてない。
 *** sticky-shift
 **** セミコロン2つでシフトを押した状態にする
-     :PROPERTIES:
-     :ID:       e36764d8-6903-4629-86a5-46dd621795a8
-     :END:
-     セミコロンを2回叩くことで shift が押されてるという状態を実現する。
+:PROPERTIES:
+:ID:       e36764d8-6903-4629-86a5-46dd621795a8
+:END:
+セミコロンを2回叩くことで shift が押されてるという状態を実現する。
 
-     これにより magit で P などを入力したい時にも ~;;p~ で入力できるし
-     通常の英字入力時にも大文字にできるので
-     左手小指が痛い時には Shift を使わずに操作ができるようになる。
+これにより magit で P などを入力したい時にも ~;;p~ で入力できるし
+通常の英字入力時にも大文字にできるので
+左手小指が痛い時には Shift を使わずに操作ができるようになる。
 
-     #+begin_src emacs-lisp :tangle inits/70-key-chord.el
+#+begin_src emacs-lisp :tangle inits/70-key-chord.el
 (key-chord-define-global ";;"
                          'event-apply-shift-modifier)
 
 (key-chord-define key-translation-map
                   ";;"
                   'event-apply-shift-modifier)
-     #+end_src
+#+end_src
 
-     ~global-key-map~ と ~key-translation-map~ の両方に定義しないと動かないが
-     その原因はよく分かってない。一旦動くから良しとしている。
+~global-key-map~ と ~key-translation-map~ の両方に定義しないと動かないが
+その原因はよく分かってない。一旦動くから良しとしている。
 
-     ここで使っている ~event-apply-shift-modifier~ はデフォルトでは ~C-x @ S~ にバインドされているやつ。
-     お仲間に ~event-apply-control-modifier~ などの各 modifier キーがいるので
-     sticky 的なことをやる上で便利な子達。
-     [[*sticky-control][sticky-control]] の中でも ~event-apply-control-modifier~ が使われているぞい。
-
+ここで使っている ~event-apply-shift-modifier~ はデフォルトでは ~C-x @ S~ にバインドされているやつ。
+お仲間に ~event-apply-control-modifier~ などの各 modifier キーがいるので
+sticky 的なことをやる上で便利な子達。
+[[*sticky-control][sticky-control]] の中でも ~event-apply-control-modifier~ が使われているぞい。
 **** やりたかったけど実現できてないこと
 ***** セミコロン*2+数字キー、セミコロン*2+記号キーの対応
-      [[https://www.emacswiki.org/emacs/sticky.el][sticky.el]] では実現されてそうなことなので、
-      同じことをできるようにしたい
+[[https://www.emacswiki.org/emacs/sticky.el][sticky.el]] では実現されてそうなことなので、
+同じことをできるようにしたい
 *** その他
-
-    [[*sticky-control][sticky-control]] も control 限定で似たようなことをしているので
-    key-chord に全部置き換えできるかもしれない。
-
+[[*sticky-control][sticky-control]] も control 限定で似たようなことをしているので
+key-chord に全部置き換えできるかもしれない。
 ** sticky-control
    :PROPERTIES:
    :EXPORT_FILE_NAME: sticky-control

--- a/inits/70-key-chord.el
+++ b/inits/70-key-chord.el
@@ -1,8 +1,6 @@
 (el-get-bundle key-chord)
 
-(setq key-chord-two-keys-delay           0.25
-      key-chord-safety-interval-backward 0.1
-      key-chord-safety-interval-forward  0.15)
+(setopt key-chord-two-keys-delay 0.25)
 
 (key-chord-mode 1)
 

--- a/recipes/key-chord.rcp
+++ b/recipes/key-chord.rcp
@@ -1,4 +1,0 @@
-(:name key-chord
-       :description "bind commands to combinations of key-strokes"
-       :type github
-       :pkgname "zk-phi/key-chord")


### PR DESCRIPTION
# 概要

誤爆も起きているので key-chord をオリジナル版に切り替えた。