### PR TITLE
chore: Use Gleek/dap-mode

### DIFF
--- a/hugo/content/programming/react-js.md
+++ b/hugo/content/programming/react-js.md
@@ -12,14 +12,14 @@ React.js を書くための設定をここにまとめている
 
 Debug Adapter Protocol をサポートするモード。入れておいた方がきっとデバッグしやすいんだろうということで入れている。
 
-その際に el-get のレシピは自前で用意している
+その際に el-get のレシピは自前で用意している。また 2025/03/15 現在はエラーが発生するので fork 版を利用している。
 
 ```emacs-lisp
 (:name dap-mode
        :description "Debug Adapter Protocol mode"
        :website "https://github.com/emacs-lsp/dap-mode"
        :type github
-       :pkgname "emacs-lsp/dap-mode"
+       :pkgname "Gleek/dap-mode"
        :depends (bui dash f lsp-mode lsp-treemacs tree-mode posframe s lsp-docker))
 ```
 

--- a/init.org
+++ b/init.org
@@ -6275,14 +6275,15 @@ React.js を書くための設定をここにまとめている
 Debug Adapter Protocol をサポートするモード。
 入れておいた方がきっとデバッグしやすいんだろうということで入れている。
 
-その際に el-get のレシピは自前で用意している
+その際に el-get のレシピは自前で用意している。
+また 2025/03/15 現在はエラーが発生するので fork 版を利用している。
 
 #+begin_src emacs-lisp :tangle recipes/dap-mode.rcp
 (:name dap-mode
        :description "Debug Adapter Protocol mode"
        :website "https://github.com/emacs-lsp/dap-mode"
        :type github
-       :pkgname "emacs-lsp/dap-mode"
+       :pkgname "Gleek/dap-mode"
        :depends (bui dash f lsp-mode lsp-treemacs tree-mode posframe s lsp-docker))
 #+end_src
 

--- a/recipes/dap-mode.rcp
+++ b/recipes/dap-mode.rcp
@@ -2,5 +2,5 @@
        :description "Debug Adapter Protocol mode"
        :website "https://github.com/emacs-lsp/dap-mode"
        :type github
-       :pkgname "emacs-lsp/dap-mode"
+       :pkgname "Gleek/dap-mode"
        :depends (bui dash f lsp-mode lsp-treemacs tree-mode posframe s lsp-docker))


### PR DESCRIPTION
現在 emacs-lsp/dap-mode@ master を使うとエラーになるので
それを修正してくれる PR にある fork 版を利用する