### PR TITLE
feat: show line numbers on markdown-mode

### DIFF
--- a/hugo/content/programming/markdown.md
+++ b/hugo/content/programming/markdown.md
@@ -17,3 +17,15 @@ Markdown を書くための設定。といいつつ markdown-mode を入れて�
 ```emacs-lisp
 (el-get-bundle markdown-mode)
 ```
+
+
+## 設定 {#設定}
+
+今のところは行番号が表示されるようにしているだけ
+
+```emacs-lisp
+(defun my/markdown-mode-hook()
+  (display-line-numbers-mode 1))
+
+(add-hook 'markdown-mode-hook 'my/markdown-mode-hook)
+```

--- a/init.org
+++ b/init.org
@@ -6195,7 +6195,15 @@ Markdown を書くための設定。
 #+begin_src emacs-lisp :tangle inits/40-markdown.el
 (el-get-bundle markdown-mode)
 #+end_src
+*** 設定
+今のところは行番号が表示されるようにしているだけ
 
+#+begin_src emacs-lisp :tangle inits/40-markdown.el
+(defun my/markdown-mode-hook()
+  (display-line-numbers-mode 1))
+
+(add-hook 'markdown-mode-hook 'my/markdown-mode-hook)
+#+end_src
 ** Mocha                                                         :Deprecated:
 :PROPERTIES:
 :EXPORT_FILE_NAME: mocha

--- a/inits/40-markdown.el
+++ b/inits/40-markdown.el
@@ -1,1 +1,6 @@
 (el-get-bundle markdown-mode)
+
+(defun my/markdown-mode-hook()
+  (display-line-numbers-mode 1))
+
+(add-hook 'markdown-mode-hook 'my/markdown-mode-hook)


### PR DESCRIPTION
markdown-mode 開始時に
display-line-numbers-mode を有効化するようにした。

Markdown では行番号が見える方が嬉しいので