### PR TITLE
fix: Move up habits over then scheduled tasks

### DIFF
--- a/hugo/content/org-mode/agenda.md
+++ b/hugo/content/org-mode/agenda.md
@@ -231,9 +231,9 @@ org-agenda では `org-agenda-prefix-format` に `%s` を指定することで�
 
 2番目には、その日の journal ファイルやレビュー対象の PR を載せているファイルのタスクを抽出している。今のところ TODO をネストさせているとそれも全部表示されるのが気に入らないけどそれはまだ直していない。あと良く見ると意味もなく habits.org を参照しているのでそれは後で消しておきたいですね。
 
-3番目には、とりあえずタスクを放り込んでおく projects.org から予定や締切を設定している仕事用のタスクを抽出している。仕事用のタスクというのは agenda-group で指定している。締切とか予定が過ぎているのを上の方に出したり、その日予定のものをだけをまとめていたり、今後1週間の予定に入っているものを並べたりとちょっと工夫している。
+3番目には毎日やってるルーチンワークを並べている。出勤打刻とかね。ほら TODO リストにないと結構忘れちゃうので……。
 
-4番目には毎日やってるルーチンワークを並べている。出勤打刻とかね。ほら TODO リストにないと結構忘れちゃうので……。
+4番目には、とりあえずタスクを放り込んでおく projects.org から予定や締切を設定している仕事用のタスクを抽出している。仕事用のタスクというのは agenda-group で指定している。締切とか予定が過ぎているのを上の方に出したり、その日予定のものをだけをまとめていたり、今後1週間の予定に入っているものを並べたりとちょっと工夫している。
 
 最後に、特に予定や締切を設定していない仕事用のタスクを並べている。いつかやりたいね〜系のものがここに並ぶ感じ。大体ローカルの環境設定をより良い感じにしたいとかが入って来る
 
@@ -257,6 +257,14 @@ org-agenda では `org-agenda-prefix-format` に `%s` を指定することで�
                                               (:name "レビュー待ち" :todo "WAIT" :property ("agenda-group" "journal-task"))
                                               (:name "修正待ち" :todo "WAIT" :category "レビュー")
                                               (:discard (:anything t))))))
+       (tags-todo "Weekday-Start-Finish|Daily"
+                  ((org-agenda-overriding-header "習慣")
+                   (org-agenda-prefix-format "  ")
+                   (org-habit-show-habits t)
+                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
+                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                              (:name "今日予定" :scheduled today)
+                                              (:discard (:anything t))))))
        (alltodo ""
                 ((org-agenda-prefix-format " ")
                  (org-agenda-overriding-header "予定業務")
@@ -272,15 +280,7 @@ org-agenda では `org-agenda-prefix-format` に `%s` を指定することで�
                                                                               (:scheduled (before ,(format-time-string "%Y-%m-%d" (time-add (current-time) (days-to-time 7))))
                                                                                           :scheduled (after ,(format-time-string "%Y-%m-%d" (current-time))))
                                                                               :property ("agenda-group" "1. Work")))
