### PR TITLE
feat(aidermacs): add support for Groq and OpenRouter API keys

### DIFF
--- a/hugo/content/external-tool/aidermacs.md
+++ b/hugo/content/external-tool/aidermacs.md
@@ -31,11 +31,15 @@ el-get にはレシピがないので自前で用意している
 
 ## 設定 {#設定}
 
-今はひとまず Gemini を使っているので環境変数に Gemini の API キーをセットしつつモデルの指定を行っている
+今はひとまず Gemini を使っているので環境変数に Gemini や Groq, OpenRouter の API キーを設定してあとデフォルトで使うモデルの指定を行っている。まあモデルはプロジェクト内の .aider.conf.yml でも結局指定するんだけども
 
 ```emacs-lisp
 (setenv "GEMINI_API_KEY"
         (funcall (plist-get (nth 0 (auth-source-search :host "gemini" :max 1)) :secret)))
+(setenv "GROQ_API_KEY"
+        (funcall (plist-get (nth 0 (auth-source-search :host "groqcloud" :max 1)) :secret)))
+(setenv "OPENROUTER_API_KEY"
+        (funcall (plist-get (nth 0 (auth-source-search :host "openrouter" :max 1)) :secret)))
 
 (setopt aidermacs-default-model "gemini-2.5-pro")
 ```

--- a/init.org
+++ b/init.org
@@ -7766,12 +7766,17 @@ el-get にはレシピがないので自前で用意している
 #+end_src
 *** 設定
 今はひとまず Gemini を使っているので
-環境変数に Gemini の API キーをセットしつつ
-モデルの指定を行っている
+環境変数に Gemini や Groq, OpenRouter の API キーを設定して
+あとデフォルトで使うモデルの指定を行っている。
+まあモデルはプロジェクト内の .aider.conf.yml でも結局指定するんだけども
 
 #+begin_src emacs-lisp :tangle inits/50-aidermacs.el
 (setenv "GEMINI_API_KEY"
         (funcall (plist-get (nth 0 (auth-source-search :host "gemini" :max 1)) :secret)))
+(setenv "GROQ_API_KEY"
+        (funcall (plist-get (nth 0 (auth-source-search :host "groqcloud" :max 1)) :secret)))
+(setenv "OPENROUTER_API_KEY"
+        (funcall (plist-get (nth 0 (auth-source-search :host "openrouter" :max 1)) :secret)))
 
 (setopt aidermacs-default-model "gemini-2.5-pro")
 #+end_src

--- a/inits/50-aidermacs.el
+++ b/inits/50-aidermacs.el
@@ -2,5 +2,9 @@
 
 (setenv "GEMINI_API_KEY"
         (funcall (plist-get (nth 0 (auth-source-search :host "gemini" :max 1)) :secret)))
+(setenv "GROQ_API_KEY"
+        (funcall (plist-get (nth 0 (auth-source-search :host "groqcloud" :max 1)) :secret)))
+(setenv "OPENROUTER_API_KEY"
+        (funcall (plist-get (nth 0 (auth-source-search :host "openrouter" :max 1)) :secret)))
 
 (setopt aidermacs-default-model "gemini-2.5-pro")


### PR DESCRIPTION
# 概要

Groq や OpenRouter も使えるようにするために
API キーを authinfo 経由で取得できるようにした