### PR TITLE
chore: Update Swiper

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -297,7 +297,7 @@
         (shrink-path :checksum
                      "c14882c8599aec79a6e8ef2d06454254bb3e1e41")
         (spinner :checksum "d4647ae87fb0cd24bc9081a3d287c860ff061c21")
-        (swiper :checksum "078dcc713e088cb959af549cbd00f2267deb175a")
+        (swiper :checksum "e33b028ed4b1258a211c87fd5fe801bed25de429")
         (transient :checksum
                    "afc88b24e4faa5c7e246303648e70b4507652f32")
         (treepy :checksum "651e2634f01f346da9ec8a64613c51f54b444bc3")


### PR DESCRIPTION
自動更新ができなくなってるので手動更新

https://github.com/abo-abo/swiper/compare/078dcc713e088cb959af549cbd00f2267deb175a...e33b028ed4b1258a211c87fd5fe801bed25de429

ざっと差分を見たけど大体リファクタな感じで
なぜ更新できないのかはよくわからない。