### PR TITLE
fix: Set copilot-indent-offset-warning-disable

### DIFF
--- a/hugo/content/editing/copilot.md
+++ b/hugo/content/editing/copilot.md
@@ -85,3 +85,9 @@ Warning (copilot): .loaddefs.el size exceeds 'copilot-max-char' (100000), copilo
 ```emacs-lisp
 (setq warning-suppress-log-types '((copilot copilot-exceeds-max-char)))
 ```
+
+またデフォルトだと indent offset は設定が見つからない時に warning を出すようになっているが結構邪魔なのでとりあえずオフにしている
+
+```emacs-lisp
+(setopt copilot-indent-offset-warning-disable t)
+```

--- a/init.org
+++ b/init.org
@@ -1742,6 +1742,13 @@ Warning (copilot): .loaddefs.el size exceeds 'copilot-max-char' (100000), copilo
 #+begin_src emacs-lisp :tangle inits/30-copilot.el
 (setq warning-suppress-log-types '((copilot copilot-exceeds-max-char)))
 #+end_src
+
+またデフォルトだと indent offset は設定が見つからない時に warning を出すようになっているが
+結構邪魔なのでとりあえずオフにしている
+
+#+begin_src emacs-lisp :tangle inits/30-copilot.el
+(setopt copilot-indent-offset-warning-disable t)
+#+end_src
 ** dmacro
 :PROPERTIES:
 :EXPORT_FILE_NAME: dmacro

--- a/inits/30-copilot.el
+++ b/inits/30-copilot.el
@@ -14,3 +14,5 @@
   (define-key copilot-completion-map (kbd "M-p") 'copilot-previous-completion))
 
 (setq warning-suppress-log-types '((copilot copilot-exceeds-max-char)))
+
+(setopt copilot-indent-offset-warning-disable t)


### PR DESCRIPTION
indent offset の設定が見つからない時に warning を出す設定だが
結構邪魔なのでとりあえず無視することにした