### PR TITLE
fix: Disable LSP based indentation on enh-ruby-mode and ruby-ts-mode

### DIFF
--- a/hugo/content/programming/ruby.md
+++ b/hugo/content/programming/ruby.md
@@ -173,6 +173,7 @@ hook 用の関数で補完などの機能を有効にしている
   (ruby-refactor-mode 1)
   (yard-mode 1)
   (eldoc-mode 1)
+  (setq-local lsp-enable-indentation nil)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode 1))
 ```
@@ -185,6 +186,8 @@ hook 用の関数で補完などの機能を有効にしている
 -   リファクタリング用に ruby-refactor-mode の有効化
 -   yard 形式のコメントも良い感じにハイライトされると便利なので yard-mode を有効化
     -   更に eldoc-mode を有効にしていると yard コメントを書く時に文法を minibuffer に表示してくれるのでこちらも有効化
+-   ruby-lsp-ls のインデントは syntax tree gem が必要なようで動いてくれなうて面倒なので無効化
+    -   無効にするとデフォルトのインデント処理が動く
 -   開きカッコと閉じカッコの組み合わせがズレないように smartparens-strict-mode を有効にしている
 -   行番号も表示されている方が便利なので display-line-numbers-mode を有効にしている
 -   lsp-mode に関してはプロジェクト毎にごにゃごにゃしたいので `.dir-locals.el` に任せる方針にしている

--- a/init.org
+++ b/init.org
@@ -6816,6 +6816,7 @@ hook 用の関数で補完などの機能を有効にしている
   (ruby-refactor-mode 1)
   (yard-mode 1)
   (eldoc-mode 1)
+  (setq-local lsp-enable-indentation nil)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode 1))
 #+end_src
@@ -6828,6 +6829,8 @@ hook 用の関数で補完などの機能を有効にしている
 - リファクタリング用に ruby-refactor-mode の有効化
 - yard 形式のコメントも良い感じにハイライトされると便利なので yard-mode を有効化
   - 更に eldoc-mode を有効にしていると yard コメントを書く時に文法を minibuffer に表示してくれるのでこちらも有効化
+- ruby-lsp-ls のインデントは syntax tree gem が必要なようで動いてくれなうて面倒なので無効化
+  - 無効にするとデフォルトのインデント処理が動く
 - 開きカッコと閉じカッコの組み合わせがズレないように smartparens-strict-mode を有効にしている
 - 行番号も表示されている方が便利なので display-line-numbers-mode を有効にしている
 - lsp-mode に関してはプロジェクト毎にごにゃごにゃしたいので ~.dir-locals.el~ に任せる方針にしている

--- a/init.org
+++ b/init.org
@@ -6607,6 +6607,7 @@ lsp-mode から eslint を使うことでやりたいことの対応ができる
 ** rspec-mode
 :PROPERTIES:
 :EXPORT_FILE_NAME: rspec-mode
+:ID:       efc3f180-6860-4925-80f2-931cdfbe7913
 :END:
 *** 概要
 [[https://github.com/pezra/rspec-mode][rspec-mode]] は Emacs で RSpec を実行したりする時に便利なパッケージ。
@@ -6669,7 +6670,7 @@ context とか describe とかが表示されない。
 :END:
 *** 概要
 Ruby のコードを編集する上での設定をここには書いている。
-別の箇所で [[*rspec-mode][rspec-mode]] などの設定も書いているので
+別の箇所で [[id:efc3f180-6860-4925-80f2-931cdfbe7913][rspec-mode]] などの設定も書いているので
 いつか記述場所を統合した方が良さそうな気もする
 
 *** rbenv.el

--- a/inits/40-ruby.el
+++ b/inits/40-ruby.el
@@ -30,6 +30,7 @@
   (ruby-refactor-mode 1)
   (yard-mode 1)
   (eldoc-mode 1)
+  (setq-local lsp-enable-indentation nil)
   (turn-on-smartparens-strict-mode)
   (display-line-numbers-mode 1))
 


### PR DESCRIPTION
# 概要

Ruby 系の major-mode では
LSP を利用したインデント整形機能は使わないようにすることで
major-mode が持つインデント整形機能を使うようにした

# 変更の理由

ruby-lsp では https://github.com/ruby-syntax-tree/syntax_tree がないとインデント処理ができないようだけど
それを導入するのもだるいし major-mode が持つ機能で対応可能なのでそちらに任せることにした