### PR TITLE
fix: Do not use argument when calling lsp

### DIFF
--- a/hugo/content/programming/yaml-mode.md
+++ b/hugo/content/programming/yaml-mode.md
@@ -29,7 +29,7 @@ hook で動作する中身が変更できて便利。
 
 ```emacs-lisp
 (defun my/yaml-mode-hook ()
-  (lsp 1)
+  (lsp)
   (flycheck-mode 1)
   (highlight-indent-guides-mode 1))
 ```

--- a/init.org
+++ b/init.org
@@ -6880,7 +6880,7 @@ hook で動作する中身が変更できて便利。
 
 #+begin_src emacs-lisp :tangle inits/40-yaml.el
 (defun my/yaml-mode-hook ()
-  (lsp 1)
+  (lsp)
   (flycheck-mode 1)
   (highlight-indent-guides-mode 1))
 #+end_src

--- a/inits/40-yaml.el
+++ b/inits/40-yaml.el
@@ -1,7 +1,7 @@
 (el-get-bundle yaml-mode)
 
 (defun my/yaml-mode-hook ()
-  (lsp 1)
+  (lsp)
   (flycheck-mode 1)
   (highlight-indent-guides-mode 1))
 


### PR DESCRIPTION
(lsp) は第一引数が t の時には
既に server が動いていても新しく lsp server を起動するらしい。

それは意図していなかったので修正する