### PR TITLE
fix: Downgrade org-mode to 9.6.30

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -16,7 +16,7 @@
         (ob-graphql :checksum "7c35419f9eec5dc44967cbcfa13c7135b9a96bfc")
         (corfu :checksum "921dd7c97ec41fe8ef81dd5f5a08b0f717586c86")
         (treesit-auto :checksum "016bd286a1ba4628f833a626f8b9d497882ecdf3")
-        (org-mode :checksum "5ebd973e09d7a46d056f1cd9b5efc44e878cce9c")
+        (org-mode :checksum "071c6e986c424d2e496be7d0815d6e9cd83ae4e6")
         (org-journal :checksum "17b34ce8df9649a73b715c13698220bde1628668")
         (company-terraform :checksum "8d5a16d1bbeeb18ca49a8fd57b5d8cd30c8b8dc7")
         (terraform-mode :checksum "abfc10f5e313c4bb99de136a14636e9bc6df74f6")

--- a/hugo/content/org-mode/base.md
+++ b/hugo/content/org-mode/base.md
@@ -17,7 +17,7 @@ Emacs に標準で入っている org-mode は古かったりするのでとり�
 (el-get-bundle org-mode)
 ```
 
-とりあえず今は Emacs 29.1 に標準で bundle されているバージョンを入れておいている。バージョンを固定するために el-get についているレシピをコピーして書き換えて使っている。
+とりあえず今は 9.6 系を入れておいている。バージョンを固定するために el-get についているレシピをコピーして書き換えて使っている。
 
 ```emacs-lisp
 (:name org-mode
@@ -25,7 +25,7 @@ Emacs に標準で入っている org-mode は古かったりするのでとり�
        :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
        :type git
        :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
-       :checkout "release_9.6.6"
+       :checkout "release_9.6.30"
        :info "doc"
        :build/berkeley-unix `,(mapcar
                                (lambda (target)
@@ -39,8 +39,8 @@ Emacs に標準で入っている org-mode は古かったりするのでとり�
        :load ("lisp/org-loaddefs.el"))
 ```
 
-その内もっと新しいのにするけど
-<span class="timestamp-wrapper"><span class="timestamp">[2023-10-30 月] </span></span> に main ブランチのものを入れたら agenda が動かなくなって焦ったのでまた落ち着いた時にトライする
+<span class="timestamp-wrapper"><span class="timestamp">[2023-10-30 月] </span></span> に main ブランチのものを入れたら agenda が動かなくなって焦ったし
+<span class="timestamp-wrapper"><span class="timestamp">[2024-08-22 木] </span></span> に 9.7 系を入れたら ox-hugo や org-gcal が動かなくなったのでとりあえず 9.6 系を使う運用にしている
 
 
 ## org 用ディレクトリの指定 {#org-用ディレクトリの指定}
@@ -74,19 +74,17 @@ org-mode といえば TODO 管理で使ってる人も多いと思う。自分�
 -   TODO
 -   DONE
 
-の2つしかないけど、それでは足りないので昔見たインターネットのどこかの記事を参考に以下のように設定している。
+    の2つしかないけど、それでは足りないので昔見たインターネットのどこかの記事を参考に以下のように設定している。
+    ```emacs-lisp
+      (setq org-todo-keywords
+            '((sequence "TODO" "EXAMINATION(e)" "READY(r)" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)")))
+    ```
+    初期状態は TODO で、作業開始時点で DOING にして待ちが発生したら WAIT にして完了したら DONE にしている。
 
-```emacs-lisp
-(setq org-todo-keywords
-      '((sequence "TODO" "EXAMINATION(e)" "READY(r)" "DOING(!)" "WAIT" "|" "DONE(!)" "SOMEDAY(s)")))
-```
+    SOMEDAY は「いつかやる」に付与しているけど最近ほとんど使ってない。
 
-初期状態は TODO で、作業開始時点で DOING にして待ちが発生したら WAIT にして完了したら DONE にしている。
-
-SOMEDAY は「いつかやる」に付与しているけど最近ほとんど使ってない。
-
-org-todo-keywords は複数の sequence を指定したり
-type を指定したりもできるがそこまでの活用ができていないので、どこかで見直したいですね。
+    org-todo-keywords は複数の sequence を指定したり
+    type を指定したりもできるがそこまでの活用ができていないので、どこかで見直したいですね。
 
 
 ## 完了時間の記録 {#完了時間の記録}

--- a/init.org
+++ b/init.org
@@ -8051,7 +8051,7 @@ Emacs に標準で入っている org-mode は古かったりするので
 (el-get-bundle org-mode)
 #+end_src
 
-とりあえず今は [2024-08-22 木] の最新版を入れておいている。
+とりあえず今は 9.6 系を入れておいている。
 バージョンを固定するために el-get についているレシピをコピーして書き換えて使っている。
 
 #+begin_src emacs-lisp :tangle recipes/org-mode.rcp
@@ -8060,7 +8060,7 @@ Emacs に標準で入っている org-mode は古かったりするので
        :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
        :type git
        :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
-       :checkout "release_9.7.10"
+       :checkout "release_9.6.30"
        :info "doc"
        :build/berkeley-unix `,(mapcar
                                (lambda (target)
@@ -8074,8 +8074,9 @@ Emacs に標準で入っている org-mode は古かったりするので
        :load ("lisp/org-loaddefs.el"))
 #+end_src
 
-[2023-10-30 月] に main ブランチのものを入れたら agenda が動かなくなって焦ったので
-とりあえずリリース版を使う運用にしている
+[2023-10-30 月] に main ブランチのものを入れたら agenda が動かなくなって焦ったし
+[2024-08-22 木] に 9.7 系を入れたら ox-hugo や org-gcal が動かなくなったので
+とりあえず 9.6 系を使う運用にしている
 
 *** org 用ディレクトリの指定
 :PROPERTIES:

--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -3,7 +3,7 @@
        :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
        :type git
        :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
-       :checkout "release_9.7.10"
+       :checkout "release_9.6.30"
        :info "doc"
        :build/berkeley-unix `,(mapcar
                                (lambda (target)


### PR DESCRIPTION
9.7 系では ox-hugo や org-gcal が動かないのでやむなし