### PR TITLE
chore: use gemini-2.5-flash on chatgpt-shell

### DIFF
--- a/hugo/content/external-tool/chatgpt-shell.md
+++ b/hugo/content/external-tool/chatgpt-shell.md
@@ -45,7 +45,7 @@ el-get 本体にはレシピがないので自前で用意している。依存�
 authinfo に登録した API キーを引っ張り出して使っている
 
 ```emacs-lisp
-(setopt chatgpt-shell-model-version "gemini-2.0-flash")
+(setopt chatgpt-shell-model-version "gemini-2.5-flash")
 (setopt chatgpt-shell-google-key
         (funcall (plist-get (nth 0 (auth-source-search :host "gemini" :max 1)) :secret)))
 ```

--- a/init.org
+++ b/init.org
@@ -8048,7 +8048,7 @@ el-get 本体にはレシピがないので自前で用意している。
 authinfo に登録した API キーを引っ張り出して使っている
 
 #+begin_src emacs-lisp :tangle inits/20-chatgpt-shell.el
-(setopt chatgpt-shell-model-version "gemini-2.0-flash")
+(setopt chatgpt-shell-model-version "gemini-2.5-flash")
 (setopt chatgpt-shell-google-key
         (funcall (plist-get (nth 0 (auth-source-search :host "gemini" :max 1)) :secret)))
 #+end_src

--- a/inits/20-chatgpt-shell.el
+++ b/inits/20-chatgpt-shell.el
@@ -1,5 +1,5 @@
 (el-get-bundle chatgpt-shell)
 
-(setopt chatgpt-shell-model-version "gemini-2.0-flash")
+(setopt chatgpt-shell-model-version "gemini-2.5-flash")
 (setopt chatgpt-shell-google-key
         (funcall (plist-get (nth 0 (auth-source-search :host "gemini" :max 1)) :secret)))


### PR DESCRIPTION
今は 2.5 flash が標準っぽいので