### PR TITLE
fix(el-get): require el-get-bundle to address autoload removal

### DIFF
--- a/hugo/content/el-get.md
+++ b/hugo/content/el-get.md
@@ -19,6 +19,9 @@ draft = false
 そして `el-get` が見つからない時はインストールするようにしている
 
 ```emacs-lisp
+(defvar el-get-install-no-shallow-clone t
+  "Avoid a shallow clone when a non-default el-get branch is requested.")
+
 (unless (require 'el-get nil 'noerror)
   (with-current-buffer
       (url-retrieve-synchronously
@@ -27,7 +30,13 @@ draft = false
     (eval-print-last-sexp)))
 ```
 
-このあたりの記述は公式の README に書かれてるやつと一緒だと思う。大分前に設定しているから今は違うかもしれんけど
+このあたりの記述は公式の README に書かれてるやつと一緒だと思う。大分前に設定しているから今は違うかもしれんけど。
+
+更に明示的に `el-get-bundle` を require している。これは2026年5月以降、autoload されなくなったことへの対応
+
+```emacs-lisp
+(require 'el-get-bundle)
+```
 
 
 ## レシピのフォルダ指定 {#レシピのフォルダ指定}

--- a/init-el-get.el
+++ b/init-el-get.el
@@ -10,6 +10,8 @@
     (goto-char (point-max))
     (eval-print-last-sexp)))
 
+(require 'el-get-bundle)
+
 (add-to-list 'el-get-recipe-path (concat user-emacs-directory "recipes"))
 
 ;; el-get のバージョンロック機構の導入

--- a/init.org
+++ b/init.org
@@ -68,7 +68,15 @@
 #+end_src
 
 このあたりの記述は公式の README に書かれてるやつと一緒だと思う。
-大分前に設定しているから今は違うかもしれんけど
+大分前に設定しているから今は違うかもしれんけど。
+
+更に明示的に ~el-get-bundle~ を require している。
+これは2026年5月以降、autoload されなくなったことへの対応
+
+#+begin_src emacs-lisp :tangle init-el-get.el
+(require 'el-get-bundle)
+#+end_src
+
 *** レシピのフォルダ指定
 自前のレシピをいくつか用意しているのでそのフォルダを el-get で読めるようにしている
 


### PR DESCRIPTION
- Explicitly require el-get-bundle to handle autoload removal after May 2026
- Update documentation to reflect the change and provide usage examples