### PR TITLE
fix: Revert unnecessary texi file changes

### DIFF
--- a/hugo/content/external-tool/magit.md
+++ b/hugo/content/external-tool/magit.md
@@ -68,6 +68,53 @@ ref: <https://github.com/mugijiru/.emacs.d/pull/2992>
        :website "https://elpa.gnu.org/packages/seq.html")
 ```
 
+transient や forge は el-get にあるレシピでは info を build するようになっているが
+build されるとリポジトリに差分が発生して update ができなくなるのでその差分はなかったことにするようにしている
+
+```emacs-lisp
+(:name transient
+       :website "https://github.com/magit/transient#readme"
+       :description "Transient commands used by magit."
+       :type github
+       :pkgname "magit/transient"
+       :branch "main"
+       :minimum-emacs-version "25.1"
+       :info "docs"
+       :load-path "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+                ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+                               "info"))
+       ;; Assume windows lacks a build environment.
+       :build/windows-nt (with-temp-file "lisp/transient-autoloads.el" nil))
+```
+
+```emacs-lisp
+(:name forge
+       :website "https://github.com/magit/forge#readme"
+       :description "Work with Git forges from the comfort of Magit."
+       :type github
+       :pkgname "magit/forge"
+       :branch "main"
+       :minimum-emacs-version "25.1"
+       ;; The package.el dependency is on `emacsql-sqlite', but el-get
+       ;; provides that via `emacsql'.
+       :depends (compat closql dash emacsql ghub let-alist magit markdown-mode
+                        seq transient yaml)
+       :info "docs"
+       :load-path "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+                ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+                               "info")))
+```
+
 そして `el-get-bundle` でインストールしている
 
 ```emacs-lisp

--- a/init.org
+++ b/init.org
@@ -7804,6 +7804,54 @@ ref: https://github.com/mugijiru/.emacs.d/pull/2992
        :website "https://elpa.gnu.org/packages/seq.html")
 #+end_src
 
+transient や forge は el-get にあるレシピでは info を build するようになっているが
+build されるとリポジトリに差分が発生して update ができなくなるので
+その差分はなかったことにするようにしている
+
+#+begin_src emacs-lisp :tangle recipes/transient.rcp
+(:name transient
+       :website "https://github.com/magit/transient#readme"
+       :description "Transient commands used by magit."
+       :type github
+       :pkgname "magit/transient"
+       :branch "main"
+       :minimum-emacs-version "25.1"
+       :info "docs"
+       :load-path "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+                ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+                               "info"))
+       ;; Assume windows lacks a build environment.
+       :build/windows-nt (with-temp-file "lisp/transient-autoloads.el" nil))
+#+end_src
+
+#+begin_src emacs-lisp :tangle recipes/forge.rcp
+(:name forge
+       :website "https://github.com/magit/forge#readme"
+       :description "Work with Git forges from the comfort of Magit."
+       :type github
+       :pkgname "magit/forge"
+       :branch "main"
+       :minimum-emacs-version "25.1"
+       ;; The package.el dependency is on `emacsql-sqlite', but el-get
+       ;; provides that via `emacsql'.
+       :depends (compat closql dash emacsql ghub let-alist magit markdown-mode
+                        seq transient yaml)
+       :info "docs"
+       :load-path "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+                ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+                               "info")))
+#+end_src
+
 そして ~el-get-bundle~ でインストールしている
 
 #+begin_src emacs-lisp :tangle inits/35-magit.el

--- a/recipes/forge.rcp
+++ b/recipes/forge.rcp
@@ -1,0 +1,20 @@
+(:name forge
+       :website "https://github.com/magit/forge#readme"
+       :description "Work with Git forges from the comfort of Magit."
+       :type github
+       :pkgname "magit/forge"
+       :branch "main"
+       :minimum-emacs-version "25.1"
+       ;; The package.el dependency is on `emacsql-sqlite', but el-get
+       ;; provides that via `emacsql'.
+       :depends (compat closql dash emacsql ghub let-alist magit markdown-mode
+                        seq transient yaml)
+       :info "docs"
+       :load-path "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+                ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+                               "info")))

--- a/recipes/transient.rcp
+++ b/recipes/transient.rcp
@@ -1,0 +1,18 @@
+(:name transient
+       :website "https://github.com/magit/transient#readme"
+       :description "Transient commands used by magit."
+       :type github
+       :pkgname "magit/transient"
+       :branch "main"
+       :minimum-emacs-version "25.1"
+       :info "docs"
+       :load-path "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+                ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+                               "info"))
+       ;; Assume windows lacks a build environment.
+       :build/windows-nt (with-temp-file "lisp/transient-autoloads.el" nil))


### PR DESCRIPTION
build によって texi ファイルに差分が生まれて
git pull ができなくなっていたので
texi ファイルの変更はなかったことにするようにした