### PR TITLE
refactor: Use setopt instead of custom-set-variables

### DIFF
--- a/hugo/content/ui/hydra.md
+++ b/hugo/content/ui/hydra.md
@@ -72,7 +72,7 @@ js2-mode 用の Hydra などを定義できて便利。
 `pretty-hydra-default-title-body-format-spec` を使うようにしている
 
 ```emacs-lisp
-(custom-set-variables '(pretty-hydra-default-title-body-format-spec "%s\n%s"))
+(setopt pretty-hydra-default-title-body-format-spec "%s\n%s")
 ```
 
 なおレシピは自前で用意している

--- a/init.org
+++ b/init.org
@@ -3394,7 +3394,7 @@ js2-mode 用の Hydra などを定義できて便利。
 ~pretty-hydra-default-title-body-format-spec~ を使うようにしている
 
 #+begin_src emacs-lisp :tangle inits/81-hydra.el
-(custom-set-variables '(pretty-hydra-default-title-body-format-spec "%s\n%s"))
+(setopt pretty-hydra-default-title-body-format-spec "%s\n%s")
 #+end_src
 
 なおレシピは自前で用意している

--- a/inits/81-hydra.el
+++ b/inits/81-hydra.el
@@ -6,7 +6,7 @@
 
 (el-get-bundle major-mode-hydra.el)
 
-(custom-set-variables '(pretty-hydra-default-title-body-format-spec "%s\n%s"))
+(setopt pretty-hydra-default-title-body-format-spec "%s\n%s")
 
 (pretty-hydra-define el-get-hydra (:separator "-" :title "el-get" :foreign-key warn :quit-key "q" :exit t)
   ("Install"


### PR DESCRIPTION
pretty-hydra の設定でも setopt を使うようにした