### PR TITLE
fix: Setup agenda config after load org-agenda

### DIFF
--- a/hugo/content/org-mode/org-commands.md
+++ b/hugo/content/org-mode/org-commands.md
@@ -141,12 +141,12 @@ org-journal で作られたその日のファイルを
 org-clock-report の対象にしたくて org-agenda-files をいい感じにするコマンドを用意した。まだ Hydra には組み込んでないけど、とりあえず M-x で呼び出して使うつもり
 
 ```emacs-lisp
-(with-eval-after-load 'org-mode
+(with-eval-after-load 'org-agenda
   (setq my/org-agenda-files--original (copy-sequence org-agenda-files))
 
   (defun my/reset-org-agenda-files ()
-  (interactive)
-  (let ((tmp my/org-agenda-files--original))
-    (setq org-agenda-files
-          (cl-pushnew (org-journal--get-entry-path) tmp)))))
+    (interactive)
+    (let ((tmp my/org-agenda-files--original))
+      (setq org-agenda-files
+            (cl-pushnew (org-journal--get-entry-path) tmp)))))
 ```

--- a/init.org
+++ b/init.org
@@ -10983,14 +10983,14 @@ org-clock-report の対象にしたくて org-agenda-files をいい感じにす
 まだ Hydra には組み込んでないけど、とりあえず M-x で呼び出して使うつもり
 
 #+begin_src emacs-lisp :tangle inits/68-my-org-commands.el
-(with-eval-after-load 'org-mode
+(with-eval-after-load 'org-agenda
   (setq my/org-agenda-files--original (copy-sequence org-agenda-files))
 
   (defun my/reset-org-agenda-files ()
-  (interactive)
-  (let ((tmp my/org-agenda-files--original))
-    (setq org-agenda-files
-          (cl-pushnew (org-journal--get-entry-path) tmp)))))
+    (interactive)
+    (let ((tmp my/org-agenda-files--original))
+      (setq org-agenda-files
+            (cl-pushnew (org-journal--get-entry-path) tmp)))))
 #+end_src
 ** org-mode 関係の keybinds
 :PROPERTIES:

--- a/inits/68-my-org-commands.el
+++ b/inits/68-my-org-commands.el
@@ -56,11 +56,11 @@ Hydra から利用するために定義している。"
          (response (shell-command-to-string cmd)))
     (insert response)))
 
-(with-eval-after-load 'org-mode
+(with-eval-after-load 'org-agenda
   (setq my/org-agenda-files--original (copy-sequence org-agenda-files))
 
   (defun my/reset-org-agenda-files ()
-  (interactive)
-  (let ((tmp my/org-agenda-files--original))
-    (setq org-agenda-files
-          (cl-pushnew (org-journal--get-entry-path) tmp)))))
+    (interactive)
+    (let ((tmp my/org-agenda-files--original))
+      (setq org-agenda-files
+            (cl-pushnew (org-journal--get-entry-path) tmp)))))


### PR DESCRIPTION
うまく読み込みができていなかったので修正。

その際に org-agenda の設定だよなあと思い、
それが読まれたら設定する、という挙動に修正した