### PR TITLE
fix: Implement codeberg compare URL generator

### DIFF
--- a/init-el-get.el
+++ b/init-el-get.el
@@ -25,9 +25,17 @@
       (unless (string= old-checksum new-checksum)
         (let* ((compare (concat old-checksum "..." new-checksum))
                (recipe (ignore-errors (el-get-package-def package)))
+               (type (plist-get recipe :type))
                (pkgname (plist-get recipe :pkgname))
+               (url (plist-get recipe :url))
                (title (concat "Update " package))
-               (body (concat "https://github.com/" pkgname "/compare/" compare))
+               (body (cond
+                      ((eq type 'github)
+                       (concat "https://github.com/" pkgname "/compare/" compare))
+                      ((string-match (concat "^" "https://codeberg.org/") url)
+                       (concat (substring url 0 (- (length url) 4)) "/compare/" compare))
+                      (t
+                       (concat "compare: " compare))))
                (commit-message (concat title "\n\n" body)))
           (write-region commit-message nil "/tmp/commit-message.txt"))))))
 


### PR DESCRIPTION
自動更新 PR の本文に出力される比較 URL が
GitHub にしか対応していなかったので
Codeberg の compare にも対応させた。

これで次回移行の undo-fu の更新で幸せになれるはず