### PR TITLE
feat: use ghub for org-reviews

### DIFF
--- a/init.org
+++ b/init.org
@@ -11192,6 +11192,41 @@ org フォルダの下に roam というフォルダを掘ってその中だけ�
                              repos-prs)))
     (cl-reduce (lambda (result prs) (append result prs)) nested-prs)))
 
+(defun my/org-reviews-fetch-by-ghub (repositories)
+  "ghub を使ってレビュー依頼されている PR を取得する"
+  (let* ((repo-str (mapconcat (lambda (repo) (concat "repo:" repo)) repositories " "))
+         (result (ghub-get "search/issues"
+                        `((per_page . 100)
+                          (sort . "created")
+                          (q . ,(concat repo-str " is:open is:pr draft:false -author:app/dependabot -author:app/renovate -author:mugijiru"))
+                          (order . "desc"))
+                        :auth 'org-reviews)))
+    (assoc-default 'items result)))
+
+(defun my/org-reviews-format-from-ghub (pr)
+  "ghub から取得した PR を emacs lisp の list に変換する"
+  (let* ((number (assoc-default 'number pr))
+         (todo-keyword "TODO")
+         (title (assoc-default 'title pr))
+         (text (assoc-default 'url pr))
+         (labels (assoc-default 'labels pr))
+         (tags (mapcar (lambda (label) (assoc-default 'name label)) labels)))
+    `( :number ,number
+       :todo-keyword ,todo-keyword
+       :title ,title
+       :text ,text
+       :tags ,tags)))
+
+(defun my/org-reviews-prs-by-ghub ()
+  "レビュー依頼されている PR を ghub で取得する"
+  (let* ((repositories (mapcar (lambda (repo)
+                                 (concat my/org-reviews-organization "/" repo))
+                               my/org-reviews-repositories))
+         (prs (my/org-reviews-fetch-by-ghub repositories)))
+    (mapcar (lambda (pr)
+              (my/org-reviews-format-from-ghub pr))
+            prs)))
+
 (defun my/org-reviews-convert-pull-request-to-list (pr org repo)
   "PR から list に変換"
   (let* ((number (gethash "number" pr))
@@ -11304,7 +11339,8 @@ org フォルダの下に roam というフォルダを掘ってその中だけ�
   (interactive)
   (find-file-other-window my/org-reviews-file)
   (let* ((saved-prs (my/org-reviews-pr-headlines))
-         (fetched-prs (my/org-reviews-prs))
+         ;; (fetched-prs (my/org-reviews-prs))
+         (fetched-prs (my/org-reviews-prs-by-ghub))
          (merged-prs (my/org-reviews-merge-prs saved-prs fetched-prs))
          (headlines (mapcar #'my/org-reviews-list-item-to-org-headline merged-prs))
          (root (apply #'org-element-create


### PR DESCRIPTION
レビュー対象の Pull request を取得する処理を
ghub で行うようにした。

旧実装では Ruby で書いたスクリプトを叩いていたが
リポジトリ毎で回していて rate limit にかかっていたことと
外部スクリプト呼び出しのために重かったのがこれで解消された。

とはいえ一旦念の為実装を残している。