### PR TITLE
fix: Remove indent from org-capture protocol templates

### DIFF
--- a/hugo/content/org-mode/org-capture.md
+++ b/hugo/content/org-mode/org-capture.md
@@ -99,10 +99,10 @@ org-capture は org-mode 用にさくっとメモを取るための機能。
            "** %?\n\t")
           ("P" "Protocol" entry
            (file+headline ,my/org-capture-pointers-file "Pointers")
-           "** %?\n   #+BEGIN_QUOTE\n   %i\n   #+END_QUOTE\n\n   Source: %u, [[%:link][%:description]]\n")
+           "** %?\n#+BEGIN_QUOTE\n%i\n#+END_QUOTE\n\nSource: %u, [[%:link][%:description]]\n")
           ("L" "Protocol Link" entry
            (file+headline ,my/org-capture-pointers-file "Pointers")
-           "** %:description\n   %:link\n   %?\n   Captured On: %U")
+           "** %:description\n%:link\n%?\nCaptured On: %U")
           ("w" "Web site" entry
            (file+headline ,my/org-capture-pointers-file "Pointers")
            "* %a %^G

--- a/init.org
+++ b/init.org
@@ -10017,10 +10017,10 @@ org-capture は org-mode 用にさくっとメモを取るための機能。
            "** %?\n\t")
           ("P" "Protocol" entry
            (file+headline ,my/org-capture-pointers-file "Pointers")
-           "** %?\n   #+BEGIN_QUOTE\n   %i\n   #+END_QUOTE\n\n   Source: %u, [[%:link][%:description]]\n")
+           "** %?\n#+BEGIN_QUOTE\n%i\n#+END_QUOTE\n\nSource: %u, [[%:link][%:description]]\n")
           ("L" "Protocol Link" entry
            (file+headline ,my/org-capture-pointers-file "Pointers")
-           "** %:description\n   %:link\n   %?\n   Captured On: %U")
+           "** %:description\n%:link\n%?\nCaptured On: %U")
           ("w" "Web site" entry
            (file+headline ,my/org-capture-pointers-file "Pointers")
            "* %a %^G

--- a/inits/61-org-capture.el
+++ b/inits/61-org-capture.el
@@ -62,10 +62,10 @@
            "** %?\n\t")
           ("P" "Protocol" entry
            (file+headline ,my/org-capture-pointers-file "Pointers")
-           "** %?\n   #+BEGIN_QUOTE\n   %i\n   #+END_QUOTE\n\n   Source: %u, [[%:link][%:description]]\n")
+           "** %?\n#+BEGIN_QUOTE\n%i\n#+END_QUOTE\n\nSource: %u, [[%:link][%:description]]\n")
           ("L" "Protocol Link" entry
            (file+headline ,my/org-capture-pointers-file "Pointers")
-           "** %:description\n   %:link\n   %?\n   Captured On: %U")
+           "** %:description\n%:link\n%?\nCaptured On: %U")
           ("w" "Web site" entry
            (file+headline ,my/org-capture-pointers-file "Pointers")
            "* %a %^G


### PR DESCRIPTION
org-capture protocol で使う org-capture のテンプレートから
インデントを除去した。

昔は org-mode では階層に合わせてインデントが入るようにしていたが
今はその設定をやめたので
今の設定に合わせたテンプレートに修正した