### PR TITLE
feat: Use GPG key on plstore-encrypt-to for org-gcal

### DIFF
--- a/hugo/content/org-mode/org-gcal.md
+++ b/hugo/content/org-mode/org-gcal.md
@@ -68,10 +68,11 @@ org-gcal が依存しているので [parsist](https://elpa.gnu.org/packages/per
 (require 'org-gcal)
 ```
 
-あとは passphrase を保存できるようにした方が良いみたいなのが確か README に比較的最近追加されたのでそれを入れている
+OAuth token の保存には GPG で暗号化するようにするため
+plstore-encrypt-to にその鍵 ID を設定している。こうするとパスフレーズを何度も入力する必要がないので便利。鍵 ID 自体もリポジトリには登録したくなかったので authinfo から取り出すようにしている。
 
 ```emacs-lisp
-(setq plstore-cache-passphrase-for-symmetric-encryption t)
+(add-to-list 'plstore-encrypt-to (funcall (plist-get (nth 0 (auth-source-search :host "org-gcal-plstore" :max 1)) :secret)))
 ```
 
 あとは設定ファイルは公開したくないので別ファイルに分けてる。

--- a/init.org
+++ b/init.org
@@ -9234,7 +9234,6 @@ HTML 4.01 Strict 信者だったこともあって抑制している。
 :EXPORT_FILE_NAME: org-gcal
 :EXPORT_HUGO_CUSTOM_FRONT_MATTER: :weight 8
 :END:
-
 *** 概要
 [[https://github.com/kidd/org-gcal.el][org-gcal]] は org-mode と Google Calendar を連携させるためのパッケージ。
 
@@ -9286,7 +9285,6 @@ org-gcal が依存しているので [[https://elpa.gnu.org/packages/persist.htm
 :PROPERTIES:
 :ID:       247a2cfe-1bee-4293-82fb-b9e68130f258
 :END:
-
 まずは org-gcal の設定が authinfo から読み込まれるようにする
 
 #+begin_src emacs-lisp :tangle inits/61-org-gcal.el
@@ -9301,10 +9299,13 @@ org-gcal が依存しているので [[https://elpa.gnu.org/packages/persist.htm
 (require 'org-gcal)
 #+end_src
 
-あとは passphrase を保存できるようにした方が良いみたいなのが確か README に比較的最近追加されたのでそれを入れている
+OAuth token の保存には GPG で暗号化するようにするため
+plstore-encrypt-to にその鍵 ID を設定している。
+こうするとパスフレーズを何度も入力する必要がないので便利。
+鍵 ID 自体もリポジトリには登録したくなかったので authinfo から取り出すようにしている。
 
 #+begin_src emacs-lisp :tangle inits/61-org-gcal.el
-(setq plstore-cache-passphrase-for-symmetric-encryption t)
+(add-to-list 'plstore-encrypt-to (funcall (plist-get (nth 0 (auth-source-search :host "org-gcal-plstore" :max 1)) :secret)))
 #+end_src
 
 あとは設定ファイルは公開したくないので別ファイルに分けてる。

--- a/inits/61-org-gcal.el
+++ b/inits/61-org-gcal.el
@@ -8,7 +8,7 @@
 
 (require 'org-gcal)
 
-(setq plstore-cache-passphrase-for-symmetric-encryption t)
+(add-to-list 'plstore-encrypt-to (funcall (plist-get (nth 0 (auth-source-search :host "org-gcal-plstore" :max 1)) :secret)))
 
 (my/load-config "my-org-gcal-config")
 


### PR DESCRIPTION
org-gcal では OAuth token を保存する際に plstore で暗号化してくれる。
しかしパスフレーズで暗号化した場合には新しく fetch する際にまたパスフレーズを入力させられるなど
何度もパスフレーズを入力させられて非常にだるい。

というわけで今回の変更で GPG の鍵を使うように変更した。
これも公式に記述のある方法である。
https://github.com/emacsmirror/org-gcal?tab=readme-ov-file#setting-example

これを設定することでパスフレーズを何度も入力させられることがなくなるっぽい。
まだ OS の再起動は試していないが
Emacs の再起動後は確かに入力を求められる回数が減ってるので良さそう