### PR TITLE
chore: Add shell-maker dependency to copilot-chat recipe again

### DIFF
--- a/hugo/content/editing/copilot-chat.md
+++ b/hugo/content/editing/copilot-chat.md
@@ -10,7 +10,7 @@ draft = false
 
 ### インストール {#インストール}
 
-el-get 本体にはレシピがないので自前で用意している。なお依存している [chatgpt-shell](https://github.com/xenodium/chatgpt-shell) などのレシピは [chatgpt-shell の設定ページ]({{< relref "chatgpt-shell" >}}) に置いてある
+el-get 本体にはレシピがないので自前で用意している。なお依存している [shell-maker](https://github.com/xenodium/shell-maker) などのレシピは [chatgpt-shell の設定ページ]({{< relref "chatgpt-shell" >}}) に置いてある
 
 ```emacs-lisp
 (:name copilot-chat
@@ -18,7 +18,7 @@ el-get 本体にはレシピがないので自前で用意している。なお�
        :description "This plugin allows you to chat with github copilot."
        :type github
        :pkgname "chep/copilot-chat.el"
-       :depends (request markdown-mode magit transient org-mode polymode))
+       :depends (request markdown-mode magit transient org-mode polymode shell-maker))
 ```
 
 そして `el-get-bundle` でインストールしている

--- a/init.org
+++ b/init.org
@@ -1903,7 +1903,7 @@ Warning (copilot): .loaddefs.el size exceeds 'copilot-max-char' (100000), copilo
 [[https://github.com/chep/copilot-chat.el][copilot-chat.el]] は Emacs から GitHub Copilot Chat を使えるようにするパッケージ。
 **** インストール
 el-get 本体にはレシピがないので自前で用意している。
-なお依存している [[https://github.com/xenodium/chatgpt-shell][chatgpt-shell]] などのレシピは [[id:93c58f71-7db1-40d7-b706-dd5868c29da0][chatgpt-shell の設定ページ]] に置いてある
+なお依存している [[https://github.com/xenodium/shell-maker][shell-maker]] などのレシピは [[id:93c58f71-7db1-40d7-b706-dd5868c29da0][chatgpt-shell の設定ページ]] に置いてある
 
 #+begin_src emacs-lisp :tangle recipes/copilot-chat.rcp
 (:name copilot-chat
@@ -1911,7 +1911,7 @@ el-get 本体にはレシピがないので自前で用意している。
        :description "This plugin allows you to chat with github copilot."
        :type github
        :pkgname "chep/copilot-chat.el"
-       :depends (request markdown-mode magit transient org-mode polymode))
+       :depends (request markdown-mode magit transient org-mode polymode shell-maker))
 #+end_src
 
 そして ~el-get-bundle~ でインストールしている

--- a/recipes/copilot-chat.rcp
+++ b/recipes/copilot-chat.rcp
@@ -3,4 +3,4 @@
        :description "This plugin allows you to chat with github copilot."
        :type github
        :pkgname "chep/copilot-chat.el"
-       :depends (request markdown-mode magit transient org-mode polymode))
+       :depends (request markdown-mode magit transient org-mode polymode shell-maker))


### PR DESCRIPTION
copilot-chat の依存関係に
再度 shell-maker が含まれるようになったのでレシピを修正した