### PR TITLE
feat: Implement my/copy-file-path command

### DIFF
--- a/hugo/content/others.md
+++ b/hugo/content/others.md
@@ -1,0 +1,17 @@
++++
+title = "その他"
+draft = false
++++
+
+## ファイルパスをコピーするコマンド {#ファイルパスをコピーするコマンド}
+
+単にファイルパスをコピーしたい時があるので適当にそういうコマンドを用意している
+
+```emacs-lisp
+(defun my/copy-file-path ()
+  "Copy the current buffer file path to the clipboard."
+  (interactive)
+    (when buffer-file-name
+      (kill-new buffer-file-name)
+      (message "Copied buffer file path '%s' to the clipboard." buffer-file-name)))
+```

--- a/hugo/content/ui/hydra.md
+++ b/hugo/content/ui/hydra.md
@@ -211,18 +211,20 @@ el-get の Hydra はここで定義してしまっている。その内 el-get �
    "Other"
    (("@" all-the-icons-hydra/body "List icons")
     ("w" which-key-show-top-level "Which key")
+    ("P" my/copy-file-path        "Get path")
     ("d" docker                   "Docker"))))
 ```
 
-| Key | 効果                      |
-|-----|-------------------------|
-| b   | キーバインドを調べる      |
-| f   | Emacs Lisp の関数を調べる |
-| v   | Emacs Lisp の変数を調べる |
-| m   | minor-mode を調べる       |
+| Key | 効果                         |
+|-----|----------------------------|
+| b   | キーバインドを調べる         |
+| f   | Emacs Lisp の関数を調べる    |
+| v   | Emacs Lisp の変数を調べる    |
+| m   | minor-mode を調べる          |
 | @   | All the icons の Hydra を起動 |
 | w   | トップレベルのキーバインドを表示する |
-| d   | docker.el の起動          |
+| P   | 現在のバッファの path をクリップボードにコピーする |
+| d   | docker.el の起動             |
 
 
 ### Text Scale {#text-scale}

--- a/init.org
+++ b/init.org
@@ -11291,7 +11291,22 @@ agenda 全然使えてなかったらこんなことに。
 その中では [[https://github.com/alphapapa/org-ql][org-ql]] の org-ql-search という関数を叩いている。
 org-ql は使いこなすと色々なことができそうではあるが
 それを内部で使ってる [[https://github.com/alphapapa/org-super-agenda][org-super-agenda]] を使えば十分な感じではある。
+* その他
+:PROPERTIES:
+:EXPORT_FILE_NAME: others
+:END:
+** ファイルパスをコピーするコマンド
+単にファイルパスをコピーしたい時があるので
+適当にそういうコマンドを用意している
 
+#+begin_src emacs-lisp :tangle inits/80-my-commands.org
+(defun my/copy-file-path ()
+  "Copy the current buffer file path to the clipboard."
+  (interactive)
+    (when buffer-file-name
+      (kill-new buffer-file-name)
+      (message "Copied buffer file path '%s' to the clipboard." buffer-file-name)))
+#+end_src
 * テスト用ツール
 :PROPERTIES:
 :EXPORT_HUGO_SECTION: testing-tool

--- a/init.org
+++ b/init.org
@@ -3284,17 +3284,19 @@ el-get の Hydra はここで定義してしまっている。
    "Other"
    (("@" all-the-icons-hydra/body "List icons")
     ("w" which-key-show-top-level "Which key")
+    ("P" my/copy-file-path        "Get path")
     ("d" docker                   "Docker"))))
 #+end_src
 
-| Key | 効果                                                                               |
-| b   | キーバインドを調べる                                                               |
-| f   | Emacs Lisp の関数を調べる                                                          |
-| v   | Emacs Lisp の変数を調べる                                                          |
-| m   | minor-mode を調べる                                                                |
-| @   | All the icons の Hydra を起動                                                      |
-| w   | トップレベルのキーバインドを表示する                                               |
-| d   | docker.el の起動                                                                   |
+| Key | 効果                                               |
+| b   | キーバインドを調べる                               |
+| f   | Emacs Lisp の関数を調べる                          |
+| v   | Emacs Lisp の変数を調べる                          |
+| m   | minor-mode を調べる                                |
+| @   | All the icons の Hydra を起動                      |
+| w   | トップレベルのキーバインドを表示する               |
+| P   | 現在のバッファの path をクリップボードにコピーする |
+| d   | docker.el の起動                                   |
 
 **** Text Scale
 :PROPERTIES:

--- a/init.org
+++ b/init.org
@@ -11301,7 +11301,7 @@ org-ql は使いこなすと色々なことができそうではあるが
 単にファイルパスをコピーしたい時があるので
 適当にそういうコマンドを用意している
 
-#+begin_src emacs-lisp :tangle inits/80-my-commands.org
+#+begin_src emacs-lisp :tangle inits/80-my-commands.el
 (defun my/copy-file-path ()
   "Copy the current buffer file path to the clipboard."
   (interactive)

--- a/inits/80-my-commands.el
+++ b/inits/80-my-commands.el
@@ -1,0 +1,6 @@
+(defun my/copy-file-path ()
+  "Copy the current buffer file path to the clipboard."
+  (interactive)
+    (when buffer-file-name
+      (kill-new buffer-file-name)
+      (message "Copied buffer file path '%s' to the clipboard." buffer-file-name)))

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -75,6 +75,7 @@
    "Other"
    (("@" all-the-icons-hydra/body "List icons")
     ("w" which-key-show-top-level "Which key")
+    ("P" my/copy-file-path        "Get path")
     ("d" docker                   "Docker"))))
 
 (pretty-hydra-define text-scale-hydra (:separator "-" :title (concat (all-the-icons-material "text_fields") " Text Scale") :exit nil :quit-key "q")


### PR DESCRIPTION
たまにそのファイルの path なんかをコピーして
Terminal とかに貼り付けたくなる時があるので
簡単にクリップボードにコピーできるコマンドを用意した