### PR TITLE
feat: Implement org search commands

### DIFF
--- a/hugo/content/org-mode/org-commands.md
+++ b/hugo/content/org-mode/org-commands.md
@@ -150,3 +150,44 @@ org-clock-report の対象にしたくて org-agenda-files をいい感じにす
       (setq org-agenda-files
             (cl-pushnew (org-journal--get-entry-path) tmp)))))
 ```
+
+
+## org ドキュメントを rg で検索する {#org-ドキュメントを-rg-で検索する}
+
+現状 org-mode で書いた文書は基本溜め込んだままになっていてそれを引っ張り出して活用する方法が限られているという課題がある。
+
+Agenda を活用して良い感じに引っ張り出したり
+org-roam で検索したりするという手はあるのだけれどあまりそれもうまくいっていない。
+
+具体的には、Agenda だとタグとかカテゴリとかで絞り込んで抽出する感じだけど、それよりも「このキーワードの情報が欲しい」ということがある。
+org-roam は heading の内容で検索してくれるが
+journal ファイルだと heading 工夫しないし、文章をガーッと書く感じなのでそれも役に立たない。
+
+つまり本文をカジュアルに検索したいわけ。
+
+というわけで org ファイルを rg で検索するためのコマンドを用意した。
+
+```emacs-lisp
+(defun my/org-search-string (string)
+  (interactive "sSearch string: ")
+  (rg string "*.org" my/org-document-dir))
+```
+
+これを使えば Org の document を収めてるディレクトリ以下の org ファイルを rg でさくっと検索できるってわけ。
+
+更に、資料を突っ込んでる pointers.org から検索するコマンドや
+journal ファイルから検索するコマンドも別途用意した。
+
+```emacs-lisp
+(defun my/org-search-string-in-pointers (string)
+  (interactive "sSearch string: ")
+  (rg string "pointers.org" my/org-document-dir))
+```
+
+```emacs-lisp
+(defun my/org-search-string-in-journals (string)
+  (interactive "sSearch string: ")
+  (rg string "*.org" (concat my/org-document-dir "roam/journal")))
+```
+
+これで過去に突っ込んだ情報の取り出しがうまくいくようになることを願う。

--- a/hugo/content/org-mode/org-mode-keybinds.md
+++ b/hugo/content/org-mode/org-mode-keybinds.md
@@ -99,6 +99,29 @@ major-mode-hydra で、org-mode のファイルを開いている時によく使
 合わせて agenda 用の major-mode-hydra も定義しているが、こちらは情報をまだまとめていない……。
 
 
+## 検索用 Hydra {#検索用-hydra}
+
+pretty-hydra を使って org のドキュメントを検索するための各コマンドを叩けるようにしている。これは後述の `global-org-hydra` から呼び出す想定である
+
+```emacs-lisp
+(with-eval-after-load 'pretty-hydra
+  (pretty-hydra-define
+    org-search-hydra
+    ( :separator "-"
+      :color teal
+      :foreign-key warn
+      :title (concat (nerd-icons-mdicon "nf-md-note_search") " Org Search")
+      :quit-key "q")
+    ("Heading"
+     (("h" org-search-view                  "Heading")
+      ("o" counsel-org-goto-all             "Outline"))
+     "RipGrep"
+     (("j" my/org-search-string-in-journals "Journal")
+      ("/" my/org-search-string             "All")
+      ("P" my/org-search-in-pointers        "Pointers")))))
+```
+
+
 ## Global な Hydra {#global-な-hydra}
 
 pretty-hydra を使って Global に使える org-mode のコマンドを叩けるようにしている
@@ -118,7 +141,8 @@ pretty-hydra を使って Global に使える org-mode のコマンドを叩け�
       ("l" org-store-link             "Store link")
       ("J" org-journal-new-entry      "Journal")
       ("R" my/org-reviews-execute     "Review")
-      ("t" my/org-tags-view-only-todo "Tagged Todo"))
+      ("t" my/org-tags-view-only-todo "Tagged Todo")
+      ("/" org-search-hydra/body      "Search"))
 
      "Calendar"
      (("F" org-gcal-fetch "Fetch Calendar")
@@ -132,33 +156,12 @@ pretty-hydra を使って Global に使える org-mode のコマンドを叩け�
       ("x" org-clock-cancel   "Cancel")
       ("j" org-clock-goto     "Goto"))
 
-     "Search"
-     (("H" org-search-view "Heading")
-      ("O" counsel-org-goto-all "Outline"))
-
      "Roam"
      ((";" org-roam-hydra/body "Menu"))
 
      "Pomodoro"
      (("p" org-pomodoro "Pomodoro")))))
 ```
