### PR TITLE
fix: Change duplicated keybind for org-mode hydra

### DIFF
--- a/hugo/content/org-mode/org-mode-keybinds.md
+++ b/hugo/content/org-mode/org-mode-keybinds.md
@@ -35,7 +35,7 @@ major-mode-hydra で、org-mode のファイルを開いている時によく使
      "Edit"
      (("a" org-archive-subtree  "Archive")
       ("r" org-refile           "Refile")
-      ("e" org-edit-special     "Edit")
+      ("'" org-edit-special     "Edit")
       ("Q" org-set-tags-command "Tag"))
 
      "View"

--- a/init.org
+++ b/init.org
@@ -11962,7 +11962,7 @@ major-mode-hydra で、org-mode のファイルを開いている時によく使
      "Edit"
      (("a" org-archive-subtree  "Archive")
       ("r" org-refile           "Refile")
-      ("e" org-edit-special     "Edit")
+      ("'" org-edit-special     "Edit")
       ("Q" org-set-tags-command "Tag"))
 
      "View"

--- a/inits/69-org-mode-hydra.el
+++ b/inits/69-org-mode-hydra.el
@@ -17,7 +17,7 @@
      "Edit"
      (("a" org-archive-subtree  "Archive")
       ("r" org-refile           "Refile")
-      ("e" org-edit-special     "Edit")
+      ("'" org-edit-special     "Edit")
       ("Q" org-set-tags-command "Tag"))
 
      "View"


### PR DESCRIPTION
org-mode 用の Hydra で keybind がかぶっていたので修正した