### PR TITLE
fix: Update magit family recipes

### DIFF
--- a/hugo/content/external-tool/magit.md
+++ b/hugo/content/external-tool/magit.md
@@ -27,7 +27,7 @@ ref: <https://github.com/mugijiru/.emacs.d/pull/2992>
        :minimum-emacs-version "26.1"
        ;; Note: `git-commit' is shipped with `magit' code itself.
        ;; Note: `magit-section' is shipped with `magit' code itself.
-       :depends (dash transient with-editor compat seq)
+       :depends (llama transient with-editor compat seq)
        ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"

--- a/hugo/content/external-tool/magit.md
+++ b/hugo/content/external-tool/magit.md
@@ -80,13 +80,13 @@ build されるとリポジトリに差分が発生して update ができなく
        :pkgname "magit/transient"
        :branch "main"
        :minimum-emacs-version "25.1"
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
-                ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
+       ;; :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
+       ;;          ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
        :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info"))
        ;; Assume windows lacks a build environment.
@@ -105,13 +105,13 @@ build されるとリポジトリに差分が発生して update ができなく
        ;; provides that via `emacsql'.
        :depends (compat closql llama emacsql ghub let-alist magit markdown-mode
                         seq transient yaml)
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
-                ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
+       ;; :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
+       ;;          ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
        :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))
 ```
@@ -141,12 +141,12 @@ ghub は compat に依存するようになったのでとりあえず自前で 
        :pkgname "magit/ghub"
        :depends (let-alist treepy compat llama)
        :branch "main"
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info"))
+       ;; :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info"))
        :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))
 ```

--- a/init.org
+++ b/init.org
@@ -8183,7 +8183,7 @@ ref: https://github.com/mugijiru/.emacs.d/pull/2992
        :minimum-emacs-version "26.1"
        ;; Note: `git-commit' is shipped with `magit' code itself.
        ;; Note: `magit-section' is shipped with `magit' code itself.
-       :depends (dash transient with-editor compat seq)
+       :depends (llama transient with-editor compat seq)
        ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"

--- a/init.org
+++ b/init.org
@@ -8237,13 +8237,13 @@ build されるとリポジトリに差分が発生して update ができなく
        :pkgname "magit/transient"
        :branch "main"
        :minimum-emacs-version "25.1"
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
-                ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
+       ;; :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
+       ;;          ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
        :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info"))
        ;; Assume windows lacks a build environment.
@@ -8262,13 +8262,13 @@ build されるとリポジトリに差分が発生して update ができなく
        ;; provides that via `emacsql'.
        :depends (compat closql llama emacsql ghub let-alist magit markdown-mode
                         seq transient yaml)
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
-                ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
+       ;; :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
+       ;;          ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
        :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))
 #+end_src
@@ -8299,12 +8299,12 @@ ghub は compat に依存するようになったのでとりあえず自前で 
        :pkgname "magit/ghub"
        :depends (let-alist treepy compat llama)
        :branch "main"
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info"))
+       ;; :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info"))
        :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))
 #+end_src

--- a/recipes/forge.rcp
+++ b/recipes/forge.rcp
@@ -9,12 +9,12 @@
        ;; provides that via `emacsql'.
        :depends (compat closql llama emacsql ghub let-alist magit markdown-mode
                         seq transient yaml)
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
-                ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
+       ;; :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
+       ;;          ("git" "checkout" "docs/forge.texi")) ;; fix: Revert docs/forge.texi changes
        :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))

--- a/recipes/ghub.rcp
+++ b/recipes/ghub.rcp
@@ -4,11 +4,11 @@
        :pkgname "magit/ghub"
        :depends (let-alist treepy compat llama)
        :branch "main"
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info"))
+       ;; :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info"))
        :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info")))

--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -7,7 +7,7 @@
        :minimum-emacs-version "26.1"
        ;; Note: `git-commit' is shipped with `magit' code itself.
        ;; Note: `magit-section' is shipped with `magit' code itself.
-       :depends (dash transient with-editor compat seq)
+       :depends (llama transient with-editor compat seq)
        ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"

--- a/recipes/transient.rcp
+++ b/recipes/transient.rcp
@@ -5,13 +5,13 @@
        :pkgname "magit/transient"
        :branch "main"
        :minimum-emacs-version "25.1"
-       :info "docs"
+       ;; :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
-       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
-                ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
+       ;; :build `(("make" ,(format "EMACS=%s" el-get-emacs) "info")
+       ;;          ("git" "checkout" "docs/transient.texi")) ;; fix: Revert docs/transient.texi changes
        :build/berkeley-unix `(("gmake" ,(format "EMACS=%s" el-get-emacs)
                                "info"))
        ;; Assume windows lacks a build environment.


### PR DESCRIPTION
magit 関係の各パッケージのレシピを修正した

magit 本体は依存関係が変わったのに追従させておいた。

それ以外は、自分が Emacs 本体の org-mode を削除した影響で
info が build/install できなくなったようなので
そのあたりの処理をしないように調整した