### PR TITLE
feat: Add docker.el

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,7 @@
 (setq el-get-lock-package-versions
-      '((bundler :checksum "43efb6be4ed118b06d787ce7fbcffd68a31732a7")
+      '((docker :checksum "6f8bba0d11a5143872dfc25afdabe16cae410d11")
+        (emacs-aio :checksum "da93523e235529fa97d6f251319d9e1d6fc24a41")
+        (bundler :checksum "43efb6be4ed118b06d787ce7fbcffd68a31732a7")
         (dmacro :checksum "c714fcdbac3ae57fcc8ff3db94b0e5aededc7468")
         (ruby-refactor :checksum "e6b7125878a08518bffec6942df0c606f748e9ee")
         (pg :checksum "2c32085cee56afb751599941221d52c5e7df3908")

--- a/el-get.lock
+++ b/el-get.lock
@@ -56,7 +56,6 @@
         (mocha :checksum "6a72fa20e7be6e55c09b1bc9887ee09c5df28e45")
         (pdf-tools :checksum "30b50544e55b8dbf683c2d932d5c33ac73323a16")
         (tablist :checksum "faab7a035ef2258cc4ea2182f67e3aedab7e2af9")
-        (aio :checksum "da93523e235529fa97d6f251319d9e1d6fc24a41")
         (git-messenger :checksum "eade986ef529aa2dac6944ad61b18de55cee0b76")
         (lsp-docker :checksum "ce291d0f80533f8eaca120eb745d55669e062636")
         (ivy-kibela :checksum "bd48bfa2ba2e655b435cf9acd6f09d835afe9b14")

--- a/hugo/content/org-mode/org-gcal.md
+++ b/hugo/content/org-mode/org-gcal.md
@@ -27,30 +27,6 @@ org-gcal が依存しているので [parsist](https://elpa.gnu.org/packages/per
 (el-get-bundle org-gcal)
 ```
 
-その際 el-get のレシピは自前で用意している
-
-```emacs-lisp
-(:name org-gcal
-       :description "Org sync with Google Calendar."
-       :website "https://github.com/kidd/org-gcal.el"
-       :type github
-       :minimum-emacs-version "26"
-       :depends (request alert cl-lib aio)
-       :pkgname "kidd/org-gcal.el")
-```
-
-`emacs-aio` も recipe を自前で用意している
-
-```emacs-lisp
-(:name aio
-       :website "https://github.com/skeeto/emacs-aio"
-       :description "aio is to Emacs Lisp as asyncio is to Python."
-       :type github
-       :pkgname "skeeto/emacs-aio")
-```
-
-のだけど確か org-gcal のレシピは修正されているし emacs-aio も recipe 追加されてたはずなので多分これは el-get 本体のものに切り替えても良いはず……
-
 
 ## 設定 {#設定}
 

--- a/hugo/content/programming/docker.md
+++ b/hugo/content/programming/docker.md
@@ -5,10 +5,32 @@ draft = false
 
 ## 概要 {#概要}
 
-Dockerfile を書いたりするための設定。ちゃんと設定したら Emacs から Docker の操作もできるようだけどそこまでは対応してない
+Docker の管理をしたり Dockerfile を書いたりするための設定を書いている
+
+
+## docker.el {#docker-dot-el}
+
+
+### 概要 {#概要}
+
+[docker.el](https://github.com/Silex/docker.el) は Docker のコンテナやらイメージやらを Emacs 上で管理するためのパッケージです。
+
+
+### インストール {#インストール}
+
+el-get 本体にレシピがあるので `el-get-bundle` でインストール
+
+```emacs-lisp
+(el-get-bundle docker)
+```
+
+設定は今のところ特に弄っていません。
+transient が動くのでキーバインドも特に設定していません。
 
 
 ## dockerfile-mode {#dockerfile-mode}
+
+[dockerfile-mode](https://github.com/spotify/dockerfile-mode) は Dockerfile を編集するためのメジャーモード
 
 
 ### インストール {#インストール}

--- a/hugo/content/ui/hydra.md
+++ b/hugo/content/ui/hydra.md
@@ -221,11 +221,11 @@ el-get の Hydra はここで定義してしまっている。その内 el-get �
    (("b" counsel-descbinds "Keybind")
     ("f" counsel-describe-function "Function")
     ("v" counsel-describe-variable "Variable")
-    ;; ("P"   my/open-review-requested-pr "Open Requested PR")
     ("m" describe-minor-mode "Minor mode"))
    "Other"
    (("@" all-the-icons-hydra/body "List icons")
     ("w" which-key-show-top-level "Which key")
+    ("d" docker                   "Docker")
     ("D" my/download-from-beorg))))
 ```
 
@@ -237,6 +237,7 @@ el-get の Hydra はここで定義してしまっている。その内 el-get �
 | m   | minor-mode を調べる                                   |
 | @   | All the icons の Hydra を起動                         |
 | w   | トップレベルのキーバインドを表示する                  |
+| d   | docker.el の起動                                      |
 | D   | beorg 連携に使ってる WebDAV サーバからダウンロード(Dropbox に移行して不要になった) |
 
 

--- a/init.org
+++ b/init.org
@@ -3215,11 +3215,11 @@ el-get の Hydra はここで定義してしまっている。
    (("b" counsel-descbinds "Keybind")
     ("f" counsel-describe-function "Function")
     ("v" counsel-describe-variable "Variable")
-    ;; ("P"   my/open-review-requested-pr "Open Requested PR")
     ("m" describe-minor-mode "Minor mode"))
    "Other"
    (("@" all-the-icons-hydra/body "List icons")
     ("w" which-key-show-top-level "Which key")
+    ("d" docker                   "Docker")
     ("D" my/download-from-beorg))))
 #+end_src
 
