### PR TITLE
fix: Remove orgit

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -42,7 +42,6 @@
         (json-mode :checksum "77125b01c0ddce537085201098bea9b4b8ba6be3")
         (json-snatcher :checksum "b28d1c0670636da6db508d03872d96ffddbc10f2")
         (json-reformat :checksum "9120ab67c5379c44bc7a7a07ca858670cea4f32f")
-        (orgit :checksum "7159e237191c35b1ee19a417a9824db89eb2d39d")
         (org-contrib :checksum "ccd4212866fb1be70d1f15a41264c45a281901ad")
         (mocha :checksum "6a72fa20e7be6e55c09b1bc9887ee09c5df28e45")
         (pdf-tools :checksum "30b50544e55b8dbf683c2d932d5c33ac73323a16")

--- a/hugo/content/external-tool/magit.md
+++ b/hugo/content/external-tool/magit.md
@@ -77,29 +77,14 @@ ref: <https://github.com/mugijiru/.emacs.d/pull/2992>
 
 ## その他設定 {#その他設定}
 
-ghub を load-path に入れないとうまくいかなかった時があったので load-path に入れてたり、
-orgit を入れていたり
+ghub を load-path に入れないとうまくいかなかった時があったので load-path に入れてたりします。
 
 ```emacs-lisp
 (with-eval-after-load 'magit
   (add-to-list 'load-path (expand-file-name "~/.emacs.d/el-get/ghub/lisp")))
-
-(el-get-bundle orgit)
 ```
 
-なお orgit は recipe を自前で用意している
-
-```emacs-lisp
-(:name orgit
-       :website "https://github.com/magit/orgit"
-       :description "Link to Magit buffers from Org documents."
-       :type github
-       :branch "main"
-       :pkgname "magit/orgit"
-       :depends (compat magit org-mode))
-```
-
-あと ghub は compat に依存するようになったのでとりあえず自前で recipe を用意している
+ghub は compat に依存するようになったのでとりあえず自前で recipe を用意している
 
 ```emacs-lisp
 (:name ghub

--- a/init.org
+++ b/init.org
@@ -7496,29 +7496,14 @@ ref: https://github.com/mugijiru/.emacs.d/pull/2992
 :ID:       77ca776f-8289-474b-a175-aabfd5569ee2
 :END:
 
-ghub を load-path に入れないとうまくいかなかった時があったので load-path に入れてたり、
-orgit を入れていたり
+ghub を load-path に入れないとうまくいかなかった時があったので load-path に入れてたりします。
 
 #+begin_src emacs-lisp :tangle inits/35-magit.el
 (with-eval-after-load 'magit
   (add-to-list 'load-path (expand-file-name "~/.emacs.d/el-get/ghub/lisp")))
-
-(el-get-bundle orgit)
 #+end_src
 
-なお orgit は recipe を自前で用意している
-
-#+begin_src emacs-lisp :tangle recipes/orgit.rcp
-(:name orgit
-       :website "https://github.com/magit/orgit"
-       :description "Link to Magit buffers from Org documents."
-       :type github
-       :branch "main"
-       :pkgname "magit/orgit"
-       :depends (compat magit org-mode))
-#+end_src
-
-あと ghub は compat に依存するようになったのでとりあえず自前で recipe を用意している
+ghub は compat に依存するようになったのでとりあえず自前で recipe を用意している
 
 #+begin_src emacs-lisp :tangle recipes/ghub.rcp
 (:name ghub

--- a/inits/35-magit.el
+++ b/inits/35-magit.el
@@ -2,5 +2,3 @@
 
 (with-eval-after-load 'magit
   (add-to-list 'load-path (expand-file-name "~/.emacs.d/el-get/ghub/lisp")))
-
-(el-get-bundle orgit)

--- a/recipes/orgit.rcp
+++ b/recipes/orgit.rcp
@@ -1,7 +1,0 @@
-(:name orgit
-       :website "https://github.com/magit/orgit"
-       :description "Link to Magit buffers from Org documents."
-       :type github
-       :branch "main"
-       :pkgname "magit/orgit"
-       :depends (compat magit org-mode))


### PR DESCRIPTION
orgit の依存関係で org-mode 9.7 系が必要になったけど
他のパッケージが 9.7 系だとコケるので 9.6 系に戻してある。

で orgit の機能はほぼ使っていないので
削除してもまあ問題ないと判断した