### PR TITLE
fix: Specify EMACS environment variable for magit family

### DIFF
--- a/hugo/content/external-tool/magit.md
+++ b/hugo/content/external-tool/magit.md
@@ -35,9 +35,9 @@ ref: <https://github.com/mugijiru/.emacs.d/pull/2992>
        ;; handle compilation and autoloads on its own.  Create an
        ;; empty autoloads file because magit.el explicitly checks for
        ;; a file of that name.
-       :build `(;; ("make" ,(format "EMACSBIN=%s" el-get-emacs) "docs") do not build manual
+       :build `(;; ("make" ,(format "EMACS=%s" el-get-emacs) "docs") do not build manual
                 ("touch" "lisp/magit-autoloads.el"))
-       :build/berkeley-unix `(;; ("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+       :build/berkeley-unix `(;; ("gmake" ,(format "EMACS=%s" el-get-emacs) "docs")
                               ("touch" "lisp/magit-autoloads.el"))
        ;; assume windows lacks make and makeinfo
        :build/windows-nt (with-temp-file "lisp/magit-autoloads.el" nil))
@@ -56,9 +56,9 @@ ref: <https://github.com/mugijiru/.emacs.d/pull/2992>
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
                 ("git" "checkout" "**/*.texi")) ;; Avoid the need for a clean checkout
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))
 ```
 
@@ -85,9 +85,9 @@ build されるとリポジトリに差分が発生して update ができなく
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
                 ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info"))
        ;; Assume windows lacks a build environment.
        :build/windows-nt (with-temp-file "lisp/transient-autoloads.el" nil))
@@ -110,9 +110,9 @@ build されるとリポジトリに差分が発生して update ができなく
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
                 ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))
 ```
 
@@ -146,8 +146,8 @@ ghub は compat に依存するようになったのでとりあえず自前で 
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info"))
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info"))
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))
 ```
 

--- a/init.org
+++ b/init.org
@@ -8048,9 +8048,9 @@ ref: https://github.com/mugijiru/.emacs.d/pull/2992
        ;; handle compilation and autoloads on its own.  Create an
        ;; empty autoloads file because magit.el explicitly checks for
        ;; a file of that name.
-       :build `(;; ("make" ,(format "EMACSBIN=%s" el-get-emacs) "docs") do not build manual
+       :build `(;; ("make" ,(format "EMACS=%s" el-get-emacs) "docs") do not build manual
                 ("touch" "lisp/magit-autoloads.el"))
-       :build/berkeley-unix `(;; ("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+       :build/berkeley-unix `(;; ("gmake" ,(format "EMACS=%s" el-get-emacs) "docs")
                               ("touch" "lisp/magit-autoloads.el"))
        ;; assume windows lacks make and makeinfo
        :build/windows-nt (with-temp-file "lisp/magit-autoloads.el" nil))
@@ -8069,9 +8069,9 @@ ref: https://github.com/mugijiru/.emacs.d/pull/2992
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
                 ("git" "checkout" "**/*.texi")) ;; Avoid the need for a clean checkout
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))
 #+end_src
 
@@ -8099,9 +8099,9 @@ build されるとリポジトリに差分が発生して update ができなく
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
                 ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info"))
        ;; Assume windows lacks a build environment.
        :build/windows-nt (with-temp-file "lisp/transient-autoloads.el" nil))
@@ -8124,9 +8124,9 @@ build されるとリポジトリに差分が発生して update ができなく
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
                 ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))
 #+end_src
 
@@ -8161,8 +8161,8 @@ ghub は compat に依存するようになったのでとりあえず自前で 
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info"))
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info"))
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))
 #+end_src
 *** 使い方

--- a/recipes/forge.rcp
+++ b/recipes/forge.rcp
@@ -14,7 +14,7 @@
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
                 ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))

--- a/recipes/ghub.rcp
+++ b/recipes/ghub.rcp
@@ -9,6 +9,6 @@
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info"))
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info"))
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))

--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -15,9 +15,9 @@
        ;; handle compilation and autoloads on its own.  Create an
        ;; empty autoloads file because magit.el explicitly checks for
        ;; a file of that name.
-       :build `(;; ("make" ,(format "EMACSBIN=%s" el-get-emacs) "docs") do not build manual
+       :build `(;; ("make" ,(format "EMACS=%s" el-get-emacs) "docs") do not build manual
                 ("touch" "lisp/magit-autoloads.el"))
-       :build/berkeley-unix `(;; ("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+       :build/berkeley-unix `(;; ("gmake" ,(format "EMACS=%s" el-get-emacs) "docs")
                               ("touch" "lisp/magit-autoloads.el"))
        ;; assume windows lacks make and makeinfo
        :build/windows-nt (with-temp-file "lisp/magit-autoloads.el" nil))

--- a/recipes/transient.rcp
+++ b/recipes/transient.rcp
@@ -10,9 +10,9 @@
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
                 ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info"))
        ;; Assume windows lacks a build environment.
        :build/windows-nt (with-temp-file "lisp/transient-autoloads.el" nil))

--- a/recipes/with-editor.rcp
+++ b/recipes/with-editor.rcp
@@ -8,7 +8,7 @@
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
                 ("git" "checkout" "**/*.texi")) ;; Avoid the need for a clean checkout
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+       :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))


### PR DESCRIPTION
el-get 本体で magit 系のレシピが修正されたので
同じ修正を取り入れる。

もしかしたらこの修正で
パッケージ更新時に info の中身が書き換えられて困る問題も解決するかもしれないけど
その検証は面倒なので今度にする