### PR TITLE
feat(docker): update installation instructions with custom recipe

### DIFF
--- a/hugo/content/programming/docker.md
+++ b/hugo/content/programming/docker.md
@@ -18,7 +18,18 @@ Docker の管理をしたり Dockerfile を書いたりするための設定を�
 
 ### インストール {#インストール}
 
-el-get 本体にレシピがあるので `el-get-bundle` でインストール
+el-get 本体にレシピがあるけどブランチ指定がされていなくて私が使ってる自動更新 PR を作る仕組みとは相性が悪いので自前で recipe を用意している
+
+```emacs-lisp
+(:name docker
+       :description "Manage docker images & containers from Emacs"
+       :type github
+       :pkgname "Silex/docker.el"
+       :minimum-emacs-version "26.1"
+       :depends (emacs-aio dash s tablist transient))
+```
+
+そしてそれを `el-get-bundle` でインストールしている
 
 ```emacs-lisp
 (el-get-bundle docker)

--- a/init.org
+++ b/init.org
@@ -5345,7 +5345,20 @@ Docker の管理をしたり Dockerfile を書いたりするための設定を�
 **** 概要
 [[https://github.com/Silex/docker.el][docker.el]] は Docker のコンテナやらイメージやらを Emacs 上で管理するためのパッケージです。
 **** インストール
-el-get 本体にレシピがあるので ~el-get-bundle~ でインストール
+el-get 本体にレシピがあるけどブランチ指定がされていなくて
+私が使ってる自動更新 PR を作る仕組みとは相性が悪いので
+自前で recipe を用意している
+
+#+begin_src emacs-lisp :tangle recipes/docker.rcp
+(:name docker
+       :description "Manage docker images & containers from Emacs"
+       :type github
+       :pkgname "Silex/docker.el"
+       :minimum-emacs-version "26.1"
+       :depends (emacs-aio dash s tablist transient))
+#+end_src
+
+そしてそれを ~el-get-bundle~ でインストールしている
 
 #+begin_src emacs-lisp :tangle inits/50-docker.el
 (el-get-bundle docker)

--- a/recipes/docker.rcp
+++ b/recipes/docker.rcp
@@ -1,0 +1,6 @@
+(:name docker
+       :description "Manage docker images & containers from Emacs"
+       :type github
+       :pkgname "Silex/docker.el"
+       :minimum-emacs-version "26.1"
+       :depends (emacs-aio dash s tablist transient))


### PR DESCRIPTION
el-get 本体に付属しているレシピがブランチ指定されていないため自動更新 PR との相性が悪い。
これを解決するために自前のレシピを用意した