-                                            (:discard (:anything t))))))
-       (tags-todo "Weekday-Start-Finish|Daily"
-                  ((org-agenda-overriding-header "習慣")
-                   (org-agenda-prefix-format "  ")
-                   (org-habit-show-habits t)
-                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
-                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                              (:name "今日予定" :scheduled today)
-                                              (:discard (:anything t))))))))
+                                            (:discard (:anything t))))))))
 ```
 
 
@@ -316,6 +316,13 @@ Emacs 以外も設定を弄りたいのはいっぱいあるからね。i3wm と
                                               (:name "TODO"       :and (:todo "TODO"  :not (:property ("agenda-group" "1. Work"))))
                                               (:name "待ち"       :and (:todo "WAIT"  :not (:property ("agenda-group" "1. Work"))))
                                               (:discard (:anything t))))))
+       (tags-todo "Holiday|Weekend|Daily"
+                  ((org-agenda-overriding-header "習慣")
+                   (org-agenda-prefix-format "  ")
+                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
+                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                              (:name "今日予定の作業" :scheduled today)
+                                              (:discard (:anything t))))))
        (alltodo ""
                 ((org-agenda-prefix-format " ")
                  (org-agenda-overriding-header "予定作業")
@@ -332,13 +339,6 @@ Emacs 以外も設定を弄りたいのはいっぱいあるからね。i3wm と
                                                                                           :scheduled (after ,(format-time-string "%Y-%m-%d" (current-time))))
                                                                               :not (:property ("agenda-group" "1. Work"))))
                                             (:discard (:anything t))))))
-       (tags-todo "Holiday|Weekend|Daily"
-                  ((org-agenda-overriding-header "習慣")
-                   (org-agenda-prefix-format "  ")
-                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
-                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                              (:name "今日予定の作業" :scheduled today)
-                                              (:discard (:anything t))))))
        (tags-todo "LEVEL=2"
                   ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
                    (org-agenda-overriding-header "Private")

--- a/init.org
+++ b/init.org
@@ -9783,15 +9783,15 @@ org-agenda では ~org-agenda-prefix-format~ に ~%s~ を指定することで
 今のところ TODO をネストさせているとそれも全部表示されるのが気に入らないけどそれはまだ直していない。
 あと良く見ると意味もなく habits.org を参照しているのでそれは後で消しておきたいですね。
 
-3番目には、とりあえずタスクを放り込んでおく projects.org から
+3番目には毎日やってるルーチンワークを並べている。出勤打刻とかね。
+ほら TODO リストにないと結構忘れちゃうので……。
+
+4番目には、とりあえずタスクを放り込んでおく projects.org から
 予定や締切を設定している仕事用のタスクを抽出している。
 仕事用のタスクというのは agenda-group で指定している。
 締切とか予定が過ぎているのを上の方に出したり、
 その日予定のものをだけをまとめていたり、
 今後1週間の予定に入っているものを並べたりとちょっと工夫している。
-
-4番目には毎日やってるルーチンワークを並べている。出勤打刻とかね。
-ほら TODO リストにないと結構忘れちゃうので……。
 
 最後に、特に予定や締切を設定していない仕事用のタスクを並べている。
 いつかやりたいね〜系のものがここに並ぶ感じ。
@@ -9817,6 +9817,14 @@ org-agenda では ~org-agenda-prefix-format~ に ~%s~ を指定することで
                                               (:name "レビュー待ち" :todo "WAIT" :property ("agenda-group" "journal-task"))
                                               (:name "修正待ち" :todo "WAIT" :category "レビュー")
                                               (:discard (:anything t))))))
+       (tags-todo "Weekday-Start-Finish|Daily"
+                  ((org-agenda-overriding-header "習慣")
+                   (org-agenda-prefix-format "  ")
+                   (org-habit-show-habits t)
+                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
+                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                              (:name "今日予定" :scheduled today)
+                                              (:discard (:anything t))))))
        (alltodo ""
                 ((org-agenda-prefix-format " ")
                  (org-agenda-overriding-header "予定業務")
@@ -9832,15 +9840,7 @@ org-agenda では ~org-agenda-prefix-format~ に ~%s~ を指定することで
                                                                               (:scheduled (before ,(format-time-string "%Y-%m-%d" (time-add (current-time) (days-to-time 7))))
                                                                                           :scheduled (after ,(format-time-string "%Y-%m-%d" (current-time))))
                                                                               :property ("agenda-group" "1. Work")))
-                                            (:discard (:anything t))))))
-       (tags-todo "Weekday-Start-Finish|Daily"
-                  ((org-agenda-overriding-header "習慣")
-                   (org-agenda-prefix-format "  ")
-                   (org-habit-show-habits t)
-                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
-                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                              (:name "今日予定" :scheduled today)
-                                              (:discard (:anything t))))))))
+                                            (:discard (:anything t))))))))
 #+end_src
 ***** 休日用 agenda
 休日にやることは平日とは異なるので別の agenda custom command を用意している。
@@ -9881,6 +9881,13 @@ Emacs 以外も設定を弄りたいのはいっぱいあるからね。i3wm と
                                               (:name "TODO"       :and (:todo "TODO"  :not (:property ("agenda-group" "1. Work"))))
                                               (:name "待ち"       :and (:todo "WAIT"  :not (:property ("agenda-group" "1. Work"))))
                                               (:discard (:anything t))))))
+       (tags-todo "Holiday|Weekend|Daily"
+                  ((org-agenda-overriding-header "習慣")
+                   (org-agenda-prefix-format "  ")
+                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
+                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                              (:name "今日予定の作業" :scheduled today)
+                                              (:discard (:anything t))))))
        (alltodo ""
                 ((org-agenda-prefix-format " ")
                  (org-agenda-overriding-header "予定作業")
@@ -9897,13 +9904,6 @@ Emacs 以外も設定を弄りたいのはいっぱいあるからね。i3wm と
                                                                                           :scheduled (after ,(format-time-string "%Y-%m-%d" (current-time))))
                                                                               :not (:property ("agenda-group" "1. Work"))))
                                             (:discard (:anything t))))))
-       (tags-todo "Holiday|Weekend|Daily"
-                  ((org-agenda-overriding-header "習慣")
-                   (org-agenda-prefix-format "  ")
-                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
-                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                              (:name "今日予定の作業" :scheduled today)
-                                              (:discard (:anything t))))))
        (tags-todo "LEVEL=2"
                   ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
                    (org-agenda-overriding-header "Private")

--- a/inits/61-org-agenda.el
+++ b/inits/61-org-agenda.el
@@ -83,6 +83,14 @@
                                               (:name "レビュー待ち" :todo "WAIT" :property ("agenda-group" "journal-task"))
                                               (:name "修正待ち" :todo "WAIT" :category "レビュー")
                                               (:discard (:anything t))))))
+       (tags-todo "Weekday-Start-Finish|Daily"
+                  ((org-agenda-overriding-header "習慣")
+                   (org-agenda-prefix-format "  ")
+                   (org-habit-show-habits t)
+                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
+                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                              (:name "今日予定" :scheduled today)
+                                              (:discard (:anything t))))))
        (alltodo ""
                 ((org-agenda-prefix-format " ")
                  (org-agenda-overriding-header "予定業務")
@@ -98,15 +106,7 @@
                                                                               (:scheduled (before ,(format-time-string "%Y-%m-%d" (time-add (current-time) (days-to-time 7))))
                                                                                           :scheduled (after ,(format-time-string "%Y-%m-%d" (current-time))))
                                                                               :property ("agenda-group" "1. Work")))
-                                            (:discard (:anything t))))))
-       (tags-todo "Weekday-Start-Finish|Daily"
-                  ((org-agenda-overriding-header "習慣")
-                   (org-agenda-prefix-format "  ")
-                   (org-habit-show-habits t)
-                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
-                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                              (:name "今日予定" :scheduled today)
-                                              (:discard (:anything t))))))))
+                                            (:discard (:anything t))))))))
 
      ("D" "Holiday"
       ((tags-todo "-Weekday-Daily-Holiday-Weekly-Weekend&LEVEL=3"
@@ -119,6 +119,13 @@
                    (org-super-agenda-groups '((:name "仕掛かり中" :and (:todo "DOING" :not (:property ("agenda-group" "1. Work"))))
                                               (:name "TODO"       :and (:todo "TODO"  :not (:property ("agenda-group" "1. Work"))))
                                               (:name "待ち"       :and (:todo "WAIT"  :not (:property ("agenda-group" "1. Work"))))
+                                              (:discard (:anything t))))))
+       (tags-todo "Holiday|Weekend|Daily"
+                  ((org-agenda-overriding-header "習慣")
+                   (org-agenda-prefix-format "  ")
+                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
+                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
+                                              (:name "今日予定の作業" :scheduled today)
                                               (:discard (:anything t))))))
        (alltodo ""
                 ((org-agenda-prefix-format " ")
@@ -136,13 +143,6 @@
                                                                                           :scheduled (after ,(format-time-string "%Y-%m-%d" (current-time))))
                                                                               :not (:property ("agenda-group" "1. Work"))))
                                             (:discard (:anything t))))))
-       (tags-todo "Holiday|Weekend|Daily"
-                  ((org-agenda-overriding-header "習慣")
-                   (org-agenda-prefix-format "  ")
-                   (org-agenda-files '("~/Documents/org/tasks/habits.org"))
-                   (org-super-agenda-groups '((:name "予定が過ぎてる作業" :scheduled past)
-                                              (:name "今日予定の作業" :scheduled today)
-                                              (:discard (:anything t))))))
        (tags-todo "LEVEL=2"
                   ((org-agenda-files '("~/Documents/org/tasks/projects.org"))
                    (org-agenda-overriding-header "Private")


### PR DESCRIPTION
予定タスク部よりも先に習慣タスクを倒した方が良いので先に目につく位置に移動した