### PR TITLE
fix: correct typo in embark package name

### DIFF
--- a/hugo/content/ui/embark.md
+++ b/hugo/content/ui/embark.md
@@ -13,7 +13,7 @@ draft = false
 el-get にはレシピがないので自前で定義している
 
 ```emacs-lisp
-( :name emberk
+( :name embark
   :website "https://github.com/oantolin/embark"
   :description "Conveniently act on minibuffer completions"
   :type github

--- a/init.org
+++ b/init.org
@@ -3024,7 +3024,7 @@ agenda などは表示する内容を絞ったりした方が dashboard とし�
 el-get にはレシピがないので自前で定義している
 
 #+begin_src emacs-lisp :tangle recipes/embark.rcp
-( :name emberk
+( :name embark
   :website "https://github.com/oantolin/embark"
   :description "Conveniently act on minibuffer completions"
   :type github

--- a/recipes/embark.rcp
+++ b/recipes/embark.rcp
@@ -1,4 +1,4 @@
-( :name emberk
+( :name embark
   :website "https://github.com/oantolin/embark"
   :description "Conveniently act on minibuffer completions"
   :type github


### PR DESCRIPTION
typo してたので修正