-
-| Key | 効果                        | 使用頻度                                      |
-|-----|---------------------------|-------------------------------------------|
-| a   | Agenda 選択                 | よく使う                                      |
-| c   | Capture                     | よく使う                                      |
-| l   | その場所へのリンクを保存    | 使ってない                                    |
-| t   | 選択したタグが付与された TODO のみ表示 | 使ってない。使うと便利かもなあ                |
-| F   | Google Calendar の情報取得  | 平日は毎日使っている                          |
-| C   | カレンダーを calfw で開く   | 最近使ってない                                |
-| A   | org-gcal で拾って来た情報を appt に登録 | appt.el 経由で通知できるようにしている        |
-| i   | Clock In                    | 使ってないというか major-mode-hydra の方があれば良い |
-| o   | Clock Out                   | 使ってない。使ってもいい気がする              |
-| r   | 最後に Clock In したやつを再開 | 使ってない。大体常に Clock しているから最後がいつも切り替わってるので使う機会がない |
-| x   | Clock Cancel                | 作業は発生しているからキャンセルしないで普通に Clock out しているなあ |
-| j   | 最後に Clock In したやつの場所に移動 | ちょくちょく使う。便利                        |
-| H   | Heading の検索              | 使ってない。インクリメンタルに検索できればいいのに |
-| p   | ポモドーロタイマー          | これも major-mode-hydra にあれば十分かな      |
 
 
 ## その他 {#その他}

--- a/init.org
+++ b/init.org
@@ -11479,6 +11479,48 @@ org-clock-report の対象にしたくて org-agenda-files をいい感じにす
       (setq org-agenda-files
             (cl-pushnew (org-journal--get-entry-path) tmp)))))
 #+end_src
+*** org ドキュメントを rg で検索する
+現状 org-mode で書いた文書は基本溜め込んだままになっていて
+それを引っ張り出して活用する方法が限られているという課題がある。
+
+Agenda を活用して良い感じに引っ張り出したり
+org-roam で検索したりするという手はあるのだけれど
+あまりそれもうまくいっていない。
+
+具体的には、Agenda だとタグとかカテゴリとかで絞り込んで抽出する感じだけど、
+それよりも「このキーワードの情報が欲しい」ということがある。
+org-roam は heading の内容で検索してくれるが
+journal ファイルだと heading 工夫しないし、文章をガーッと書く感じなので
+それも役に立たない。
+
+つまり本文をカジュアルに検索したいわけ。
+
+というわけで org ファイルを rg で検索するためのコマンドを用意した。
+
+#+begin_src emacs-lisp :tangle inits/68-my-org-commands.el
+(defun my/org-search-string (string)
+  (interactive "sSearch string: ")
+  (rg string "*.org" my/org-document-dir))
+#+end_src
+
+これを使えば Org の document を収めてるディレクトリ以下の org ファイルを rg でさくっと検索できるってわけ。
+
+更に、資料を突っ込んでる pointers.org から検索するコマンドや
+journal ファイルから検索するコマンドも別途用意した。
+
+#+begin_src emacs-lisp :tangle inits/68-my-org-commands.el
+(defun my/org-search-string-in-pointers (string)
+  (interactive "sSearch string: ")
+  (rg string "pointers.org" my/org-document-dir))
+#+end_src
+
+#+begin_src emacs-lisp :tangle inits/68-my-org-commands.el
+(defun my/org-search-string-in-journals (string)
+  (interactive "sSearch string: ")
+  (rg string "*.org" (concat my/org-document-dir "roam/journal")))
+#+end_src
+
+これで過去に突っ込んだ情報の取り出しがうまくいくようになることを願う。
 ** org-mode 関係の keybinds
 :PROPERTIES:
 :EXPORT_FILE_NAME: org-mode-keybinds

