### PR TITLE
feat: Implement my projectile commands

### DIFF
--- a/hugo/content/nav/projectile.md
+++ b/hugo/content/nav/projectile.md
@@ -77,16 +77,20 @@ counsel-projectile はいくつかの絞り込み処理を提供してくれて�
 (with-eval-after-load 'pretty-hydra
   (pretty-hydra-define
     projectile-hydra (:separator "-" :title "Projectile" :foreign-key warn :quit-key "q" :exit t)
-    ("File"
+    ("Find"
      (("f" counsel-projectile-find-file "Find File")
       ("d" counsel-projectile-find-dir "Find Dir")
       ("r" projectile-recentf "Recentf"))
+
+     "Jump"
+     (("l" projectile-edit-dir-locals "dir-locals"))
 
      "Edit"
      (("R" projectile-replace "Replace"))
 
      "Other"
-     (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")))))
+     (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")
+      ("SPC" my/project-hydra "Hydra")))))
 ```
 
 | Key | 効果                    |
@@ -94,16 +98,118 @@ counsel-projectile はいくつかの絞り込み処理を提供してくれて�
 | f   | プロジェクト内のファイルを検索 |
 | d   | プロジェクト内のフォルダを検索 |
 | r   | プロジェクト内で最近触ったファイルのリスト表示 |
+| l   | .dir-locals.el を開く   |
+| E   | 一括置換する            |
 | p   | 別のプロジェクトに切り替え |
+| SPC | プロジェクト固有の Hydra を起動する |
 
 -   `projectile-find-implementation-or-test`
--   `projectile-replace`
 -   `projectile-replace-regexp`
 
 あたりも使えるようにするともしかしたら便利かもしれない。あとは `counsel-projectile-grep` とかの類かな〜
 
 
-## その他 {#その他}
+## projectile 用のコマンド/ヘルパー関数 {#projectile-用のコマンド-ヘルパー関数}
 
-基本的に Rails のプロジェクトをやっているので
-projectile-rails をベースにいつも触ってるので projectile そのものはあまり弄ってないのであった
+
+### プロジェクト固有の Hydra 呼び出し {#プロジェクト固有の-hydra-呼び出し}
+
+プロジェクト固有の Hydra を `{project-dir-name}-hydra` のように定義しておけばプロジェクトのディレクトリ名を用いてそれ用の Hydra を呼び出す関数。
+
+プロジェクト固有の Hydra は .dir-locals で定義することを念頭に置いているが、
+Emacs の設定ファイルに直接埋め込んでいても特に問題はないはず。
+
+```emacs-lisp
+(defun my/project-hydra ()
+  "Call the project specific hydra."
+  (interactive)
+  (let* ((project-path (directory-file-name (projectile-acquire-root)))
+         (project-dir-name (file-name-base project-path))
+         (hydra-body (intern (concat project-dir-name "-hydra/body"))))
+    (cond
+     ((fboundp hydra-body)
+      (funcall hydra-body))
+     (t
+      (user-error "project hydra is not defined on %s." project-dir-name)))))
+```
+
+
+### プロジェクト内のファイルを開く {#プロジェクト内のファイルを開く}
+
+プロジェクト内に1つしかないようなファイルは completing-read で絞り込む必要がないのでぱぱっと開けるようにするためのコマンドを用意した。
+
+```emacs-lisp
+(defun my/projectile-goto-file (file-path)
+  "Go to the file path"
+  (let ((path (concat (projectile-acquire-root) file-path)))
+    (cond
+     ((file-exists-p path)
+      (find-file path))
+     (t
+      (user-error "%s is not found." file-path)))))
+```
+
+
+### プロジェクト内の指定フォルダのファイルを検索 {#プロジェクト内の指定フォルダのファイルを検索}
+
+実装ファイルなどは特定のフォルダ以下に複数存在するのが一般形なので指定したフォルダ以下のファイルを completing-read で絞り込めるようにしている。
+
+```emacs-lisp
+(defun my/projectile-find-file-in-dir (dir-path)
+  "Find the file path"
+  (interactive)
+  (let ((path (concat (projectile-acquire-root) dir-path)))
+    (cond
+     ((and (file-exists-p path) (file-directory-p path))
+      (projectile-find-file-in-directory path))
+     (t
+      (user-error "%s is not directory." dir-path)))))
+```
+
+
+### Dockerfile を開く {#dockerfile-を開く}
+
+今時は Docker がよく使われているので Dockerfile を開くコマンドを用意した。
+
+```emacs-lisp
+(defun my/projectile-goto-dockerfile ()
+  "Find the Dockerfile"
+  (interactive)
+  (my/projectile-goto-file "Dockerfile"))
+```
+
+
+### .circleci/config.yml を開く {#dot-circleci-config-dot-yml-を開く}
+
+`.circleci/config.yml` も時々開くよねってことで追加した
+
+```emacs-lisp
+(defun my/projectile-goto-circleci-config ()
+  "Find the CircleCI config.yml"
+  (interactive)
+  (my/projectile-goto-file ".circleci/config.yml"))
+```
+
+
+### Gemfile を開く {#gemfile-を開く}
+
+Ruby 書いているとお馴染の Gemfile もぱぱっと開きたいので追加
+
+```emacs-lisp
+(defun my/projectile-goto-gemfile ()
+  "Find the Gemfile"
+  (interactive)
+  (my/projectile-goto-file "Gemfile"))
+```
+
+
+### .rubocop.yml を開く {#dot-rubocop-dot-yml-を開く}
+
+Ruby 書いていたら大体 rubocop も使うので追加
+
+```emacs-lisp
+(defun my/projectile-goto-rubocop-config ()
+  "Find the .rubocop.yml"
+  (interactive)
+  (my/projectile-goto-file ".rubocop.yml"))
+```

--- a/hugo/content/ui/hydra.md
+++ b/hugo/content/ui/hydra.md
@@ -297,6 +297,7 @@ el-get の Hydra はここで定義してしまっている。その内 el-get �
 
    "Tool"
    (("SPC" major-mode-hydra         "Hydra(Major)")
+    ("h"   my/project-hydra         "Hydra(Project)")
     ("s"   toggle-hydra/body        "Toggle switches")
     ("c"   counsel-org-capture      "Capture")
     ("o"   global-org-hydra/body    "Org")
@@ -328,6 +329,7 @@ el-get の Hydra はここで定義してしまっている。その内 el-get �
 | +   | [文字サイズ変更用 Hydra](#text-scale) の起動                               |
 | w   | Window の入替                                                              |
 | SPC | [major-mode-hydra](https://github.com/jerrypnz/major-mode-hydra.el) の起動 |
+| h   | プロジェクト固有の Hydra があればそれを起動する                            |
 | s   | [ON/OFF 切替系の Hydra](#toggle-switches) を起動する                       |
 | c   | counsel-org-capture を呼び出す                                             |
 | o   | org-mode 用の Hydra を起動する                                             |

--- a/init.org
+++ b/init.org
@@ -4786,35 +4786,121 @@ counsel-projectile はいくつかの絞り込み処理を提供してくれて�
 (with-eval-after-load 'pretty-hydra
   (pretty-hydra-define
     projectile-hydra (:separator "-" :title "Projectile" :foreign-key warn :quit-key "q" :exit t)
-    ("File"
+    ("Find"
      (("f" counsel-projectile-find-file "Find File")
       ("d" counsel-projectile-find-dir "Find Dir")
       ("r" projectile-recentf "Recentf"))
+
+     "Jump"
+     (("l" projectile-edit-dir-locals "dir-locals"))
 
      "Edit"
      (("R" projectile-replace "Replace"))
 
      "Other"
-     (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")))))
+     (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")
+      ("SPC" my/project-hydra "Hydra")))))
 #+end_src
 
 | Key | 効果                                           |
 | f   | プロジェクト内のファイルを検索                 |
 | d   | プロジェクト内のフォルダを検索                 |
 | r   | プロジェクト内で最近触ったファイルのリスト表示 |
+| l   | .dir-locals.el を開く                          |
+| E   | 一括置換する                                   |
 | p   | 別のプロジェクトに切り替え                     |
+| SPC | プロジェクト固有の Hydra を起動する            |
 
 - ~projectile-find-implementation-or-test~
-- ~projectile-replace~
 - ~projectile-replace-regexp~
 
 あたりも使えるようにするともしかしたら便利かもしれない。
 あとは ~counsel-projectile-grep~ とかの類かな〜
+*** projectile 用のコマンド/ヘルパー関数
+**** プロジェクト固有の Hydra 呼び出し
+プロジェクト固有の Hydra を ~{project-dir-name}-hydra~ のように定義しておけば
+プロジェクトのディレクトリ名を用いてそれ用の Hydra を呼び出す関数。
 
-*** その他
-基本的に Rails のプロジェクトをやっているので
-projectile-rails をベースにいつも触ってるので projectile そのものはあまり弄ってないのであった
+プロジェクト固有の Hydra は .dir-locals で定義することを念頭に置いているが、
+Emacs の設定ファイルに直接埋め込んでいても特に問題はないはず。
+#+begin_src emacs-lisp :tangle inits/30-projectile.el
+(defun my/project-hydra ()
+  "Call the project specific hydra."
+  (interactive)
+  (let* ((project-path (directory-file-name (projectile-acquire-root)))
+         (project-dir-name (file-name-base project-path))
+         (hydra-body (intern (concat project-dir-name "-hydra/body"))))
+    (cond
+     ((fboundp hydra-body)
+      (funcall hydra-body))
+     (t
+      (user-error "project hydra is not defined on %s." project-dir-name)))))
+#+end_src
+**** プロジェクト内のファイルを開く
+プロジェクト内に1つしかないようなファイルは completing-read で絞り込む必要がないので
+ぱぱっと開けるようにするためのコマンドを用意した。
 
+#+begin_src emacs-lisp :tangle inits/30-projectile.el
+(defun my/projectile-goto-file (file-path)
+  "Go to the file path"
+  (let ((path (concat (projectile-acquire-root) file-path)))
+    (cond
+     ((file-exists-p path)
+      (find-file path))
+     (t
+      (user-error "%s is not found." file-path)))))
+#+end_src
+**** プロジェクト内の指定フォルダのファイルを検索
+実装ファイルなどは特定のフォルダ以下に複数存在するのが一般形なので
+指定したフォルダ以下のファイルを completing-read で絞り込めるようにしている。
+
+#+begin_src emacs-lisp :tangle inits/30-projectile.el
+(defun my/projectile-find-file-in-dir (dir-path)
+  "Find the file path"
+  (interactive)
+  (let ((path (concat (projectile-acquire-root) dir-path)))
+    (cond
+     ((and (file-exists-p path) (file-directory-p path))
+      (projectile-find-file-in-directory path))
+     (t
+      (user-error "%s is not directory." dir-path)))))
+#+end_src
+**** Dockerfile を開く
+今時は Docker がよく使われているので Dockerfile を開くコマンドを用意した。
+
+#+begin_src emacs-lisp :tangle inits/30-projectile.el
+(defun my/projectile-goto-dockerfile ()
+  "Find the Dockerfile"
+  (interactive)
+  (my/projectile-goto-file "Dockerfile"))
+#+end_src
+**** .circleci/config.yml を開く
+~.circleci/config.yml~ も時々開くよねってことで追加した
+
+#+begin_src emacs-lisp :tangle inits/30-projectile.el
+(defun my/projectile-goto-circleci-config ()
+  "Find the CircleCI config.yml"
+  (interactive)
+  (my/projectile-goto-file ".circleci/config.yml"))
+#+end_src
+**** Gemfile を開く
+Ruby 書いているとお馴染の Gemfile もぱぱっと開きたいので追加
+
+#+begin_src emacs-lisp :tangle inits/30-projectile.el
+(defun my/projectile-goto-gemfile ()
+  "Find the Gemfile"
+  (interactive)
+  (my/projectile-goto-file "Gemfile"))
+#+end_src
+**** .rubocop.yml を開く
+Ruby 書いていたら大体 rubocop も使うので追加
+
+#+begin_src emacs-lisp :tangle inits/30-projectile.el
+(defun my/projectile-goto-rubocop-config ()
+  "Find the .rubocop.yml"
+  (interactive)
+  (my/projectile-goto-file ".rubocop.yml"))
+#+end_src
 * プログラミング関係の設定
 :PROPERTIES:
 :EXPORT_HUGO_SECTION: programming

--- a/init.org
+++ b/init.org
@@ -3250,6 +3250,7 @@ el-get の Hydra はここで定義してしまっている。
 
    "Tool"
    (("SPC" major-mode-hydra         "Hydra(Major)")
+    ("h"   my/project-hydra         "Hydra(Project)")
     ("s"   toggle-hydra/body        "Toggle switches")
     ("c"   counsel-org-capture      "Capture")
     ("o"   global-org-hydra/body    "Org")
@@ -3280,6 +3281,7 @@ el-get の Hydra はここで定義してしまっている。
 | +   | [[*Text Scale][文字サイズ変更用 Hydra]] の起動                                             |
 | w   | Window の入替                                                             |
 | SPC | [[https://github.com/jerrypnz/major-mode-hydra.el][major-mode-hydra]] の起動                                                   |
+| h   | プロジェクト固有の Hydra があればそれを起動する                           |
 | s   | [[*Toggle Switches][ON/OFF 切替系の Hydra]] を起動する                                          |
 | c   | counsel-org-capture を呼び出す                                            |
 | o   | org-mode 用の Hydra を起動する                                            |

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -30,3 +30,12 @@
 
      "Other"
      (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")))))
+
+(defun my/projectile-goto-file (file-path)
+  "Go to the file path"
+  (let ((path (concat (projectile-acquire-root) file-path)))
+    (cond
+     ((file-exists-p path)
+      (find-file path))
+     (t
+      (message "%s is not found." file-path)))))

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -54,7 +54,7 @@
      ((file-exists-p path)
       (find-file path))
      (t
-      (message "%s is not found." file-path)))))
+      (user-error "%s is not found." file-path)))))
 
 (defun my/projectile-find-file-in-dir (dir-path)
   "Find the file path"

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -54,3 +54,8 @@
   "Find the Gemfile"
   (interactive)
   (my/projectile-goto-file "Dockerfile"))
+
+(defun my/projectile-goto-circleci-config ()
+  "Find the CircleCI config.yml"
+  (interactive)
+  (my/projectile-goto-file ".circleci/config.yml"))

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -67,7 +67,7 @@
       (user-error "%s is not directory." dir-path)))))
 
 (defun my/projectile-goto-dockerfile ()
-  "Find the Gemfile"
+  "Find the Dockerfile"
   (interactive)
   (my/projectile-goto-file "Dockerfile"))
 
@@ -82,6 +82,6 @@
   (my/projectile-goto-file "Gemfile"))
 
 (defun my/projectile-goto-rubocop-config ()
-  "Find the Gemfile"
+  "Find the .rubocop.yml"
   (interactive)
   (my/projectile-goto-file ".rubocop.yml"))

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -31,6 +31,18 @@
      "Other"
      (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")))))
 
+(defun my/project-hydra ()
+  "Call the project specific hydra."
+  (interactive)
+  (let* ((project-path (directory-file-name (projectile-acquire-root)))
+         (project-dir-name (file-name-base project-path))
+         (hydra-body (intern (concat project-dir-name "-hydra/body"))))
+    (cond
+     ((fboundp hydra-body)
+      (funcall hydra-body))
+     (t
+      (user-error "project hydra is not defined on %s." project-dir-name)))))
+
 (defun my/projectile-goto-file (file-path)
   "Go to the file path"
   (let ((path (concat (projectile-acquire-root) file-path)))

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -59,3 +59,8 @@
   "Find the CircleCI config.yml"
   (interactive)
   (my/projectile-goto-file ".circleci/config.yml"))
+
+(defun my/projectile-goto-gemfile ()
+  "Find the Gemfile"
+  (interactive)
+  (my/projectile-goto-file "Gemfile"))

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -49,3 +49,8 @@
       (projectile-find-file-in-directory path))
      (t
       (user-error "%s is not directory." dir-path)))))
+
+(defun my/projectile-goto-dockerfile ()
+  "Find the Gemfile"
+  (interactive)
+  (my/projectile-goto-file "Dockerfile"))

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -25,6 +25,9 @@
       ("d" counsel-projectile-find-dir "Find Dir")
       ("r" projectile-recentf "Recentf"))
 
+     "Jump"
+     (("l" projectile-edit-dir-locals "dir-locals"))
+
      "Edit"
      (("R" projectile-replace "Replace"))
 

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -64,3 +64,8 @@
   "Find the Gemfile"
   (interactive)
   (my/projectile-goto-file "Gemfile"))
+
+(defun my/projectile-goto-rubocop-config ()
+  "Find the Gemfile"
+  (interactive)
+  (my/projectile-goto-file ".rubocop.yml"))

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -39,3 +39,13 @@
       (find-file path))
      (t
       (message "%s is not found." file-path)))))
+
+(defun my/projectile-find-file-in-dir (dir-path)
+  "Find the file path"
+  (interactive)
+  (let ((path (concat (projectile-acquire-root) dir-path)))
+    (cond
+     ((and (file-exists-p path) (file-directory-p path))
+      (projectile-find-file-in-directory path))
+     (t
+      (user-error "%s is not directory." dir-path)))))

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -20,7 +20,7 @@
 (with-eval-after-load 'pretty-hydra
   (pretty-hydra-define
     projectile-hydra (:separator "-" :title "Projectile" :foreign-key warn :quit-key "q" :exit t)
-    ("File"
+    ("Find"
      (("f" counsel-projectile-find-file "Find File")
       ("d" counsel-projectile-find-dir "Find Dir")
       ("r" projectile-recentf "Recentf"))

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -32,7 +32,8 @@
      (("R" projectile-replace "Replace"))
 
      "Other"
-     (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")))))
+     (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")
+      ("SPC" my/project-hydra "Hydra")))))
 
 (defun my/project-hydra ()
   "Call the project specific hydra."

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -120,6 +120,7 @@
 
    "Tool"
    (("SPC" major-mode-hydra         "Hydra(Major)")
+    ("h"   my/project-hydra         "Hydra(Project)")
     ("s"   toggle-hydra/body        "Toggle switches")
     ("c"   counsel-org-capture      "Capture")
     ("o"   global-org-hydra/body    "Org")


### PR DESCRIPTION
Projectile を用いたコマンドをいくつか定義した。
これらをプロジェクト固有の Hydra で使う予定。

またプロジェクト固有の Hydra を `(my/project-hydra)` で呼び出せるようにした。

プロジェクト固有の Hydra は各プロジェクトの `.dir-locals.el` で定義するつもり。
とはいえ別に Emacs の設定ファイルに埋め込んでいてもあまり問題はないはず。