### PR TITLE
fix(copilot): Use copilot-max-char-warning-disable instead.

### DIFF
--- a/hugo/content/editing/copilot.md
+++ b/hugo/content/editing/copilot.md
@@ -83,7 +83,7 @@ Warning (copilot): .loaddefs.el size exceeds 'copilot-max-char' (100000), copilo
 とか出るけど、そんなもんは分かってるので warning が出ないように黙らせている
 
 ```emacs-lisp
-(setq warning-suppress-log-types '((copilot copilot-exceeds-max-char)))
+(setopt copilot-max-char-warning-disable t)
 ```
 
 またデフォルトだと indent offset は設定が見つからない時に warning を出すようになっているが結構邪魔なのでとりあえずオフにしている

--- a/init.org
+++ b/init.org
@@ -1741,7 +1741,7 @@ Warning (copilot): .loaddefs.el size exceeds 'copilot-max-char' (100000), copilo
 とか出るけど、そんなもんは分かってるので warning が出ないように黙らせている
 
 #+begin_src emacs-lisp :tangle inits/30-copilot.el
-(setq warning-suppress-log-types '((copilot copilot-exceeds-max-char)))
+(setopt copilot-max-char-warning-disable t)
 #+end_src
 
 またデフォルトだと indent offset は設定が見つからない時に warning を出すようになっているが

--- a/inits/30-copilot.el
+++ b/inits/30-copilot.el
@@ -13,7 +13,7 @@
   (define-key copilot-completion-map (kbd "M-n") 'copilot-next-completion)
   (define-key copilot-completion-map (kbd "M-p") 'copilot-previous-completion))
 
-(setq warning-suppress-log-types '((copilot copilot-exceeds-max-char)))
+(setopt copilot-max-char-warning-disable t)
 
 (setopt copilot-indent-offset-warning-disable t)
 


### PR DESCRIPTION
新しく追加された変数でやりたいことができるようになったようなので
そちらを使うように置き換えた