### PR TITLE
feat: define major-mode-hydra for copilot-chat modes

### DIFF
--- a/hugo/content/editing/copilot-chat.md
+++ b/hugo/content/editing/copilot-chat.md
@@ -8,7 +8,7 @@ draft = false
 [copilot-chat.el](https://github.com/chep/copilot-chat.el) は Emacs から GitHub Copilot Chat を使えるようにするパッケージ。
 
 
-### インストール {#インストール}
+## インストール {#インストール}
 
 el-get 本体にはレシピがないので自前で用意している。なお依存している [shell-maker](https://github.com/xenodium/shell-maker) などのレシピは [chatgpt-shell の設定ページ]({{< relref "chatgpt-shell" >}}) に置いてある
 
@@ -28,7 +28,7 @@ el-get 本体にはレシピがないので自前で用意している。なお�
 ```
 
 
-### 最初の起動 {#最初の起動}
+## 最初の起動 {#最初の起動}
 
 とりあえず `M-x copilot-chat-display` で起動する。
 
@@ -36,7 +36,7 @@ el-get 本体にはレシピがないので自前で用意している。なお�
 GitHub Copilot Chat を有効にするための認証コードとメッセージが minibuffer に表示されるのでその認証コードをコピーして Enter を叩いたら Web ブラウザに認証コードを入れる画面が表示されるのであとは画面に従って動かしましょう
 
 
-### 設定 {#設定}
+## 設定 {#設定}
 
 色々使っていると frontend は `shell-maker` の方が使いやすいっぽいのでそれを指定している
 
@@ -55,7 +55,7 @@ GitHub Copilot Chat を有効にするための認証コードとメッセージ
 ```
 
 
-### キーバインド {#キーバインド}
+## キーバインド {#キーバインド}
 
 色々な起動コマンドがあるので `pretty-hydra` を使って Hydra の定義をしてる。使うのは偏るかもしれないけど、とりあえずこれで行ってみる
 
@@ -79,3 +79,20 @@ GitHub Copilot Chat を有効にするための認証コードとメッセージ
      "Commit message"
      (("I" copilot-chat-insert-commit-message "Insert")))))
 ```
+
+transient も標準で定義されているのでそれを各 prompt-mode で [major-mode-hydra]({{< relref "hydra#major-mode-hydra-のインストール" >}}) 経由で起動できるようにしている。
+
+```emacs-lisp
+(with-eval-after-load 'major-mode-hydra
+  (major-mode-hydra-define copilot-chat-org-prompt-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-robot") " Copilot Chat Org Prompt"))
+    ("Common"
+     (("m" copilot-chat-transient "Menu"))))
+  (major-mode-hydra-define copilot-chat-markdown-prompt-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-robot") " Copilot Chat Markdown Prompt"))
+    ("Common"
+     (("m" copilot-chat-transient "Menu"))))
+  (major-mode-hydra-define copilot-chat-shell-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-robot") " Copilot Chat Shell Prompt"))
+    ("Common"
+     (("m" copilot-chat-transient "Menu")))))
+```
+
+まあ pretty-hydra で定義されているやつを移植したりしても良さそうだけど一旦ミニマムに対応。頑張るのも面倒なので。

--- a/init.org
+++ b/init.org
@@ -1901,7 +1901,7 @@ Warning (copilot): .loaddefs.el size exceeds 'copilot-max-char' (100000), copilo
 :END:
 *** 概要
 [[https://github.com/chep/copilot-chat.el][copilot-chat.el]] は Emacs から GitHub Copilot Chat を使えるようにするパッケージ。
-**** インストール
+*** インストール
 el-get 本体にはレシピがないので自前で用意している。
 なお依存している [[https://github.com/xenodium/shell-maker][shell-maker]] などのレシピは [[id:93c58f71-7db1-40d7-b706-dd5868c29da0][chatgpt-shell の設定ページ]] に置いてある
 
@@ -1919,14 +1919,14 @@ el-get 本体にはレシピがないので自前で用意している。
 #+begin_src emacs-lisp :tangle inits/30-copilot.el
 (el-get-bundle copilot-chat)
 #+end_src
-**** 最初の起動
+*** 最初の起動
 とりあえず ~M-x copilot-chat-display~ で起動する。
 
 最初の起動の時は適当なメッセージを ~C-c C-c~ で送信すると
 GitHub Copilot Chat を有効にするための認証コードとメッセージが minibuffer に表示されるので
 その認証コードをコピーして Enter を叩いたら Web ブラウザに認証コードを入れる画面が表示されるので
 あとは画面に従って動かしましょう
-**** 設定
+*** 設定
 色々使っていると frontend は ~shell-maker~ の方が使いやすいっぽいのでそれを指定している
 
 #+begin_src emacs-lisp :tangle inits/30-copilot.el
@@ -1944,7 +1944,7 @@ GitHub Copilot Chat を有効にするための認証コードとメッセージ
 (with-eval-after-load 'copilot-chat-common
   (setopt copilot-chat-prompt-suffix "\n出力には日本語を用います"))
 #+end_src
-**** キーバインド
+*** キーバインド
 色々な起動コマンドがあるので ~pretty-hydra~ を使って Hydra の定義をしてる。
 使うのは偏るかもしれないけど、とりあえずこれで行ってみる
 
@@ -1968,6 +1968,25 @@ GitHub Copilot Chat を有効にするための認証コードとメッセージ
      "Commit message"
      (("I" copilot-chat-insert-commit-message "Insert")))))
 #+end_src
+
+transient も標準で定義されているので
+それを各 prompt-mode で [[id:1daf2240-355e-4ecf-8a7d-875062872207][major-mode-hydra]] 経由で起動できるようにしている。
+
+#+begin_src emacs-lisp :tangle inits/30-copilot.el
+(with-eval-after-load 'major-mode-hydra
+  (major-mode-hydra-define copilot-chat-org-prompt-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-robot") " Copilot Chat Org Prompt"))
+    ("Common"
+     (("m" copilot-chat-transient "Menu"))))
+  (major-mode-hydra-define copilot-chat-markdown-prompt-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-robot") " Copilot Chat Markdown Prompt"))
+    ("Common"
+     (("m" copilot-chat-transient "Menu"))))
+  (major-mode-hydra-define copilot-chat-shell-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-robot") " Copilot Chat Shell Prompt"))
+    ("Common"
+     (("m" copilot-chat-transient "Menu")))))
+#+end_src
+
+まあ pretty-hydra で定義されているやつを移植したりしても良さそうだけど
+一旦ミニマムに対応。頑張るのも面倒なので。
 ** dmacro
 :PROPERTIES:
 :EXPORT_FILE_NAME: dmacro

--- a/inits/30-copilot.el
+++ b/inits/30-copilot.el
@@ -42,3 +42,14 @@
       ("f" copilot-chat-explain-defun          "Function"))
      "Commit message"
      (("I" copilot-chat-insert-commit-message "Insert")))))
+
+(with-eval-after-load 'major-mode-hydra
+  (major-mode-hydra-define copilot-chat-org-prompt-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-robot") " Copilot Chat Org Prompt"))
+    ("Common"
+     (("m" copilot-chat-transient "Menu"))))
+  (major-mode-hydra-define copilot-chat-markdown-prompt-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-robot") " Copilot Chat Markdown Prompt"))
+    ("Common"
+     (("m" copilot-chat-transient "Menu"))))
+  (major-mode-hydra-define copilot-chat-shell-mode (:separator "-" :quit-key "q" :title (concat (nerd-icons-mdicon "nf-md-robot") " Copilot Chat Shell Prompt"))
+    ("Common"
+     (("m" copilot-chat-transient "Menu")))))


### PR DESCRIPTION
Copilot Chat のバッファで
major-mode-hydra 経由で
copilot-chat-transient を起動できるようにした。

キーバインドを覚えられないので自前で定義している。