### PR TITLE
ci: Use Emacs 30.1 on GitHub Workflow

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 29.3
+        version: 30.1
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 29.4
+          - 30.1
 
     steps:
     - uses: purcell/setup-emacs@master

--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 29.3
+        version: 30.1
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/verify-config-diff.yml
+++ b/.github/workflows/verify-config-diff.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: purcell/setup-emacs@master
         with:
-          version: 29.3
+          version: 30.1
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
手元で Emacs 30 を使うようになったので
CI でもそれを使うようにした