### PR TITLE
chore: Bump org-mode to 9.7(retry)

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -37,7 +37,7 @@
         (ob-graphql :checksum "7c35419f9eec5dc44967cbcfa13c7135b9a96bfc")
         (corfu :checksum "c7626a699b55c53a389916ef1816c59e1b853b9b")
         (treesit-auto :checksum "016bd286a1ba4628f833a626f8b9d497882ecdf3")
-        (org-mode :checksum "071c6e986c424d2e496be7d0815d6e9cd83ae4e6")
+        (org-mode :checksum "5a4686915e568ace469f490c0606d2a016c1101c")
         (org-journal :checksum "17b34ce8df9649a73b715c13698220bde1628668")
         (company-terraform :checksum "8d5a16d1bbeeb18ca49a8fd57b5d8cd30c8b8dc7")
         (terraform-mode :checksum "5bdd734a87f67f6574664f63eb4d02a0bc74c0d0")

--- a/hugo/content/org-mode/base.md
+++ b/hugo/content/org-mode/base.md
@@ -25,7 +25,7 @@ Emacs に標準で入っている org-mode は古かったりするのでとり�
        :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
        :type git
        :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
-       :checkout "release_9.6.30"
+       :checkout "release_9.7.19"
        :info "doc"
        :build/berkeley-unix `,(mapcar
                                (lambda (target)

--- a/init.org
+++ b/init.org
@@ -8723,7 +8723,7 @@ Emacs に標準で入っている org-mode は古かったりするので
        :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
        :type git
        :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
-       :checkout "release_9.6.30"
+       :checkout "release_9.7.19"
        :info "doc"
        :build/berkeley-unix `,(mapcar
                                (lambda (target)

--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -3,7 +3,7 @@
        :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
        :type git
        :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
-       :checkout "release_9.6.30"
+       :checkout "release_9.7.19"
        :info "doc"
        :build/berkeley-unix `,(mapcar
                                (lambda (target)


### PR DESCRIPTION
# 概要

org-mode を再度 9.7 に上げます。

# 経緯

https://github.com/mugijiru/.emacs.d/pull/5404 で上げたけど
ox-hugo とか org-gcal がうまく動かなかったので
https://github.com/mugijiru/.emacs.d/pull/5411 で下げた。

なのだけど org-mode を更新した後に
org-gcal や ox-hugo の elc をコンパイルし直せば動くと聞いて
試してみたところ大丈夫そうなので上げます