### PR TITLE
fix(projectile): resolve duplicate key bindings in hydra menu

### DIFF
--- a/hugo/content/nav/projectile.md
+++ b/hugo/content/nav/projectile.md
@@ -87,9 +87,9 @@ counsel-projectile はいくつかの絞り込み処理を提供してくれて�
 
      "Jump"
      (("l" projectile-edit-dir-locals "dir-locals")
-      ("d" my/projectile-goto-docker-file "Dockerfile")
-      ("c" my/projectile-goto-circleci-config "CircleCI Config")
-      ("r" my/projectile-goto-rubocop-config ".rubocop.yml"))
+      ("D" my/projectile-goto-docker-file "Dockerfile")
+      ("C" my/projectile-goto-circleci-config "CircleCI Config")
+      ("c" my/projectile-goto-rubocop-config ".rubocop.yml"))
 
      "Search"
      (("g" counsel-projectile-rg "RipGrep(Counsel)")
@@ -97,7 +97,7 @@ counsel-projectile はいくつかの絞り込み処理を提供してくれて�
 
      "Other"
      (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")
-      ("c" counsel-projectile-org-capture "Capture")
+      ("o" counsel-projectile-org-capture "Capture")
       ("SPC" my/project-hydra "Hydra")))))
 ```
 
@@ -108,14 +108,13 @@ counsel-projectile はいくつかの絞り込み処理を提供してくれて�
 | r   | プロジェクト内で最近触ったファイルのリスト表示 |
 | R   | 一括置換する                   |
 | l   | .dir-locals.el を開く          |
-| d   | Dockerfile を開く              |
-| c   | .circieci/config.yml を開く    |
-| r   | .rubocop.yml を開く            |
-| d   | Dockerfile を開く              |
+| D   | Dockerfile を開く              |
+| C   | .circieci/config.yml を開く    |
+| c   | .rubocop.yml を開く            |
 | g   | RipGrep で検索し counsel で結果を表示 |
 | G   | RipGrep で検索し rg.el のバッファで結果を表示 |
 | p   | 別のプロジェクトに切り替え     |
-| c   | プロジェクト用に org-capture でメモを取る |
+| o   | プロジェクト用に org-capture でメモを取る |
 | SPC | プロジェクト固有の Hydra を起動する |
 
 -   `projectile-find-implementation-or-test`

--- a/init.org
+++ b/init.org
@@ -5243,9 +5243,9 @@ counsel-projectile はいくつかの絞り込み処理を提供してくれて�
 
      "Jump"
      (("l" projectile-edit-dir-locals "dir-locals")
-      ("d" my/projectile-goto-docker-file "Dockerfile")
-      ("c" my/projectile-goto-circleci-config "CircleCI Config")
-      ("r" my/projectile-goto-rubocop-config ".rubocop.yml"))
+      ("D" my/projectile-goto-docker-file "Dockerfile")
+      ("C" my/projectile-goto-circleci-config "CircleCI Config")
+      ("c" my/projectile-goto-rubocop-config ".rubocop.yml"))
 
      "Search"
      (("g" counsel-projectile-rg "RipGrep(Counsel)")
@@ -5253,7 +5253,7 @@ counsel-projectile はいくつかの絞り込み処理を提供してくれて�
 
      "Other"
      (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")
-      ("c" counsel-projectile-org-capture "Capture")
+      ("o" counsel-projectile-org-capture "Capture")
       ("SPC" my/project-hydra "Hydra")))))
 #+end_src
 
@@ -5263,14 +5263,13 @@ counsel-projectile はいくつかの絞り込み処理を提供してくれて�
 | r   | プロジェクト内で最近触ったファイルのリスト表示 |
 | R   | 一括置換する                                   |
 | l   | .dir-locals.el を開く                          |
-| d   | Dockerfile を開く                              |
-| c   | .circieci/config.yml を開く                    |
-| r   | .rubocop.yml を開く                            |
-| d   | Dockerfile を開く                              |
+| D   | Dockerfile を開く                              |
+| C   | .circieci/config.yml を開く                    |
+| c   | .rubocop.yml を開く                            |
 | g   | RipGrep で検索し counsel で結果を表示          |
 | G   | RipGrep で検索し rg.el のバッファで結果を表示  |
 | p   | 別のプロジェクトに切り替え                     |
-| c   | プロジェクト用に org-capture でメモを取る      |
+| o   | プロジェクト用に org-capture でメモを取る      |
 | SPC | プロジェクト固有の Hydra を起動する            |
 
 - ~projectile-find-implementation-or-test~

--- a/inits/30-projectile.el
+++ b/inits/30-projectile.el
@@ -30,9 +30,9 @@
 
      "Jump"
      (("l" projectile-edit-dir-locals "dir-locals")
-      ("d" my/projectile-goto-docker-file "Dockerfile")
-      ("c" my/projectile-goto-circleci-config "CircleCI Config")
-      ("r" my/projectile-goto-rubocop-config ".rubocop.yml"))
+      ("D" my/projectile-goto-docker-file "Dockerfile")
+      ("C" my/projectile-goto-circleci-config "CircleCI Config")
+      ("c" my/projectile-goto-rubocop-config ".rubocop.yml"))
 
      "Search"
      (("g" counsel-projectile-rg "RipGrep(Counsel)")
@@ -40,7 +40,7 @@
 
      "Other"
      (("p" (counsel-projectile-switch-project 'counsel-projectile-switch-project-action-vc) "Switch Project")
-      ("c" counsel-projectile-org-capture "Capture")
+      ("o" counsel-projectile-org-capture "Capture")
       ("SPC" my/project-hydra "Hydra")))))
 
 (defun my/project-hydra ()


### PR DESCRIPTION
- Updated key bindings in projectile hydra to avoid duplications
  (e.g., distinguishing between "c" and "C", "d" and "D").
- Adjusted "Capture" binding from "c" to "o" for better clarity.
- Ensured consistency across all relevant configuration files.