### PR TITLE
fix: Ignore magit docs on recipe

### DIFF
--- a/hugo/content/external-tool/magit.md
+++ b/hugo/content/external-tool/magit.md
@@ -24,11 +24,11 @@ ref: <https://github.com/mugijiru/.emacs.d/pull/2992>
        :type github
        :pkgname "magit/magit"
        :branch "main"
-       :minimum-emacs-version "25.1"
+       :minimum-emacs-version "26.1"
        ;; Note: `git-commit' is shipped with `magit' code itself.
        ;; Note: `magit-section' is shipped with `magit' code itself.
        :depends (dash transient with-editor compat seq)
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
@@ -37,7 +37,7 @@ ref: <https://github.com/mugijiru/.emacs.d/pull/2992>
        ;; a file of that name.
        :build `(;; ("make" ,(format "EMACSBIN=%s" el-get-emacs) "docs") do not build manual
                 ("touch" "lisp/magit-autoloads.el"))
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+       :build/berkeley-unix `(;; ("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
                               ("touch" "lisp/magit-autoloads.el"))
        ;; assume windows lacks make and makeinfo
        :build/windows-nt (with-temp-file "lisp/magit-autoloads.el" nil))

--- a/init.org
+++ b/init.org
@@ -7395,11 +7395,11 @@ ref: https://github.com/mugijiru/.emacs.d/pull/2992
        :type github
        :pkgname "magit/magit"
        :branch "main"
-       :minimum-emacs-version "25.1"
+       :minimum-emacs-version "26.1"
        ;; Note: `git-commit' is shipped with `magit' code itself.
        ;; Note: `magit-section' is shipped with `magit' code itself.
        :depends (dash transient with-editor compat seq)
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
@@ -7408,7 +7408,7 @@ ref: https://github.com/mugijiru/.emacs.d/pull/2992
        ;; a file of that name.
        :build `(;; ("make" ,(format "EMACSBIN=%s" el-get-emacs) "docs") do not build manual
                 ("touch" "lisp/magit-autoloads.el"))
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+       :build/berkeley-unix `(;; ("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
                               ("touch" "lisp/magit-autoloads.el"))
        ;; assume windows lacks make and makeinfo
        :build/windows-nt (with-temp-file "lisp/magit-autoloads.el" nil))

--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -4,7 +4,7 @@
        :type github
        :pkgname "magit/magit"
        :branch "main"
-       :minimum-emacs-version "25.1"
+       :minimum-emacs-version "26.1"
        ;; Note: `git-commit' is shipped with `magit' code itself.
        ;; Note: `magit-section' is shipped with `magit' code itself.
        :depends (dash transient with-editor compat seq)

--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -8,7 +8,7 @@
        ;; Note: `git-commit' is shipped with `magit' code itself.
        ;; Note: `magit-section' is shipped with `magit' code itself.
        :depends (dash transient with-editor compat seq)
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
@@ -17,7 +17,7 @@
        ;; a file of that name.
        :build `(;; ("make" ,(format "EMACSBIN=%s" el-get-emacs) "docs") do not build manual
                 ("touch" "lisp/magit-autoloads.el"))
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+       :build/berkeley-unix `(;; ("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
                               ("touch" "lisp/magit-autoloads.el"))
        ;; assume windows lacks make and makeinfo
        :build/windows-nt (with-temp-file "lisp/magit-autoloads.el" nil))


### PR DESCRIPTION
magit の build に失敗するから
とりあえずドキュメントを無視してみることにした