### PR TITLE
fix(org-reviews): use html_url instead of url for PR text

### DIFF
--- a/init.org
+++ b/init.org
@@ -11459,7 +11459,7 @@ org フォルダの下に roam というフォルダを掘ってその中だけ�
   (let* ((number (assoc-default 'number pr))
          (todo-keyword "TODO")
          (title (assoc-default 'title pr))
-         (text (assoc-default 'url pr))
+         (text (assoc-default 'html_url pr))
          (labels (assoc-default 'labels pr))
          (tags (mapcar (lambda (label) (assoc-default 'name label)) labels)))
     `( :number ,number

--- a/inits/65-org-reviews.el
+++ b/inits/65-org-reviews.el
@@ -66,7 +66,7 @@
   (let* ((number (assoc-default 'number pr))
          (todo-keyword "TODO")
          (title (assoc-default 'title pr))
-         (text (assoc-default 'url pr))
+         (text (assoc-default 'html_url pr))
          (labels (assoc-default 'labels pr))
          (tags (mapcar (lambda (label) (assoc-default 'name label)) labels)))
     `( :number ,number


### PR DESCRIPTION
url だと API で利用する URL を取得していた。
欲しいのはブラウザでアクセスする URL なので
html_url を使うように修正した