### PR TITLE
fix(lock): add inheritenv checksum to el-get.lock

### DIFF
--- a/el-get.lock
+++ b/el-get.lock
@@ -1,5 +1,7 @@
 (setq el-get-lock-package-versions
-      '((cond-let :checksum "8bf87d45e169ebc091103b2aae325aece3aa804d")
+      '((inheritenv :checksum
+                    "b9e67cc20c069539698a9ac54d0e6cc11e616c6f")
+        (cond-let :checksum "8bf87d45e169ebc091103b2aae325aece3aa804d")
         (mcp :checksum "5c105a8db470eb9777fdbd26251548dec42c03f0")
         (gcmh :checksum "0089f9c3a6d4e9a310d0791cf6fa8f35642ecfd9")
         (vterm :checksum "056ad74653704bc353d8ec8ab52ac75267b7d373")


### PR DESCRIPTION
- el-get.lockにinheritenvパッケージのchecksumを追加しました
- パッケージ管理の整合性を保つための更新です