### PR TITLE
chore(gitignore): update ignored files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ request
 tree-sitter
 .cask
 .local
+games
+eln-cache
 
 # auto generated files
 .authinfo.gpg
@@ -40,3 +42,4 @@ forge-database*.sqlite
 oauth2-auto.plist
 org-roam.db
 projects
+.aider*


### PR DESCRIPTION
- Add `games`, `eln-cache`, and `.aider*` to `.gitignore`

games, eln-cache は自動生成されるディレクトリなので無視する
.aider* は Aider でコード変更する際に使う設定ファイルだけど
特に公開する気がないので無視リストに入れておく