### PR TITLE
ci: remove custom el-get install branch and URL from workflows and scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,5 @@ jobs:
     - name: Run tests
       run: |
         emacs -Q --batch --eval "(setq user-emacs-directory \"$(pwd)/\")" \
-        --eval '(setq el-get-git-install-url "https://github.com/mugijiru/el-get.git")' \
-        --eval '(setq el-get-install-branch "fix-install-for-emacs29")' \
         -l inits/test/*-test.el \
         -l inits/test/run-tests.el

--- a/.github/workflows/create-package-update-pr.yml
+++ b/.github/workflows/create-package-update-pr.yml
@@ -30,8 +30,6 @@ jobs:
     - name: Update package
       run: |
         emacs -Q --batch --eval "(setq user-emacs-directory \"$(pwd)/\")" \
-          --eval '(setq el-get-git-install-url "https://github.com/mugijiru/el-get.git")' \
-          --eval '(setq el-get-install-branch "fix-install-for-emacs29")' \
           --eval '(setq byte-compiler-warnings nil)' \
           -l ./init-el-get.el \
           --eval "(my/el-get-auto-update \"$PACKAGE\")"

--- a/count-emacs-obsolute-packages.sh
+++ b/count-emacs-obsolute-packages.sh
@@ -7,8 +7,6 @@ script_dir=$(cd $(dirname $0); pwd)
 if [ ! -e $file ] || [ $(($current-$(stat -c "%Y" $file))) -gt 3600 ]; then
     emacs --batch -Q --eval "(setq user-emacs-directory \"${script_dir}/\")" \
           -l ${script_dir}/el-get-lock-update-check.el \
-          --eval '(setq el-get-git-install-url "https://github.com/mugijiru/el-get.git")' \
-          --eval '(setq el-get-install-branch "fix-install-for-emacs29")' \
           --eval "(el-get-lock-update-check-print-obsolute-only)" > $file
 fi
 


### PR DESCRIPTION
GitHub Actions の自動パッケージ更新が動かなくなってる。
指定ブランチからインストールができないようなので一度本家の master に戻す