--- a/init.org
+++ b/init.org
@@ -11621,7 +11621,30 @@ major-mode-hydra で、org-mode のファイルを開いている時によく使
 
 合わせて agenda 用の major-mode-hydra も定義しているが、
 こちらは情報をまだまとめていない……。
+*** 検索用 Hydra
+:PROPERTIES:
+:ID:       71a3d529-c616-466f-aa6f-0245a20ff2e7
+:END:
+pretty-hydra を使って org のドキュメントを検索するための各コマンドを叩けるようにしている。
+これは後述の ~global-org-hydra~ から呼び出す想定である
 
+#+begin_src emacs-lisp :tangle inits/69-org-mode-hydra.el
+(with-eval-after-load 'pretty-hydra
+  (pretty-hydra-define
+    org-search-hydra
+    ( :separator "-"
+      :color teal
+      :foreign-key warn
+      :title (concat (nerd-icons-mdicon "nf-md-note_search") " Org Search")
+      :quit-key "q")
+    ("Heading"
+     (("h" org-search-view                  "Heading")
+      ("o" counsel-org-goto-all             "Outline"))
+     "RipGrep"
+     (("j" my/org-search-string-in-journals "Journal")
+      ("/" my/org-search-string             "All")
+      ("P" my/org-search-in-pointers        "Pointers")))))
+#+end_src
 *** Global な Hydra
 :PROPERTIES:
 :ID:       85c76d3b-7cdd-435b-839f-53693e69fa1b
@@ -11643,7 +11666,8 @@ pretty-hydra を使って Global に使える org-mode のコマンドを叩け�
       ("l" org-store-link             "Store link")
       ("J" org-journal-new-entry      "Journal")
       ("R" my/org-reviews-execute     "Review")
-      ("t" my/org-tags-view-only-todo "Tagged Todo"))
+      ("t" my/org-tags-view-only-todo "Tagged Todo")
+      ("/" org-search-hydra/body      "Search"))
 
      "Calendar"
      (("F" org-gcal-fetch "Fetch Calendar")
@@ -11657,33 +11681,12 @@ pretty-hydra を使って Global に使える org-mode のコマンドを叩け�
       ("x" org-clock-cancel   "Cancel")
       ("j" org-clock-goto     "Goto"))
 
-     "Search"
-     (("H" org-search-view "Heading")
-      ("O" counsel-org-goto-all "Outline"))
-
      "Roam"
      ((";" org-roam-hydra/body "Menu"))
 
      "Pomodoro"
      (("p" org-pomodoro "Pomodoro")))))
 #+end_src
-
-| Key | 効果                                    | 使用頻度                                                                            |
-|-----+-----------------------------------------+-------------------------------------------------------------------------------------|
-| a   | Agenda 選択                             | よく使う                                                                            |
-| c   | Capture                                 | よく使う                                                                            |
-| l   | その場所へのリンクを保存                | 使ってない                                                                          |
-| t   | 選択したタグが付与された TODO のみ表示  | 使ってない。使うと便利かもなあ                                                      |
-| F   | Google Calendar の情報取得              | 平日は毎日使っている                                                                |
-| C   | カレンダーを calfw で開く               | 最近使ってない                                                                      |
-| A   | org-gcal で拾って来た情報を appt に登録 | appt.el 経由で通知できるようにしている                                              |
-| i   | Clock In                                | 使ってないというか major-mode-hydra の方があれば良い                                |
-| o   | Clock Out                               | 使ってない。使ってもいい気がする                                                    |
-| r   | 最後に Clock In したやつを再開          | 使ってない。大体常に Clock しているから最後がいつも切り替わってるので使う機会がない |
-| x   | Clock Cancel                            | 作業は発生しているからキャンセルしないで普通に Clock out しているなあ               |
-| j   | 最後に Clock In したやつの場所に移動    | ちょくちょく使う。便利                                                              |
-| H   | Heading の検索                          | 使ってない。インクリメンタルに検索できればいいのに                                  |
-| p   | ポモドーロタイマー                      | これも major-mode-hydra にあれば十分かな                                            |
 
 *** その他
 org-agenda 用の Hydra も用意しておいた方が良さそうだなというのが最近の実感。

