### PR TITLE
ci: Remove old emacs from ci testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 27.2
-          - 28.2
           - 29.4
 
     steps:


### PR DESCRIPTION
Emacs 29.1 以降に依存しているパッケージやコードがあるので
古い Emacs ではテストしないようにした