### PR TITLE
fix(doom-modeline): copilot-chat との相性問題を回避

### DIFF
--- a/hugo/content/ui/mode-line.md
+++ b/hugo/content/ui/mode-line.md
@@ -210,6 +210,21 @@ doom-modeline で見た目をカッコよくしているのでこっちに設定
 ```
 
 
+### copilot-chat との相性問題回避 {#copilot-chat-との相性問題回避}
+
+copilot-chat を使っていると mode-line が readonly 扱いにされるっぽくてそのせいで doom-modeline の表示がうまくいかないので一時的にテキストの readonly mode を無効にすることで
+mode-line の表示がされなくなる問題を回避している
+
+```emacs-lisp
+(defun my/inhibit-read-only (orig-fun &rest args)
+  "Temporarily disable read-only mode."
+  (let ((inhibit-read-only t))
+    (apply orig-fun args)))
+
+(advice-add 'doom-modeline-string-pixel-width :around #'my/inhibit-read-only)
+```
+
+
 ### アイコン表示 {#アイコン表示}
 
 [nerd-icons](https://github.com/rainstormstudio/nerd-icons.el) に依存しているのでそれの設定もここに書いておく

--- a/init.org
+++ b/init.org
@@ -4333,6 +4333,20 @@ doom-modeline で見た目をカッコよくしているのでこっちに設定
 (display-battery-mode 1)
 #+end_src
 
+**** copilot-chat との相性問題回避
+copilot-chat を使っていると mode-line が readonly 扱いにされるっぽくて
+そのせいで doom-modeline の表示がうまくいかないので
+一時的にテキストの readonly mode を無効にすることで
+mode-line の表示がされなくなる問題を回避している
+
+#+begin_src emacs-lisp :tangle inits/91-doom-modeline.el
+(defun my/inhibit-read-only (orig-fun &rest args)
+  "Temporarily disable read-only mode."
+  (let ((inhibit-read-only t))
+    (apply orig-fun args)))
+
+(advice-add 'doom-modeline-string-pixel-width :around #'my/inhibit-read-only)
+#+end_src
 **** アイコン表示
 [[https://github.com/rainstormstudio/nerd-icons.el][nerd-icons]] に依存しているのでそれの設定もここに書いておく
 

--- a/inits/91-doom-modeline.el
+++ b/inits/91-doom-modeline.el
@@ -5,3 +5,10 @@
 (setq doom-modeline-vcs-max-length 30)
 
 (display-battery-mode 1)
+
+(defun my/inhibit-read-only (orig-fun &rest args)
+  "Temporarily disable read-only mode."
+  (let ((inhibit-read-only t))
+    (apply orig-fun args)))
+
+(advice-add 'doom-modeline-string-pixel-width :around #'my/inhibit-read-only)


### PR DESCRIPTION
copilot-chat を使用していると
mode-line が readonly 扱いにされる問題を回避するため
一時的に readonly mode を無効にする advice を定義し
それを利用することで
doom-modeline の表示が正しく行われるように対応した