### PR TITLE
feat: reset org-agenda-files after create journal

### DIFF
--- a/hugo/content/org-mode/org-journal.md
+++ b/hugo/content/org-mode/org-journal.md
@@ -68,10 +68,16 @@ org-clock-report では前日分も target に入れてほしいのでそれの 
 
 ## hook {#hook}
 
-org-journal ファイルを新しく作る度にそのファイルを refile target で扱って欲しいので
-hook で org-refile-targets を設定し直すようにしている
+org-journal ファイルを新しく作る度にそのファイルを refile target で扱って欲しいのと
+org-agenda-files も同様に扱って欲しいので
+hook でそれらを設定し直すようにしている
 
 ```emacs-lisp
+(defun my/org-journal-mode-hooks ()
+  "Set org-journal mode hooks."
+  (my/reset-org-agenda-files)
+  (my/reset-org-refile-targets))
+
 (with-eval-after-load 'org-journal
-  (add-to-list 'org-journal-after-header-create-hook 'my/reset-org-refile-targets))
+  (add-to-list 'org-journal-after-header-create-hook 'my/org-journal-mode-hooks))
 ```

--- a/init.org
+++ b/init.org
@@ -11181,14 +11181,19 @@ org-clock-report では前日分も target に入れてほしいので
 
 *** hook
 
-org-journal ファイルを新しく作る度にそのファイルを refile target で扱って欲しいので
-hook で org-refile-targets を設定し直すようにしている
+org-journal ファイルを新しく作る度にそのファイルを refile target で扱って欲しいのと
+org-agenda-files も同様に扱って欲しいので
+hook でそれらを設定し直すようにしている
 
 #+begin_src emacs-lisp :tangle inits/66-org-journal.el
-(with-eval-after-load 'org-journal
-  (add-to-list 'org-journal-after-header-create-hook 'my/reset-org-refile-targets))
-#+end_src
+(defun my/org-journal-mode-hooks ()
+  "Set org-journal mode hooks."
+  (my/reset-org-agenda-files)
+  (my/reset-org-refile-targets))
 
+(with-eval-after-load 'org-journal
+  (add-to-list 'org-journal-after-header-create-hook 'my/org-journal-mode-hooks))
+#+end_src
 ** ox-hugo
 :PROPERTIES:
 :EXPORT_HUGO_CUSTOM_FRONT_MATTER: :weight 12

--- a/inits/66-org-journal.el
+++ b/inits/66-org-journal.el
@@ -18,5 +18,10 @@
 (setopt org-journal-enable-agenda-integration nil)
 (setopt org-journal-carryover-items "TODO={TODO\\|DOING\\|WAIT}")
 
+(defun my/org-journal-mode-hooks ()
+  "Set org-journal mode hooks."
+  (my/reset-org-agenda-files)
+  (my/reset-org-refile-targets))
+
 (with-eval-after-load 'org-journal
-  (add-to-list 'org-journal-after-header-create-hook 'my/reset-org-refile-targets))
+  (add-to-list 'org-journal-after-header-create-hook 'my/org-journal-mode-hooks))


### PR DESCRIPTION
# 概要

新規で journal ファイルが作られる時に
org-agenda-files を reset することで
その journal ファイルも org-agenda-files の対象となるように調整した