### PR TITLE
feat: Improve ruby and rspec settings

### DIFF
--- a/hugo/content/programming/rspec-mode.md
+++ b/hugo/content/programming/rspec-mode.md
@@ -35,13 +35,3 @@ C-c C-c で開いている rspec ファイルのカーソルがある行のテ�
 ```
 
 他にも色々な機能があるのだけどキーバインド未設定なのでこれだけしか使ってない。
-
-
-## Docker 連携 {#docker-連携}
-
-Docker と連携するように調整
-
-```emacs-lisp
-(custom-set-variables
- '(rspec-use-docker-when-possible t))
-```

--- a/hugo/content/programming/ruby.md
+++ b/hugo/content/programming/ruby.md
@@ -138,22 +138,24 @@ hook 用の関数で補完などの機能を有効にしている
 (defun my/ruby-modes-hook ()
   (origami-mode 1)
   (company-mode 1)
+  (setq-local company-backends
+              '(company-capf (company-keywords company-dabbrev-code) company-yasnippet company-files company-dabbrev))
+
   (subword-mode 1)
   (copilot-mode 1)
   (yard-mode 1)
   (eldoc-mode 1)
-  (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode 1))
 ```
 
 -   コード折り畳み用に origami を有効化
 -   補完用に company-mode を有効化
+    -   backend も余計なものが入らないようにカスタマイズしている
 -   CamelCase の単語区切りを有効にするため subword-mode を有効化
 -   Copilot もあると便利なので有効化
 -   yard 形式のコメントも良い感じにハイライトされると便利なので yard-mode を有効化
     -   更に eldoc-mode を有効にしていると yard コメントを書く時に文法を minibuffer に表示してくれるのでこちらも有効化
--   lsp-mode の自動フォーマットを保存時に実行するようにしている
 -   開きカッコと閉じカッコの組み合わせがズレないように smartparens-strict-mode を有効にしている
 -   行番号も表示されている方が便利なので display-line-numbers-mode を有効にしている
 -   lsp-mode に関してはプロジェクト毎にごにゃごにゃしたいので `.dir-locals.el` に任せる方針にしている
@@ -210,9 +212,9 @@ Ruby を使ってる時にコメント部分はクォートの外以外では自
                  "Other"
                  (("j" dumb-jump-go       "Dumb Jump")
                   ("o" origami-hydra/body "Origami")))))
-    (eval `(major-mode-hydra-define enh-ruby-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
+    (eval `(major-mode-hydra-define enh-ruby-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-language_ruby") " Ruby commands"))
              (,@heads)))
-    (eval `(major-mode-hydra-define ruby-ts-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
+    (eval `(major-mode-hydra-define ruby-ts-mode  (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-language_ruby") " Ruby commands"))
              (,@heads)))))
 ```
 

--- a/init.org
+++ b/init.org
@@ -6097,18 +6097,6 @@ C-c C-c で開いている rspec ファイルのカーソルがある行のテ�
 (define-key rspec-mode-map (kbd "C-c C-c") 'rspec-verify-single)
 #+end_src
 他にも色々な機能があるのだけどキーバインド未設定なのでこれだけしか使ってない。
-
-*** Docker 連携
-:PROPERTIES:
-:ID:       6c468980-ddd6-4d2a-a79f-d5fc3cc948de
-:END:
-Docker と連携するように調整
-
-#+begin_src emacs-lisp :tangle inits/42-rspec.el
-(custom-set-variables
- '(rspec-use-docker-when-possible t))
-#+end_src
-
 ** ruby
 :PROPERTIES:
 :EXPORT_FILE_NAME: ruby
@@ -6236,22 +6224,24 @@ hook 用の関数で補完などの機能を有効にしている
 (defun my/ruby-modes-hook ()
   (origami-mode 1)
   (company-mode 1)
+  (setq-local company-backends
+              '(company-capf (company-keywords company-dabbrev-code) company-yasnippet company-files company-dabbrev))
+
   (subword-mode 1)
   (copilot-mode 1)
   (yard-mode 1)
   (eldoc-mode 1)
-  (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode 1))
 #+end_src
 
 - コード折り畳み用に origami を有効化
 - 補完用に company-mode を有効化
+  - backend も余計なものが入らないようにカスタマイズしている
 - CamelCase の単語区切りを有効にするため subword-mode を有効化
 - Copilot もあると便利なので有効化
 - yard 形式のコメントも良い感じにハイライトされると便利なので yard-mode を有効化
   - 更に eldoc-mode を有効にしていると yard コメントを書く時に文法を minibuffer に表示してくれるのでこちらも有効化
-- lsp-mode の自動フォーマットを保存時に実行するようにしている
 - 開きカッコと閉じカッコの組み合わせがズレないように smartparens-strict-mode を有効にしている
 - 行番号も表示されている方が便利なので display-line-numbers-mode を有効にしている
 - lsp-mode に関してはプロジェクト毎にごにゃごにゃしたいので ~.dir-locals.el~ に任せる方針にしている
@@ -6310,9 +6300,9 @@ Ruby を使ってる時にコメント部分はクォートの外以外では
                  "Other"
                  (("j" dumb-jump-go       "Dumb Jump")
                   ("o" origami-hydra/body "Origami")))))
-    (eval `(major-mode-hydra-define enh-ruby-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
+    (eval `(major-mode-hydra-define enh-ruby-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-language_ruby") " Ruby commands"))
              (,@heads)))
-    (eval `(major-mode-hydra-define ruby-ts-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
+    (eval `(major-mode-hydra-define ruby-ts-mode  (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-language_ruby") " Ruby commands"))
              (,@heads)))))
 #+end_src
 

--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -17,11 +17,13 @@
 (defun my/ruby-modes-hook ()
   (origami-mode 1)
   (company-mode 1)
+  (setq-local company-backends
+              '(company-capf (company-keywords company-dabbrev-code) company-yasnippet company-files company-dabbrev))
+
   (subword-mode 1)
   (copilot-mode 1)
   (yard-mode 1)
   (eldoc-mode 1)
-  (add-hook 'before-save-hook #'lsp-format-buffer nil 'local)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode 1))
 
@@ -50,7 +52,7 @@
                  "Other"
                  (("j" dumb-jump-go       "Dumb Jump")
                   ("o" origami-hydra/body "Origami")))))
-    (eval `(major-mode-hydra-define enh-ruby-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
+    (eval `(major-mode-hydra-define enh-ruby-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-language_ruby") " Ruby commands"))
              (,@heads)))
-    (eval `(major-mode-hydra-define ruby-ts-mode (:separator "-" :quit-key "q" :title (concat (all-the-icons-alltheicon "ruby-alt") " Ruby commands"))
+    (eval `(major-mode-hydra-define ruby-ts-mode  (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-language_ruby") " Ruby commands"))
              (,@heads)))))

--- a/inits/42-rspec.el
+++ b/inits/42-rspec.el
@@ -3,6 +3,3 @@
 (add-hook 'after-init-hook 'inf-ruby-switch-setup)
 
 (define-key rspec-mode-map (kbd "C-c C-c") 'rspec-verify-single)
-
-(custom-set-variables
- '(rspec-use-docker-when-possible t))


### PR DESCRIPTION
Ruby と RSpec の設定を更新した

Ruby の方は適当な雑スクリプトだと LSP を使わないので
before-save-hook での LSP による自動フォーマットの設定を削除した
また company-mode の backends を指定するようにした
company-bbdb とか Ruby には不要そうなので

RSpec の方は ~rspec-use-docker-when-possible~ を削除した。
これはプロジェクト事情によりそうなので
.dir-locals.el に書く方針にした