--- a/inits/68-my-org-commands.el
+++ b/inits/68-my-org-commands.el
@@ -64,3 +64,15 @@ Hydra から利用するために定義している。"
     (let ((tmp my/org-agenda-files--original))
       (setq org-agenda-files
             (cl-pushnew (org-journal--get-entry-path) tmp)))))
+
+(defun my/org-search-string (string)
+  (interactive "sSearch string: ")
+  (rg string "*.org" my/org-document-dir))
+
+(defun my/org-search-string-in-pointers (string)
+  (interactive "sSearch string: ")
+  (rg string "pointers.org" my/org-document-dir))
+
+(defun my/org-search-string-in-journals (string)
+  (interactive "sSearch string: ")
+  (rg string "*.org" (concat my/org-document-dir "roam/journal")))

--- a/inits/69-org-mode-hydra.el
+++ b/inits/69-org-mode-hydra.el
@@ -79,6 +79,22 @@
 
 (with-eval-after-load 'pretty-hydra
   (pretty-hydra-define
+    org-search-hydra
+    ( :separator "-"
+      :color teal
+      :foreign-key warn
+      :title (concat (nerd-icons-mdicon "nf-md-note_search") " Org Search")
+      :quit-key "q")
+    ("Heading"
+     (("h" org-search-view                  "Heading")
+      ("o" counsel-org-goto-all             "Outline"))
+     "RipGrep"
+     (("j" my/org-search-string-in-journals "Journal")
+      ("/" my/org-search-string             "All")
+      ("P" my/org-search-in-pointers        "Pointers")))))
+
+(with-eval-after-load 'pretty-hydra
+  (pretty-hydra-define
     global-org-hydra
     (:separator "-"
                 :color teal
@@ -91,7 +107,8 @@
       ("l" org-store-link             "Store link")
       ("J" org-journal-new-entry      "Journal")
       ("R" my/org-reviews-execute     "Review")
-      ("t" my/org-tags-view-only-todo "Tagged Todo"))
+      ("t" my/org-tags-view-only-todo "Tagged Todo")
+      ("/" org-search-hydra/body      "Search"))
 
      "Calendar"
      (("F" org-gcal-fetch "Fetch Calendar")
@@ -104,10 +121,6 @@
       ("r" org-clock-in-last  "Restart")
       ("x" org-clock-cancel   "Cancel")
       ("j" org-clock-goto     "Goto"))
-
-     "Search"
-     (("H" org-search-view "Heading")
-      ("O" counsel-org-goto-all "Outline"))
 
      "Roam"
      ((";" org-roam-hydra/body "Menu"))


### PR DESCRIPTION
# 概要

org-mode のドキュメント本文を検索するためのコマンドを追加し
以前から用意している org ファイル検索用のコマンド群とともに
新しく用意した org-search-hydra から起動するようにした

# 変更の理由

org-mode 等にある検索機能は基本的に heading を検索する仕組みになっているが
すごーく雑に書いた文書では heading もすごーく適当で本文が長くてその中にキーワードが紛れていることが多い。
例えば日記などはその典型で、日記で文書構造なんて意識して書くことはないので、
既存の検索方法では過去の出来事を検索することが困難であった。

# 変更内容

org 文書を放り込むフォルダ以下を ripgrep を使って検索できるコマンドを追加した。

また、雑に書かれがちな journal ファイル群や雑に情報を放り込む pointers.org に対しては
それ専用の検索コマンドも用意している。

そして org-search-hydra というものを新しく定義して
既存の検索コマンドと共にその Hydra に放り込んで使えるようにした。

# その他

journal ファイルや pointers.org に関しては特別にコマンドを用意したけれども
うまい具合に検索範囲を指定できるコマンドを用意したらそれ1つで済むかもしれない。
けど、とりあえずはそこまで作り込む気力がないので一旦この状態にしておく。