### PR TITLE
fix(dashboard): update package name to emacs-dashboard/dashboard

### DIFF
--- a/hugo/content/ui/dashboard.md
+++ b/hugo/content/ui/dashboard.md
@@ -17,7 +17,7 @@ el-get のレシピは自前で用意している
 (:name dashboard
        :type github
        :description "A startup screen extracted from Spacemacs"
-       :pkgname "emacs-dashboard/emacs-dashboard"
+       :pkgname "emacs-dashboard/dashboard"
        :depends (page-break-lines)
        :minimum-emacs-version (25 3))
 ```

--- a/init.org
+++ b/init.org
@@ -2997,7 +2997,7 @@ el-get のレシピは自前で用意している
 (:name dashboard
        :type github
        :description "A startup screen extracted from Spacemacs"
-       :pkgname "emacs-dashboard/emacs-dashboard"
+       :pkgname "emacs-dashboard/dashboard"
        :depends (page-break-lines)
        :minimum-emacs-version (25 3))
 #+end_src

--- a/recipes/dashboard.rcp
+++ b/recipes/dashboard.rcp
@@ -1,6 +1,6 @@
 (:name dashboard
        :type github
        :description "A startup screen extracted from Spacemacs"
-       :pkgname "emacs-dashboard/emacs-dashboard"
+       :pkgname "emacs-dashboard/dashboard"
        :depends (page-break-lines)
        :minimum-emacs-version (25 3))


### PR DESCRIPTION
- dashboardパッケージのpkgnameを正しいリポジトリ名に修正
- リポジトリ名が変わっていたのでそれに合わせた