### PR TITLE
fix: Improve weekday agenda

### DIFF
--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -280,12 +280,6 @@ org-agenda では `org-agenda-prefix-format` に `%s` を指定することで�
                    (org-agenda-files '("~/Documents/org/tasks/habits.org"))
                    (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                               (:name "今日予定" :scheduled today)
-                                              (:discard (:anything t))))))
-
-       (tags-todo "LEVEL=2"
-                  ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                   (org-agenda-overriding-header "予定なし")
-                   (org-super-agenda-groups '((:and (:property ("agenda-group" "1. Work") :scheduled nil :deadline nil))
                                               (:discard (:anything t))))))))
 ```
 

--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -273,7 +273,7 @@ org-agenda では `org-agenda-prefix-format` に `%s` を指定することで�
                                                                                           :scheduled (after ,(format-time-string "%Y-%m-%d" (current-time))))
                                                                               :property ("agenda-group" "1. Work")))
                                             (:discard (:anything t))))))
-       (tags-todo "Weekday-Finish|Daily"
+       (tags-todo "Weekday-Start-Finish|Daily"
                   ((org-agenda-overriding-header "習慣")
                    (org-agenda-prefix-format "  ")
                    (org-habit-show-habits t)

--- a/init.org
+++ b/init.org
@@ -8704,12 +8704,6 @@ org-agenda では ~org-agenda-prefix-format~ に ~%s~ を指定することで
                    (org-agenda-files '("~/Documents/org/tasks/habits.org"))
                    (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                               (:name "今日予定" :scheduled today)
-                                              (:discard (:anything t))))))
-
-       (tags-todo "LEVEL=2"
-                  ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                   (org-agenda-overriding-header "予定なし")
-                   (org-super-agenda-groups '((:and (:property ("agenda-group" "1. Work") :scheduled nil :deadline nil))
                                               (:discard (:anything t))))))))
 #+end_src
 ***** 休日用 agenda

--- a/init.org
+++ b/init.org
@@ -8697,7 +8697,7 @@ org-agenda では ~org-agenda-prefix-format~ に ~%s~ を指定することで
                                                                                           :scheduled (after ,(format-time-string "%Y-%m-%d" (current-time))))
                                                                               :property ("agenda-group" "1. Work")))
                                             (:discard (:anything t))))))
-       (tags-todo "Weekday-Finish|Daily"
+       (tags-todo "Weekday-Start-Finish|Daily"
                   ((org-agenda-overriding-header "習慣")
                    (org-agenda-prefix-format "  ")
                    (org-habit-show-habits t)

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -106,12 +106,6 @@
                    (org-agenda-files '("~/Documents/org/tasks/habits.org"))
                    (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                               (:name "今日予定" :scheduled today)
-                                              (:discard (:anything t))))))
-
-       (tags-todo "LEVEL=2"
-                  ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
-                   (org-agenda-overriding-header "予定なし")
-                   (org-super-agenda-groups '((:and (:property ("agenda-group" "1. Work") :scheduled nil :deadline nil))
                                               (:discard (:anything t))))))))
 
      ("D" "Holiday"

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -99,7 +99,7 @@
                                                                                           :scheduled (after ,(format-time-string "%Y-%m-%d" (current-time))))
                                                                               :property ("agenda-group" "1. Work")))
                                             (:discard (:anything t))))))
-       (tags-todo "Weekday-Finish|Daily"
+       (tags-todo "Weekday-Start-Finish|Daily"
                   ((org-agenda-overriding-header "習慣")
                    (org-agenda-prefix-format "  ")
                    (org-habit-show-habits t)


### PR DESCRIPTION
平日に確認する agenda から情報を一部削減した。

具体的には、
業務開始時や終了時に行う作業と
予定が決めてない業務系タスク(思い付きで試してみたいやつとか)は表示しないようにした。

業務開始時や終了時に行う作業については別でチェックする agenda があり、
予定がないタスクもまた別の agenda でチェックできる。

また、それらはここに表示していてもほとんど見てないので、まあ不要だなあと。