### PR TITLE
ci: add debug message for checksums

### DIFF
--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -32,6 +32,7 @@ jobs:
         emacs -Q --batch --eval "(setq user-emacs-directory \"$(pwd)/\")" \
           --eval '(setq el-get-git-install-url "https://github.com/mugijiru/el-get.git")' \
           --eval '(setq el-get-install-branch "fix-install-for-emacs29")' \
+          --eval '(setq byte-compiler-warnings nil)` \
           -l ./init-el-get.el \
           --eval "(my/el-get-auto-update \"$PACKAGE\")"
 

--- a/hugo/content/el-get-functions.md
+++ b/hugo/content/el-get-functions.md
@@ -16,6 +16,7 @@ el-get と el-get-lock を使った関数を用意している
     (el-get-lock-checkout package)
     (el-get-update package)
     (let ((new-checksum (my/el-get-lock-checksum package)))
+      (message "debug: %s -> %s" old-checksum new-checksum)
       (unless (string= old-checksum new-checksum)
         (let* ((compare (concat old-checksum "..." new-checksum))
                (recipe (ignore-errors (el-get-package-def package)))

--- a/init-el-get.el
+++ b/init-el-get.el
@@ -27,6 +27,7 @@
     (el-get-lock-checkout package)
     (el-get-update package)
     (let ((new-checksum (my/el-get-lock-checksum package)))
+      (message "debug: %s -> %s" old-checksum new-checksum)
       (unless (string= old-checksum new-checksum)
         (let* ((compare (concat old-checksum "..." new-checksum))
                (recipe (ignore-errors (el-get-package-def package)))

--- a/init.org
+++ b/init.org
@@ -173,6 +173,7 @@ el-get と el-get-lock を使った関数を用意している
     (el-get-lock-checkout package)
     (el-get-update package)
     (let ((new-checksum (my/el-get-lock-checksum package)))
+      (message "debug: %s -> %s" old-checksum new-checksum)
       (unless (string= old-checksum new-checksum)
         (let* ((compare (concat old-checksum "..." new-checksum))
                (recipe (ignore-errors (el-get-package-def package)))


### PR DESCRIPTION
自動更新で失敗する原因を掴むためにデバッグメッセージを仕込んだ。

なぜか el-get.lock の一番上にあるやつがダメなんですよね。
cdr とかの記述がよくない気もする