### PR TITLE
fix: Remove daily tasks from weekday start agenda

### DIFF
--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -170,7 +170,7 @@ org-agenda では `org-agenda-prefix-format` に `%s` を指定することで�
 
     ```emacs-lisp
          ("hs" "Weekday Start"
-          ((tags "Weekday&Start|Daily"
+          ((tags "Weekday&Start"
                  ((org-agenda-prefix-format "  ")
                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                              (:name "今日の作業" :scheduled today)

--- a/init.org
+++ b/init.org
@@ -8595,7 +8595,7 @@ org-agenda では ~org-agenda-prefix-format~ に ~%s~ を指定することで
 
 #+begin_src emacs-lisp :tangle inits/61-org-agenda.el
      ("hs" "Weekday Start"
-      ((tags "Weekday&Start|Daily"
+      ((tags "Weekday&Start"
              ((org-agenda-prefix-format "  ")
               (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                          (:name "今日の作業" :scheduled today)

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -37,7 +37,7 @@
    '(("h" . "Habits")
 
      ("hs" "Weekday Start"
-      ((tags "Weekday&Start|Daily"
+      ((tags "Weekday&Start"
              ((org-agenda-prefix-format "  ")
               (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
                                          (:name "今日の作業" :scheduled today)


### PR DESCRIPTION
業務開始時に眺める習慣タスク一覧から
日中にやればいつでも OK 的なタスクを省いた。