### PR TITLE
ci: Ignore compiles files on package update workflow

### DIFF
--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -24,6 +24,10 @@ jobs:
 
     - uses: actions/checkout@v4
 
+    - name: Ignore compiled files
+      run: |
+        mkdir -p ~/.config/git/
+        echo "*.elc" >> ~/.config/git/ignore
     - name: Update package
       run: |
         emacs -Q --batch --eval "(setq user-emacs-directory \"$(pwd)/\")" \


### PR DESCRIPTION
*.elc ファイルが自動生成されていて
パッケージ更新ができないことがあるので無視するようにした