### PR TITLE
fix: Improve copilot-chat settings for v2.0

### DIFF
--- a/hugo/content/editing/copilot-chat.md
+++ b/hugo/content/editing/copilot-chat.md
@@ -41,7 +41,7 @@ GitHub Copilot Chat を有効にするための認証コードとメッセージ
 色々使っていると frontend は `shell-maker` の方が使いやすいっぽいのでそれを指定している
 
 ```emacs-lisp
-(setopt copilot-chat-frontend 'shell-maker)
+(setopt copilot-chat-frontend 'org)
 ```
 
 また出力は日本語の方が日本人には嬉しいのでひとまず `copilot-chat-prompt` の末尾に日本語を出力するように指定している。

--- a/hugo/content/editing/copilot-chat.md
+++ b/hugo/content/editing/copilot-chat.md
@@ -18,7 +18,7 @@ el-get 本体にはレシピがないので自前で用意している。なお�
        :description "This plugin allows you to chat with github copilot."
        :type github
        :pkgname "chep/copilot-chat.el"
-       :depends (request markdown-mode chatgpt-shell magit transient org-mode shell-maker))
+       :depends (request markdown-mode magit transient org-mode polymode))
 ```
 
 そして `el-get-bundle` でインストールしている

--- a/init.org
+++ b/init.org
@@ -1911,7 +1911,7 @@ el-get 本体にはレシピがないので自前で用意している。
        :description "This plugin allows you to chat with github copilot."
        :type github
        :pkgname "chep/copilot-chat.el"
-       :depends (request markdown-mode chatgpt-shell magit transient org-mode shell-maker))
+       :depends (request markdown-mode magit transient org-mode polymode))
 #+end_src
 
 そして ~el-get-bundle~ でインストールしている

--- a/init.org
+++ b/init.org
@@ -1930,7 +1930,7 @@ GitHub Copilot Chat を有効にするための認証コードとメッセージ
 色々使っていると frontend は ~shell-maker~ の方が使いやすいっぽいのでそれを指定している
 
 #+begin_src emacs-lisp :tangle inits/30-copilot.el
-(setopt copilot-chat-frontend 'shell-maker)
+(setopt copilot-chat-frontend 'org)
 #+end_src
 
 また出力は日本語の方が日本人には嬉しいので

--- a/inits/30-copilot.el
+++ b/inits/30-copilot.el
@@ -19,7 +19,7 @@
 
 (el-get-bundle copilot-chat)
 
-(setopt copilot-chat-frontend 'shell-maker)
+(setopt copilot-chat-frontend 'org)
 
 (with-eval-after-load 'copilot-chat-common
   (setq my/copilot-chat-prompt-original copilot-chat-prompt)

--- a/recipes/copilot-chat.rcp
+++ b/recipes/copilot-chat.rcp
@@ -3,4 +3,4 @@
        :description "This plugin allows you to chat with github copilot."
        :type github
        :pkgname "chep/copilot-chat.el"
-       :depends (request markdown-mode chatgpt-shell magit transient org-mode shell-maker))
+       :depends (request markdown-mode chatgpt-shell magit transient org-mode shell-maker polymode))

--- a/recipes/copilot-chat.rcp
+++ b/recipes/copilot-chat.rcp
@@ -3,4 +3,4 @@
        :description "This plugin allows you to chat with github copilot."
        :type github
        :pkgname "chep/copilot-chat.el"
-       :depends (request markdown-mode chatgpt-shell magit transient org-mode shell-maker polymode))
+       :depends (request markdown-mode magit transient org-mode polymode))


### PR DESCRIPTION
copilot-chat の v2.0 からは
chatgpt-shell と shell-maker の依存が外れて
代わりに polymode を使うようになる。

そのためレシピを修正している。

また shell-maker は依存が外れた際に
一瞬だけ copilot-chat-frontend のサポートも外れてしまっていた
今後あまりそこには力を入れなさそうな気がするので
それを org-mode に切り替えることにした

see: https://github.com/mugijiru/.emacs.d/pull/6752#issuecomment-2660845874