@@ -3230,6 +3230,7 @@ el-get の Hydra はここで定義してしまっている。
 | m   | minor-mode を調べる                                                                |
 | @   | All the icons の Hydra を起動                                                      |
 | w   | トップレベルのキーバインドを表示する                                               |
+| d   | docker.el の起動                                                                   |
 | D   | beorg 連携に使ってる WebDAV サーバからダウンロード(Dropbox に移行して不要になった) |
 
 **** Text Scale

--- a/init.org
+++ b/init.org
@@ -9749,31 +9749,6 @@ org-gcal が依存しているので [[https://elpa.gnu.org/packages/persist.htm
 #+begin_src emacs-lisp :tangle inits/61-org-gcal.el
 (el-get-bundle org-gcal)
 #+end_src
-
-その際 el-get のレシピは自前で用意している
-
-#+begin_src emacs-lisp :tangle recipes/org-gcal.rcp
-(:name org-gcal
-       :description "Org sync with Google Calendar."
-       :website "https://github.com/kidd/org-gcal.el"
-       :type github
-       :minimum-emacs-version "26"
-       :depends (request alert cl-lib aio)
-       :pkgname "kidd/org-gcal.el")
-#+end_src
-
-~emacs-aio~ も recipe を自前で用意している
-
-#+begin_src emacs-lisp :tangle recipes/aio.rcp
-(:name aio
-       :website "https://github.com/skeeto/emacs-aio"
-       :description "aio is to Emacs Lisp as asyncio is to Python."
-       :type github
-       :pkgname "skeeto/emacs-aio")
-#+end_src
-
-のだけど確か org-gcal のレシピは修正されているし emacs-aio も recipe 追加されてたはずなので
-多分これは el-get 本体のものに切り替えても良いはず……
 *** 設定
 :PROPERTIES:
 :ID:       247a2cfe-1bee-4293-82fb-b9e68130f258

--- a/init.org
+++ b/init.org
@@ -4991,7 +4991,7 @@ Ruby 書いていたら大体 rubocop も使うので追加
 ここでは各言語やフレームワーク毎の設定をまとめている。
 markdown-mode とか yaml-mode なんかはプログラム言語ではないけど面倒なので一旦ここにまとめている。
 
-- [[id:d8faf854-ed24-464d-b670-b76346fed6b4][Docker]] :: Dockerfile を書くための設定
+- [[id:d8faf854-ed24-464d-b670-b76346fed6b4][Docker]] :: Docker の管理や Dockerfile を書くための設定
 - [[*emacs-lisp][emacs-lisp]] :: Emacs Lisp を書くための設定
 - [[*Ember.js][Ember.js]] :: Web フロントエンド MVC フレームワークである Ember.js 用の設定を書いている
 - [[*es6][es6]] :: ES2015 以降の JS に関する設定。es6 としているのは過去の経緯のため。
@@ -5019,10 +5019,21 @@ markdown-mode とか yaml-mode なんかはプログラム言語ではないけ�
 :ID:       d8faf854-ed24-464d-b670-b76346fed6b4
 :END:
 *** 概要
-Dockerfile を書いたりするための設定。
-ちゃんと設定したら Emacs から Docker の操作もできるようだけど
-そこまでは対応してない
+Docker の管理をしたり Dockerfile を書いたりするための設定を書いている
+*** docker.el
+**** 概要
+[[https://github.com/Silex/docker.el][docker.el]] は Docker のコンテナやらイメージやらを Emacs 上で管理するためのパッケージです。
+**** インストール
+el-get 本体にレシピがあるので ~el-get-bundle~ でインストール
+
+#+begin_src emacs-lisp :tangle inits/50-docker.el
+(el-get-bundle docker)
+#+end_src
+
+設定は今のところ特に弄っていません。
+transient が動くのでキーバインドも特に設定していません。
 *** dockerfile-mode
+[[https://github.com/spotify/dockerfile-mode][dockerfile-mode]] は Dockerfile を編集するためのメジャーモード
 **** インストール
 :PROPERTIES:
 :ID:       88f3745f-2c1a-4df1-ab75-6ee3270933b3

--- a/inits/50-docker.el
+++ b/inits/50-docker.el
@@ -1,0 +1,1 @@
+(el-get-bundle docker)

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -75,11 +75,11 @@
    (("b" counsel-descbinds "Keybind")
     ("f" counsel-describe-function "Function")
     ("v" counsel-describe-variable "Variable")
-    ;; ("P"   my/open-review-requested-pr "Open Requested PR")
     ("m" describe-minor-mode "Minor mode"))
    "Other"
    (("@" all-the-icons-hydra/body "List icons")
     ("w" which-key-show-top-level "Which key")
+    ("d" docker                   "Docker")
     ("D" my/download-from-beorg))))
 
 (pretty-hydra-define text-scale-hydra (:separator "-" :title (concat (all-the-icons-material "text_fields") " Text Scale") :exit nil :quit-key "q")

--- a/recipes/aio.rcp
+++ b/recipes/aio.rcp
@@ -1,5 +1,0 @@
-(:name aio
-       :website "https://github.com/skeeto/emacs-aio"
-       :description "aio is to Emacs Lisp as asyncio is to Python."
-       :type github
-       :pkgname "skeeto/emacs-aio")

--- a/recipes/org-gcal.rcp
+++ b/recipes/org-gcal.rcp
@@ -3,5 +3,5 @@
        :website "https://github.com/kidd/org-gcal.el"
        :type github
        :minimum-emacs-version "26"
-       :depends (request alert cl-lib aio)
+       :depends (request alert cl-lib emacs-aio)
        :pkgname "kidd/org-gcal.el")

--- a/recipes/org-gcal.rcp
+++ b/recipes/org-gcal.rcp
@@ -1,7 +1,0 @@
-(:name org-gcal
-       :description "Org sync with Google Calendar."
-       :website "https://github.com/kidd/org-gcal.el"
-       :type github
-       :minimum-emacs-version "26"
-       :depends (request alert cl-lib emacs-aio)
-       :pkgname "kidd/org-gcal.el")


### PR DESCRIPTION
# 概要

docker.el を導入してそれを Hydra から呼び出せるようにした

# その他

org-gcal のレシピを el-get 本体に付属しているものを使うように修正した。

docker.el が emacs-aio に依存していてそれが入って来たが
以前に自前で定義した org-gcal のレシピの定義だと emacs-aio のレシピを aio で定義していて
二重インストールになってしまっていたのでその是正を目的としている