### PR TITLE
feat: Add filename and tags to org-roam-node-display-template

### DIFF
--- a/hugo/content/org-mode/org-roam.md
+++ b/hugo/content/org-mode/org-roam.md
@@ -56,11 +56,13 @@ el-get 本体ではレシピを提供していないのでとりあえず自前�
 ## 設定 {#設定}
 
 既存の org ファイル全てを対象にすると最初の DB 構築で無限に時間がかかるので
-org フォルダの下に roam というフォルダを掘ってその中だけを対象としている
+org フォルダの下に roam というフォルダを掘ってその中だけを対象としている。
+
+また node を検索する時にデフォルト設定だと情報が足らないのでファイル名やタグも検索できるように調整している
 
 ```emacs-lisp
-(custom-set-variables
- '(org-roam-directory (file-truename (concat org-directory "roam/"))))
+(setopt org-roam-directory (file-truename (concat org-directory "roam/")))
+(setopt org-roam-node-display-template "${file}/${title} ${tags}")
 ```
 
 そして自動的に SQLite3 と同期するように自動同期の設定を入れている

--- a/init.org
+++ b/init.org
@@ -11019,11 +11019,14 @@ el-get 本体ではレシピを提供していないのでとりあえず自前�
 #+end_src
 *** 設定
 既存の org ファイル全てを対象にすると最初の DB 構築で無限に時間がかかるので
-org フォルダの下に roam というフォルダを掘ってその中だけを対象としている
+org フォルダの下に roam というフォルダを掘ってその中だけを対象としている。
+
+また node を検索する時にデフォルト設定だと情報が足らないので
+ファイル名やタグも検索できるように調整している
 
 #+begin_src emacs-lisp :tangle inits/65-org-roam.el
-(custom-set-variables
- '(org-roam-directory (file-truename (concat org-directory "roam/"))))
+(setopt org-roam-directory (file-truename (concat org-directory "roam/")))
+(setopt org-roam-node-display-template "${file}/${title} ${tags}")
 #+end_src
 
 そして自動的に SQLite3 と同期するように自動同期の設定を入れている

--- a/inits/65-org-roam.el
+++ b/inits/65-org-roam.el
@@ -1,7 +1,6 @@
 (el-get-bundle org-roam)
 
-(custom-set-variables
- '(org-roam-directory (file-truename (concat org-directory "roam/"))))
+(setopt org-roam-directory (file-truename (concat org-directory "roam/")))
 
 (org-roam-db-autosync-mode 1)
 

--- a/inits/65-org-roam.el
+++ b/inits/65-org-roam.el
@@ -1,6 +1,7 @@
 (el-get-bundle org-roam)
 
 (setopt org-roam-directory (file-truename (concat org-directory "roam/")))
+(setopt org-roam-node-display-template "${file}/${title} ${tags}")
 
 (org-roam-db-autosync-mode 1)
 


### PR DESCRIPTION
デフォルト設定の "${title}" だと検索する際に情報が足らなかったので
ファイル名やタグなども検索できるようにするために
org-roam-node-display-template を変更してそれらも検索対象となるように調整した