### PR TITLE
fix(keybinds): correct neotree-toggle keybinding syntax

### DIFF
--- a/hugo/content/keybinds/global-keybinds.md
+++ b/hugo/content/keybinds/global-keybinds.md
@@ -167,7 +167,7 @@ Helm から乗り換えて今はこちらをメインで使っている。基本
 Neotree]] は IDE みたいにファイルツリーを表示を表示するパッケージ。有効にしているとちょっぴりモダンな雰囲気になるぞい。
 
 ```emacs-lisp
-(keymap-global-set "<f8>" 'neotree-toggle[f8])
+(keymap-global-set "<f8>" 'neotree-toggle)
 ```
 
 f8 にバインドしているけど

--- a/init.org
+++ b/init.org
@@ -1426,7 +1426,7 @@ Neotree]] は IDE みたいにファイルツリーを表示を表示するパ�
 有効にしているとちょっぴりモダンな雰囲気になるぞい。
 
 #+begin_src emacs-lisp :tangle inits/80-global-keybinds.el
-(keymap-global-set "<f8>" 'neotree-toggle[f8])
+(keymap-global-set "<f8>" 'neotree-toggle)
 #+end_src
 
 f8 にバインドしているけど

--- a/inits/80-global-keybinds.el
+++ b/inits/80-global-keybinds.el
@@ -37,7 +37,7 @@
 
 (keymap-global-set "C-x 1" 'zoom-window-zoom)
 
-(keymap-global-set "<f8>" 'neotree-toggle[f8])
+(keymap-global-set "<f8>" 'neotree-toggle)
 
 (setq my/org-mode-prefix-key "C-c o ")
 (keymap-global-set (concat my/org-mode-prefix-key "a") 'org-agenda)


### PR DESCRIPTION
編集時にミスって変なのが入ってた