### PR TITLE
feat: Add copilot keybinds

### DIFF
--- a/hugo/content/editing/copilot.md
+++ b/hugo/content/editing/copilot.md
@@ -48,15 +48,8 @@ draft = false
 ;; (add-hook 'prog-mode-hook 'copilot-mode)
 ```
 
-また、そのままだと enh-ruby-mode では有効にならないので
-`copilot-major-mode-alist` に突っ込んでいる。なおこの設定は [公式の README にも書かれている](https://github.com/zerolfx/copilot.el#programming-language-detection)
-
-```emacs-lisp
-(with-eval-after-load 'copilot
-  (add-to-list 'copilot-major-mode-alist '("enh-ruby" . "ruby")))
-```
-
-あと何故か忘れたけど inline preview を無効にするような設定を入れている
+あとは company-mode と組み合わせてもそれなりに動くようにするため
+inline preview を無効にするような設定を入れている。なおこの設定は[公式の README の中のコード](https://github.com/copilot-emacs/copilot.el#example-for-spacemacs)を使っている
 
 ```emacs-lisp
 (with-eval-after-load 'company
@@ -72,7 +65,10 @@ draft = false
 ```emacs-lisp
 (with-eval-after-load 'copilot
   (define-key copilot-completion-map (kbd "<tab>") 'copilot-accept-completion)
-  (define-key copilot-completion-map (kbd "TAB") 'copilot-accept-completion))
+  (define-key copilot-completion-map (kbd "TAB") 'copilot-accept-completion)
+  (define-key copilot-completion-map (kbd "M-f") 'copilot-accept-completion-by-word)
+  (define-key copilot-completion-map (kbd "M-n") 'copilot-next-completion)
+  (define-key copilot-completion-map (kbd "M-p") 'copilot-previous-completion))
 ```
 
 

--- a/init.org
+++ b/init.org
@@ -1722,16 +1722,9 @@ save-place-mode を有効にしていると
 ;; (add-hook 'prog-mode-hook 'copilot-mode)
 #+end_src
 
-また、そのままだと enh-ruby-mode では有効にならないので
-~copilot-major-mode-alist~ に突っ込んでいる。
-なおこの設定は [[https://github.com/zerolfx/copilot.el#programming-language-detection][公式の README にも書かれている]]
-
-#+begin_src emacs-lisp :tangle inits/30-copilot.el
-(with-eval-after-load 'copilot
-  (add-to-list 'copilot-major-mode-alist '("enh-ruby" . "ruby")))
-#+end_src
-
-あと何故か忘れたけど inline preview を無効にするような設定を入れている
+あとは company-mode と組み合わせてもそれなりに動くようにするため
+inline preview を無効にするような設定を入れている。
+なおこの設定は[[https://github.com/copilot-emacs/copilot.el#example-for-spacemacs][公式の README の中のコード]]を使っている
 
 #+begin_src emacs-lisp :tangle inits/30-copilot.el
 (with-eval-after-load 'company
@@ -1744,7 +1737,10 @@ save-place-mode を有効にしていると
 #+begin_src emacs-lisp :tangle inits/30-copilot.el
 (with-eval-after-load 'copilot
   (define-key copilot-completion-map (kbd "<tab>") 'copilot-accept-completion)
-  (define-key copilot-completion-map (kbd "TAB") 'copilot-accept-completion))
+  (define-key copilot-completion-map (kbd "TAB") 'copilot-accept-completion)
+  (define-key copilot-completion-map (kbd "M-f") 'copilot-accept-completion-by-word)
+  (define-key copilot-completion-map (kbd "M-n") 'copilot-next-completion)
+  (define-key copilot-completion-map (kbd "M-p") 'copilot-previous-completion))
 #+end_src
 *** warning 非表示
 大きいファイルが開かれると

--- a/inits/30-copilot.el
+++ b/inits/30-copilot.el
@@ -2,15 +2,15 @@
 
 ;; (add-hook 'prog-mode-hook 'copilot-mode)
 
-(with-eval-after-load 'copilot
-  (add-to-list 'copilot-major-mode-alist '("enh-ruby" . "ruby")))
-
 (with-eval-after-load 'company
   ;; disable inline previews
   (delq 'company-preview-if-just-one-frontend company-frontends))
 
 (with-eval-after-load 'copilot
   (define-key copilot-completion-map (kbd "<tab>") 'copilot-accept-completion)
-  (define-key copilot-completion-map (kbd "TAB") 'copilot-accept-completion))
+  (define-key copilot-completion-map (kbd "TAB") 'copilot-accept-completion)
+  (define-key copilot-completion-map (kbd "M-f") 'copilot-accept-completion-by-word)
+  (define-key copilot-completion-map (kbd "M-n") 'copilot-next-completion)
+  (define-key copilot-completion-map (kbd "M-p") 'copilot-previous-completion))
 
 (setq warning-suppress-log-types '((copilot copilot-exceeds-max-char)))


### PR DESCRIPTION
次の候補を見たり word 単位で補完したりしたかったので
それ用にキーバインドを追加した

その際 enh-ruby-mode 用の設定は不要になってることに気付いたので
それは削除している